### PR TITLE
infra: 增加PR build pipeline

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,27 @@
+name: PR Build
+
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint, build, and test
+        run: npm run verify

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -6,12 +6,17 @@ on:
       - "docs/**"
       - "**/*.md"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -151,6 +151,7 @@
 - [ ] **Kimi Coding OAuth 订阅登录**：当前 `kimi-coding` 走 apiKey 路径（手动粘贴 `KIMI_API_KEY`）。pi-ai 的 `kimiCodingProvider()` 同时声明 `lazyOAuth("Kimi Code (subscription)")`；接入需与 GitHub Copilot OAuth 共用同一套 OAuth 基建（electron 层 pi-ai OAuth helper + refresh token 持久化 + 前端登录按钮），实现免粘贴 key。
 
 - [x] **本地验证流水线**：新增 root `npm run verify` 覆盖 lint/build/core+i18n+app unit tests/i18n check，新增 `npm run verify:e2e` 在此基础上运行 app E2E。
+- [x] **PR build pipeline**：新增 `.github/workflows/pr-build.yml`，`pull_request` 触发（`paths-ignore` 跳过纯文档变更），复用 root `npm run verify`（lint/build/单测/i18n check）在合并前自动验证，避免把 lint/类型/单测问题带进 dev/main。
 - [ ] **app 包类型检查纳入 verify**：`packages/app` 的 build 走 `electron-vite build`，只做转译不做类型检查；`tsconfig.node.json`（electron 目录）与 `tsconfig.json`（renderer）的类型错误会被静默放过（如 schema 变更后遗留的 `settings.defaultModel` 读取）。应新增 `npm run typecheck`（`tsc --noEmit` 双 project）并纳入 root `npm run verify`，防止类型错误漏到运行时。
 - [ ] **React DOM 组件测试工具链**：为 `packages/app` 引入组件级测试基础设施（如 Testing Library + user-event + jsdom/happy-dom），用于测试 React 组件渲染、ARIA 状态、用户交互和菜单/折叠等局部 UI 行为，补足当前 Vitest 单测与 Playwright E2E 之间的测试层级。
 - [x] **electron-builder 打包**：配置生产构建和跨平台打包

--- a/docs/official/project-structure.md
+++ b/docs/official/project-structure.md
@@ -364,6 +364,7 @@ spherse/
 ├── .github/
 │   └── workflows/
 │       ├── build-and-release.yml     # Git tag 触发的 CI：mac/win 并行构建 + GitHub Releases 发布（win --publish always，mac --publish never + gh upload dmg）
+│       ├── pr-build.yml              # PR 触发的 CI：checkout + npm ci + npm run verify（lint/build/单测/i18n check）
 │       └── deploy-pages.yml          # main 分支 landing/web 变更触发的 CI：构建并部署到 GitHub Pages
 ├── .husky/
 │   └── pre-commit                    # Husky pre-commit 钩子（执行 npm run lint）


### PR DESCRIPTION
## 变更内容

新增 PR build pipeline（`.github/workflows/pr-build.yml`），在 pull request 上自动运行构建验证：

- `pull_request` 触发，`paths-ignore` 跳过纯文档变更（`docs/**`、`**/*.md`）
- 复用 root `npm run verify`（lint / build / core+server+sdk+i18n+app+desktop+landing 单测 / i18n check），在合并前自动验证，避免把 lint/类型/单测问题带进 dev
- `concurrency`：同分支 re-push 时取消旧运行
- `timeout-minutes: 30` 防止任务挂起
- 顺带更新 `docs/official/project-structure.md` 与 `docs/dev/backlog.md`

## 验证

- YAML 解析通过
- `npm run verify` 为 package.json 中已存在的有效命令
- 纯声明式 YAML + 文档变更，无 TS/JS 逻辑改动

Commits: 47358ef（主体）、6e244e7（concurrency + timeout）