### PR TITLE
fix: ad-hoc sign unsigned macOS release builds

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -64,7 +64,17 @@ jobs:
 
       - name: Build installer (electron-builder)
         working-directory: packages/app
-        run: npx electron-builder ${{ matrix.build-args }} --publish never
+        shell: bash
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_NAME: ${{ secrets.CSC_NAME }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          if [[ "$RUNNER_OS" == "macOS" && -z "${CSC_LINK:-}${CSC_NAME:-}" ]]; then
+            npx electron-builder ${{ matrix.build-args }} --config.mac.identity=- --config.mac.hardenedRuntime=false --publish never
+          else
+            npx electron-builder ${{ matrix.build-args }} --publish never
+          fi
 
       - name: Upload macOS dmg
         if: runner.os == 'macOS'


### PR DESCRIPTION
## Summary

- ad-hoc sign macOS release builds when neither `CSC_LINK` nor `CSC_NAME` is configured
- keep the normal certificate-backed signing path when signing credentials are present
- leave Windows release builds unchanged

## Why

The release workflow currently has no macOS signing identity, so electron-builder skips signing. Quarantined downloads can then be treated as damaged or only offer “Move to Trash”, without a usable “Open Anyway” path.

Ad-hoc signing gives the app bundle a verifiable integrity signature. It does not claim a trusted Developer ID and does not replace notarization.

`hardenedRuntime=false` is scoped to the ad-hoc branch because pre-signed Electron frameworks otherwise fail library validation. Certificate-backed builds retain electron-builder defaults.

## Verification

- parsed the updated workflow as YAML
- ran the same ad-hoc electron-builder flags locally for an arm64 macOS directory build
- verified the result with `codesign --verify --deep --strict`
- confirmed `Signature=adhoc` and no Team ID
- repository pre-commit lint completed with no errors