### PR TITLE
feat：给markdown code block右上角加复制按钮

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -35,6 +35,7 @@
 
 ## 功能增强
 
+- [x] **markdown 代码块复制按钮**：Markdown 渲染的 fenced code block 右上角新增复制按钮（hover 显现，成功后图标切换为对勾 2s 复位）。新增纯函数 `extractCodeText`（`packages/app/src/components/markdown-code-text.ts`，递归提取 react-markdown `<pre>` children 中的代码文本）+ `CodeBlock` 组件（`packages/app/src/components/CodeBlock.tsx`，包裹 `<pre data-md-code>` 与绝对定位按钮；`data-md-code` 钩子仍留在 `<pre>` 上，不影响既有主题选择器），`MarkdownContent` 两个 variant 的 `pre` 均改用 `CodeBlock`；新增 `markdown.copyCode` 三语 i18n 与 `markdown-code-text.test.ts` 单元测试
 - [x] **LLM ask_user 工具（运行中向用户提问）**：新增内置工具 `ask_user`，agent 运行中向用户提一个问题（可选 2–6 候选项）并阻塞等待回答，答案作为 tool result 返回模型、同一 run 内继续执行。复用 `SessionControlBus` 新增 `kind: "question"`（`AskGate` 薄适配器），前端 QuestionCard 内联展示待答/已答/超时三态，跨会话 toast 复用 `ApprovalNoticeBridge`；超时默认 600s（`timeout_s` 可调，clamp 60–3600）返回 `{ timedOut: true }` 提示模型自行判断继续，abort 走 `bus.rejectAll`。per-agent opt-in（profile `tools:`，默认模板已启用）。参见 `docs/dev/features/2026-08-15-llm-ask-user-tool/design.md`
 - [x] **run_command 超时上限放宽**：`MAX_TIMEOUT_MS` 600s → 1800s（30min），默认 60s 与下限 1s 不变；`timeout_ms` 参数 description 更新 max 值并引导长任务显式传预估时长；导出 `clampTimeout` 供单测。不触碰审批 5min 超时。参见 `docs/dev/features/2026-08-15-run-command-timeout-relaxation/design.md`
 - [ ] **run_command 后台执行模式**：`background: true` 立即返回 job id、agent 轮询输出，长任务不再阻塞 agent 回合（超时放宽的根治方向）；per-agent 超时配置与 CommandCard 运行时长展示视后续诉求跟进。参见 `docs/dev/features/2026-08-15-run-command-timeout-relaxation/design.md`「未来演进」

--- a/packages/app/src/components/CodeBlock.structure.test.ts
+++ b/packages/app/src/components/CodeBlock.structure.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+describe("CodeBlock structure", () => {
+  it("keeps the data-md-code theme hook on the inner pre, not the wrapper div", () => {
+    const source = readFileSync(join(currentDir, "CodeBlock.tsx"), "utf8");
+
+    expect(source).toContain("<pre data-md-code className={className} {...props}>");
+  });
+
+  it("guards against a missing navigator.clipboard before writing", () => {
+    const source = readFileSync(join(currentDir, "CodeBlock.tsx"), "utf8");
+
+    expect(source).toContain("if (!navigator.clipboard) return;");
+  });
+});

--- a/packages/app/src/components/CodeBlock.test.tsx
+++ b/packages/app/src/components/CodeBlock.test.tsx
@@ -1,0 +1,98 @@
+import { act } from "react";
+import { createElement, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CodeBlock } from "./CodeBlock";
+
+let host: HTMLDivElement;
+let root: ReturnType<typeof createRoot> | null = null;
+let writeText: ReturnType<typeof vi.fn>;
+
+function setClipboard(value: { writeText?: unknown } | undefined) {
+  Object.defineProperty(navigator, "clipboard", { value, configurable: true, writable: true });
+}
+
+beforeEach(() => {
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  writeText = vi.fn().mockResolvedValue(undefined);
+  setClipboard({ writeText });
+});
+
+afterEach(() => {
+  if (root) {
+    act(() => root!.unmount());
+    root = null;
+  }
+  host.remove();
+});
+
+function render(children: ReactNode) {
+  act(() => {
+    root = createRoot(host);
+    root.render(<CodeBlock className="mb-3">{children}</CodeBlock>);
+  });
+}
+
+function pre(): HTMLPreElement {
+  return host.querySelector("pre[data-md-code]")!;
+}
+
+function copyButton(): HTMLButtonElement {
+  return host.querySelector("button[aria-label]")!;
+}
+
+describe("CodeBlock", () => {
+  it("renders data-md-code on the inner pre and keeps the code text", () => {
+    render(createElement("code", { className: "language-js" }, "const x = 1;\n"));
+    expect(pre()).not.toBeNull();
+    expect(pre().textContent).toContain("const x = 1;");
+    expect(host.querySelector("div.group.relative")).not.toBeNull();
+  });
+
+  it("renders a copy button with the copy-code accessible label", () => {
+    render("code text");
+    expect(copyButton()).toBeDefined();
+    expect(copyButton().getAttribute("aria-label")).toBe("复制代码");
+    expect(copyButton().getAttribute("title")).toBe("复制代码");
+  });
+
+  it("copies the extracted code text to the clipboard on click", async () => {
+    render(createElement("code", null, "console.log(1);\n"));
+    await act(async () => {
+      copyButton().click();
+    });
+    expect(writeText).toHaveBeenCalledWith("console.log(1);\n");
+  });
+
+  it("swaps to a check icon after a successful copy and resets after 2s", async () => {
+    render(createElement("code", null, "hello"));
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        copyButton().click();
+      });
+      expect(host.querySelector("button svg.lucide-check")).not.toBeNull();
+      expect(host.querySelector("button svg.lucide-copy")).toBeNull();
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(host.querySelector("button svg.lucide-check")).toBeNull();
+      expect(host.querySelector("button svg.lucide-copy")).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not throw when the clipboard is unavailable", () => {
+    setClipboard(undefined);
+    render("text");
+    expect(() => {
+      act(() => {
+        copyButton().click();
+      });
+    }).not.toThrow();
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/components/CodeBlock.tsx
+++ b/packages/app/src/components/CodeBlock.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import { useI18n } from "@spherse/i18n/react";
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { Button } from "./ui/button";
+import { extractCodeText } from "./markdown-code-text";
+
+interface CodeBlockProps extends React.HTMLAttributes<HTMLPreElement> {
+  children?: React.ReactNode;
+}
+
+export function CodeBlock({ children, className, ...props }: CodeBlockProps) {
+  const { t } = useI18n();
+  const [copied, setCopied] = useState(false);
+  const text = extractCodeText(children);
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {});
+  };
+
+  return (
+    <div className="group relative">
+      <pre data-md-code className={className} {...props}>
+        {children}
+      </pre>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        className="absolute top-2 end-2 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+        onClick={handleCopy}
+        title={t("markdown.copyCode")}
+        aria-label={t("markdown.copyCode")}
+      >
+        {copied ? <CheckIcon /> : <CopyIcon />}
+      </Button>
+    </div>
+  );
+}

--- a/packages/app/src/components/CodeBlock.tsx
+++ b/packages/app/src/components/CodeBlock.tsx
@@ -14,6 +14,7 @@ export function CodeBlock({ children, className, ...props }: CodeBlockProps) {
   const text = extractCodeText(children);
 
   const handleCopy = () => {
+    if (!navigator.clipboard) return;
     void navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
@@ -28,7 +29,7 @@ export function CodeBlock({ children, className, ...props }: CodeBlockProps) {
       <Button
         variant="ghost"
         size="icon-sm"
-        className="absolute top-2 end-2 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+        className="absolute top-2 end-2 text-muted-foreground opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
         onClick={handleCopy}
         title={t("markdown.copyCode")}
         aria-label={t("markdown.copyCode")}

--- a/packages/app/src/components/MarkdownContent.tsx
+++ b/packages/app/src/components/MarkdownContent.tsx
@@ -3,6 +3,7 @@ import Markdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
 import { cn } from "@/lib/utils";
+import { CodeBlock } from "./CodeBlock";
 
 interface MarkdownContentProps {
   children: string;
@@ -45,7 +46,7 @@ const DOCUMENT_COMPONENTS: Components = {
     <code data-md-code-inline className={cn("rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]", className)} {...props} />
   ),
   pre: ({ className, ...props }) => (
-    <pre data-md-code className={cn("mb-3 p-3 overflow-x-auto rounded-md bg-muted font-mono text-xs", className)} {...props} />
+    <CodeBlock className={cn("mb-3 p-3 overflow-x-auto rounded-md bg-muted font-mono text-xs", className)} {...props} />
   ),
   blockquote: ({ className, ...props }) => (
     <blockquote data-md-quote className={cn("mb-3 rounded-r border-l-4 border-border bg-muted/50 pl-3 text-foreground/80 text-[13px] italic", className)} {...props} />
@@ -95,7 +96,7 @@ const CHAT_COMPONENTS: Components = {
     <code data-md-code-inline className={cn("rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]", className)} {...props} />
   ),
   pre: ({ className, ...props }) => (
-    <pre data-md-code className={cn("mb-2 p-2 overflow-x-auto rounded-md bg-muted font-mono text-xs", className)} {...props} />
+    <CodeBlock className={cn("mb-2 p-2 overflow-x-auto rounded-md bg-muted font-mono text-xs", className)} {...props} />
   ),
   blockquote: ({ className, ...props }) => (
     <blockquote data-md-quote className={cn("mb-3 rounded-r border-l-4 border-border bg-muted/50 pl-3 text-foreground/80 text-[13px] italic", className)} {...props} />

--- a/packages/app/src/components/markdown-code-text.test.ts
+++ b/packages/app/src/components/markdown-code-text.test.ts
@@ -1,4 +1,4 @@
-import { createElement } from "react";
+import { createElement, Fragment } from "react";
 import { describe, expect, it } from "vitest";
 import { extractCodeText } from "./markdown-code-text";
 
@@ -39,5 +39,17 @@ describe("extractCodeText", () => {
       "world",
     );
     expect(extractCodeText(deep)).toBe("hello world");
+  });
+
+  it("extracts text from a non-array iterable of nodes", () => {
+    expect(extractCodeText(new Set(["a", "b"]))).toBe("ab");
+  });
+
+  it("extracts text from a React fragment", () => {
+    expect(extractCodeText(createElement(Fragment, null, "foo", "bar"))).toBe("foobar");
+  });
+
+  it("extracts text from a bigint node", () => {
+    expect(extractCodeText(10n)).toBe("10");
   });
 });

--- a/packages/app/src/components/markdown-code-text.test.ts
+++ b/packages/app/src/components/markdown-code-text.test.ts
@@ -1,0 +1,43 @@
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+import { extractCodeText } from "./markdown-code-text";
+
+describe("extractCodeText", () => {
+  it("returns empty string for nullish and boolean nodes", () => {
+    expect(extractCodeText(null)).toBe("");
+    expect(extractCodeText(undefined)).toBe("");
+    expect(extractCodeText(false)).toBe("");
+    expect(extractCodeText(true)).toBe("");
+  });
+
+  it("returns plain string and number nodes as-is", () => {
+    expect(extractCodeText("const x = 1;")).toBe("const x = 1;");
+    expect(extractCodeText(42)).toBe("42");
+  });
+
+  it("extracts text from a single code element (react-markdown block code)", () => {
+    const code = createElement("code", { className: "language-js" }, "const x = 1;\n");
+    expect(extractCodeText(code)).toBe("const x = 1;\n");
+  });
+
+  it("extracts text from a nested pre > code structure", () => {
+    const code = createElement("code", { className: "language-js" }, "console.log(1);\n");
+    const pre = createElement("pre", null, code);
+    expect(extractCodeText(pre)).toBe("console.log(1);\n");
+  });
+
+  it("concatenates text across an array of nodes", () => {
+    const children = ["a", createElement("span", null, "b"), "c"];
+    expect(extractCodeText(children)).toBe("abc");
+  });
+
+  it("joins deeply nested element children", () => {
+    const deep = createElement(
+      "span",
+      null,
+      createElement("em", null, "hello "),
+      "world",
+    );
+    expect(extractCodeText(deep)).toBe("hello world");
+  });
+});

--- a/packages/app/src/components/markdown-code-text.ts
+++ b/packages/app/src/components/markdown-code-text.ts
@@ -1,0 +1,11 @@
+import { isValidElement, type ReactNode } from "react";
+
+export function extractCodeText(node: ReactNode): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(extractCodeText).join("");
+  if (isValidElement(node)) {
+    return extractCodeText((node.props as { children?: ReactNode }).children);
+  }
+  return "";
+}

--- a/packages/app/src/components/markdown-code-text.ts
+++ b/packages/app/src/components/markdown-code-text.ts
@@ -1,11 +1,19 @@
 import { isValidElement, type ReactNode } from "react";
 
+function isIterableNode(value: unknown): value is Iterable<ReactNode> {
+  if (typeof value !== "object" || value === null) return false;
+  return Symbol.iterator in value;
+}
+
 export function extractCodeText(node: ReactNode): string {
   if (node == null || typeof node === "boolean") return "";
-  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (typeof node === "string" || typeof node === "number" || typeof node === "bigint") {
+    return String(node);
+  }
   if (Array.isArray(node)) return node.map(extractCodeText).join("");
   if (isValidElement(node)) {
     return extractCodeText((node.props as { children?: ReactNode }).children);
   }
+  if (isIterableNode(node)) return Array.from(node).map(extractCodeText).join("");
   return "";
 }

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -310,6 +310,7 @@ export const en: Record<TranslationKey, string> = {
   "chat.htmlCard.showCard": "Show this card",
   "chat.htmlCard.collapse": "Collapse",
   "chat.copyTooltip": "Copy",
+  "markdown.copyCode": "Copy code",
   "chat.close": "Close",
   "chat.responseGenerationFailed": "Response generation failed",
   "chat.error.modelNotConfigured": "No model configured. Please select a model in Settings before sending messages.",

--- a/packages/i18n/src/locales/zh-CN.ts
+++ b/packages/i18n/src/locales/zh-CN.ts
@@ -632,6 +632,8 @@ export const zhCN = {
   "chat.htmlCard.collapse": "折叠",
   // 复制按钮悬停提示
   "chat.copyTooltip": "复制",
+  // markdown 代码块右上角「复制代码」按钮的悬停提示
+  "markdown.copyCode": "复制代码",
   // Chat 关闭按钮悬停提示
   "chat.close": "关闭",
   // 消息生成失败时的固定提示文案，点击可展开查看具体错误

--- a/packages/i18n/src/locales/zh-TW.ts
+++ b/packages/i18n/src/locales/zh-TW.ts
@@ -310,6 +310,7 @@ export const zhTW: Record<TranslationKey, string> = {
   "chat.htmlCard.showCard": "展開此卡片",
   "chat.htmlCard.collapse": "摺疊",
   "chat.copyTooltip": "複製",
+  "markdown.copyCode": "複製程式碼",
   "chat.close": "關閉",
   "chat.responseGenerationFailed": "回覆產生失敗",
   "chat.error.modelNotConfigured": "尚未設定模型，請在設定中選擇一個模型後再傳送訊息。",


### PR DESCRIPTION
## 变更内容
markdown 渲染的 fenced code block 右上角新增**复制按钮**（hover 显现，点击复制后图标切换为对勾 2s 复位）。

## 实现
- 新增 `CodeBlock` 组件（`packages/app/src/components/CodeBlock.tsx`）：包裹 `<pre data-md-code>`（主题钩子仍保留在 `<pre>` 上，不影响既有主题选择器）+ 绝对定位复制按钮（`navigator.clipboard`，缺失守卫）。
- 新增纯函数 `extractCodeText`（`packages/app/src/components/markdown-code-text.ts`）：递归提取 react-markdown `<pre>` children 的代码文本（覆盖 string/number/bigint/数组/Fragment/非数组 iterable）。
- `MarkdownContent` 两个 variant（chat/document）的 `pre` 均改用 `CodeBlock`。
- i18n 新增 `markdown.copyCode`（zh-CN「复制代码」/ zh-TW「複製程式碼」/ en「Copy code」）。

## 测试
- app：93 文件 **870 用例全部通过**（新增 `CodeBlock.test.tsx` 5 用例、`CodeBlock.structure.test.ts` 2 用例、`extractCodeText` 边界 3 用例）。
- i18n：10 用例通过；`check:i18n` ✅；lint 0 error。

## Commits
- `a44e3a9` feat: markdown 代码块右上角加复制按钮
- `725b1e4` fix: review 修复（clipboard 守卫、pointer-events、extractCodeText 边界）并补组件测试