### PR TITLE
fix：把聊天输入框左下角图片上传按钮icon改成图片的图标

### DIFF
--- a/packages/app/src/features/chat/Composer.structure.test.ts
+++ b/packages/app/src/features/chat/Composer.structure.test.ts
@@ -17,7 +17,8 @@ describe("Composer structure", () => {
     expect(source).toContain('type="file"');
     expect(source).toContain('accept="image/*"');
     expect(source).toContain("fileInputRef");
-    expect(source).toContain("PaperclipIcon");
+    expect(source).toContain("<ImageIcon />");
+    expect(source).not.toContain("PaperclipIcon");
   });
 
   it("runs the compress -> upload pipeline and deletes on remove", () => {

--- a/packages/app/src/features/chat/Composer.structure.test.ts
+++ b/packages/app/src/features/chat/Composer.structure.test.ts
@@ -21,6 +21,10 @@ describe("Composer structure", () => {
     expect(source).not.toContain("PaperclipIcon");
   });
 
+  it("swaps the attach button icon for the spinner while busy", () => {
+    expect(source).toMatch(/attachBusy \? <Loader2Icon[^>]*\/> : <ImageIcon \/>/);
+  });
+
   it("runs the compress -> upload pipeline and deletes on remove", () => {
     expect(source).toContain("compressImage");
     expect(source).toContain("uploadAttachedImage");

--- a/packages/app/src/features/chat/Composer.test.tsx
+++ b/packages/app/src/features/chat/Composer.test.tsx
@@ -127,6 +127,12 @@ describe("Composer input availability", () => {
     expect(onAbort).toHaveBeenCalledTimes(1);
   });
 
+  it("shows the image icon on the attach button instead of the paperclip", () => {
+    renderComposer({ streaming: false });
+    expect(host.querySelector("[data-chat-composer] button svg.lucide-image")).not.toBeNull();
+    expect(host.querySelector("[data-chat-composer] button svg.lucide-paperclip")).toBeNull();
+  });
+
   it("still disables the textarea while session history is loading", () => {
     renderComposer({ loading: true });
     expect(textarea().hasAttribute("disabled")).toBe(true);

--- a/packages/app/src/features/chat/Composer.tsx
+++ b/packages/app/src/features/chat/Composer.tsx
@@ -3,7 +3,7 @@ import { useI18n } from "@spherse/i18n/react";
 import { toast } from "sonner";
 import { Button } from "../../components/ui/button";
 import { Textarea } from "../../components/ui/textarea";
-import { ChevronsDownIcon, ChevronsUpIcon, Loader2Icon, PaperclipIcon, SendIcon, SquareIcon } from "lucide-react";
+import { ChevronsDownIcon, ChevronsUpIcon, ImageIcon, Loader2Icon, SendIcon, SquareIcon } from "lucide-react";
 import type { AttachedImage } from "./types";
 import { compressImage } from "./utils/compress-image";
 import { AttachmentBar, type AttachStatus } from "./AttachmentBar";
@@ -194,7 +194,7 @@ export function Composer({ streaming, loading = false, sessionId, onSend, onAbor
             onClick={handleAttachClick}
             title={t("chat.attachImage")}
           >
-            {attachBusy ? <Loader2Icon className="animate-spin" /> : <PaperclipIcon />}
+            {attachBusy ? <Loader2Icon className="animate-spin" /> : <ImageIcon />}
           </Button>
           {streaming ? (
             <Button variant="destructive" size="icon-lg" onClick={onAbort}>


### PR DESCRIPTION
将聊天输入框（Composer）左下角图片上传按钮的 icon 由回形针（PaperclipIcon）改为图片图标（ImageIcon），加载态 Loader2Icon 保持不变。

- packages/app/src/features/chat/Composer.tsx：icon 替换
- Composer.test.tsx：新增 DOM 级用例（渲染 svg.lucide-image、无 svg.lucide-paperclip）
- Composer.structure.test.ts：断言更新 + busy 态 icon 切换结构断言

验证：app 包 90 文件 / 854 测试全部通过，lint 0 errors。