### PR TITLE
fix：app新版本检测

### DIFF
--- a/docs/dev/infra/2026-08-17-app-update-oss-source/design.md
+++ b/docs/dev/infra/2026-08-17-app-update-oss-source/design.md
@@ -15,6 +15,8 @@
 
 两平台检测都硬依赖 GitHub，而目标用户主要在国内网络环境。
 
+**Windows in-app 自动更新从未实际生效**（作者确认）。考古 CI 历史：初版 pipeline（3d659a6）Windows 曾 `--publish always`（会上传 latest.yml），但随后的 pipeline 重构（fd86e0e/edbd11b「infra(release): update release pipeline」）起两平台统一改为 `--publish never` + `gh release upload`，`latest.yml` 不再上传至今；叠加 GitHub 国内不可达，electron-updater 的 in-app 下载/安装链路（`downloading`/`downloaded` 状态）从未对用户产生过实际价值。
+
 同时仓库已有现成资产：CI `publish-oss` job（`build-and-release.yml`）每次发版自动将安装包上传至 Aliyun OSS 并生成稳定清单 `https://mengru-open-source.oss-cn-beijing.aliyuncs.com/spherse/latest.json`：
 
 ```json
@@ -115,6 +117,7 @@ interface OssUpdateManifest {
 
 - **OSS 单点依赖**：清单不可用/欠费时检测失败，与现状（GitHub 失败）等价，但 OSS 由作者自控、可观测性更好；landing 已同源依赖，风险已存在且被接受。
 - **存量旧版 app**：仍指向 GitHub 的旧版本用户无法收到引导——当前版本 0.1.19、用户量极小（早期阶段），可接受。
-- **Windows in-app 全自动更新事实下线**：由「前往下载」引导替代；NSIS 本就非 oneClick，损失有限；恢复路径已在 backlog #149 记录。
+- **Windows in-app 全自动更新事实下线**：由「前往下载」引导替代——**无回归**：如背景所述该功能从未实际生效（latest.yml 极早期即不再上传 + GitHub 不可达），方案 A 不损失任何实际可用功能；恢复路径已在 backlog #149 记录。
+- **in-app 死代码保留的说明**：electron-updater 依赖与 `downloadUpdate`/`installUpdate`/`cancelUpdate` 链路保留不删，仅为 #149 未来复活留低门槛；因从未生效，保留与删除对用户行为均无差异，选保留以缩小本次 diff。
 - **Mac x64 机器缺 intel 键**（极旧清单）：`downloadUrl` 为 undefined → UI 回退渲染「下载」按钮，点击后进入不可用的 in-app 路径（electron-updater 报 error）——UI 已有 error 展示与重试，不静默失败；实际清单始终含 intel 键（CI 必需资产校验），触发概率≈0。
 - **清单 version 非法**（如空串）：`compareVersions` NaN 分支返回 0 → 视为无更新，安全侧退化。

--- a/docs/dev/infra/2026-08-17-app-update-oss-source/design.md
+++ b/docs/dev/infra/2026-08-17-app-update-oss-source/design.md
@@ -1,7 +1,7 @@
 # App 新版本检测切换 OSS 镜像源
 
 - 日期：2026-08-17
-- 状态：Proposed
+- 状态：Implemented（2026-08-17，4a67d77）
 - 关联：`docs/dev/infra/2026-07-27-release-oss-mirror/design.md`（OSS 镜像与 latest.json 清单）、backlog #149（恢复 Windows 自动更新 feed，本设计不解决、继续保留为 follow-up）、`docs/dev/infra/2026-07-03-app-update-mechanism/design.md`（原始更新机制）
 
 ## 背景
@@ -90,7 +90,8 @@ interface OssUpdateManifest {
 | 文件 | 变更 |
 |---|---|
 | `packages/desktop/electron/updater.ts` | 新增 `OSS_UPDATE_MANIFEST_URL` 常量、`OssUpdateManifest` 类型、`checkForUpdatesViaOss()`；`checkForUpdates` 两平台统一走之；删除 `checkForUpdatesMacFallback`；`compareVersions` 不变 |
-| `packages/app/src/features/settings/UpdateChecker.tsx` | error 兜底链接 GitHub Releases → landing page |
+| `packages/app/src/features/settings/UpdateChecker.tsx` | error 兜底链接 GitHub Releases → landing page；文案 key `gotoReleases` → `gotoDownloadPage` |
+| `packages/i18n/src/locales/{zh-CN,en,zh-TW}.ts` | 兜底按钮三语文案改为「前往官网下载」 |
 | `packages/desktop/electron/updater.test.ts` | 重写检测用例（见测试策略） |
 
 不改动：`host-bridge.ts` 契约（`UpdateState`/`UpdateEvent` 已有 `downloadUrl?` 字段）、`preload.ts`、`main.ts`（启动静默检查调用不变）、electron-builder.yml publish 配置（未来恢复 feed 用）、CI（`publish-oss` 已自动维护清单）。

--- a/docs/dev/infra/2026-08-17-app-update-oss-source/design.md
+++ b/docs/dev/infra/2026-08-17-app-update-oss-source/design.md
@@ -61,7 +61,7 @@ checkForUpdates(opts):
     releaseNotes = ""（清单无 notes，UI 自动隐藏）
     downloadUrl =
       darwin: process.arch === "arm64" ? mac.arm64 : mac.intel
-              # x64 Mac → intel 包；缺键 → undefined → UI 回退 in-app 分支（实际不触发）
+              # 缺键时互为回退（Rosetta 2 可跑 intel 包）；全缺 → undefined → UI 回退 in-app 分支
       win32:  process.arch === "arm64" ? (win.arm64 ?? win.x64 ?? win.setup)
                                        : (win.x64 ?? win.setup)
               # 旧清单 win.setup 兼容回退；x64 包在 ARM64 Windows 可模拟运行（与 landing 语义一致）
@@ -71,7 +71,7 @@ checkForUpdates(opts):
 
 ### 附带修正
 
-- `UpdateChecker.tsx` error 状态的「前往 Releases」兜底按钮当前指向 GitHub Releases（国内同样难打开），改为 landing page（`https://mengrru.github.io/Spherse/`）——landing 有按平台/架构选包的下载按钮且自身带 GitHub 回退。
+- `UpdateChecker.tsx` error 状态的「前往 Releases」兜底按钮当前指向 GitHub Releases（国内同样难打开），改为 landing page（`https://spherse.mengru.work/`，自定义域名，`github.io` 会 301 过去）——landing 有按平台/架构选包的下载按钮且自身带 GitHub 回退。
 
 ## 接口与数据
 
@@ -106,10 +106,10 @@ interface OssUpdateManifest {
 5. 版本相等 / 清单版本更低 → `update-not-available`。
 6. fetch 非 200 / JSON 非法 → `update-error`。
 7. dev 模式（`app.isPackaged=false`）→ upToDate 且不发 fetch。
-8. silent=true 时所有分支不 sendEvent（静默语义不变）。
+8. silent=true：available 分支仍通知（启动静默检查的目的就是发现新版本弹窗，与原实现语义一致），not-available / error 分支不 sendEvent。
 9. `compareVersions` 既有用例保留。
 
-`UpdateChecker.structure.test.ts`：error 兜底链接断言更新为 landing page。
+`UpdateChecker.structure.test.ts`：error 兜底链接断言更新为 landing page（且断言不再含 GitHub releases 链接）。
 
 回归：`npm run verify`（desktop 测试 + app 测试 + i18n + lint）。
 

--- a/docs/dev/infra/2026-08-17-app-update-oss-source/design.md
+++ b/docs/dev/infra/2026-08-17-app-update-oss-source/design.md
@@ -1,0 +1,120 @@
+# App 新版本检测切换 OSS 镜像源
+
+- 日期：2026-08-17
+- 状态：Proposed
+- 关联：`docs/dev/infra/2026-07-27-release-oss-mirror/design.md`（OSS 镜像与 latest.json 清单）、backlog #149（恢复 Windows 自动更新 feed，本设计不解决、继续保留为 follow-up）、`docs/dev/infra/2026-07-03-app-update-mechanism/design.md`（原始更新机制）
+
+## 背景
+
+用户反馈「app 内检查更新总是失败」。代码级根因：
+
+| 平台 | 当前检测链路 | 失败原因 |
+|---|---|---|
+| macOS | `updater.ts` `checkForUpdatesMacFallback()`：fetch `https://api.github.com/repos/mengrru/Spherse/releases/latest` | GitHub API 在国内网络不可达，检测必然失败 |
+| Windows | `autoUpdater.checkForUpdates()`（electron-updater，GitHub provider） | ① GitHub 国内不可达；② 自 ba8c049 起 CI 统一 `--publish never` + `gh release upload`，GitHub Release 上不存在 `latest.yml`，feed 请求必然 404（backlog #149 已记录） |
+
+两平台检测都硬依赖 GitHub，而目标用户主要在国内网络环境。
+
+同时仓库已有现成资产：CI `publish-oss` job（`build-and-release.yml`）每次发版自动将安装包上传至 Aliyun OSS 并生成稳定清单 `https://mengru-open-source.oss-cn-beijing.aliyuncs.com/spherse/latest.json`：
+
+```json
+{
+  "version": "0.1.19",
+  "mac": { "arm64": "<dmg url>", "intel": "<dmg url>" },
+  "win": { "x64": "<exe url>", "arm64": "<exe url>" }
+}
+```
+
+（`win.arm64` 为可选键；更早版本清单曾用 `win.setup` 表示 x64 包。）landing page 已通过 `resolveDownloadUrl` 消费该清单，脱离 GitHub API。
+
+UI 侧（`UpdateChecker.tsx`）已天然支持 `downloadUrl` 模式：`available` 状态携带 `downloadUrl` 时弹窗显示「前往下载」按钮 → `bridge.openExternal(url)` 引导浏览器下载；`releaseNotes` 为空时 notes 区块自动隐藏。**切换检测源到 OSS 后 UI 侧零改动。**
+
+## 方案
+
+### 方案选型
+
+**方案 A（采纳）：统一轻量自研检测，全部平台走 OSS 清单 + 引导浏览器下载。**
+
+- `updater.ts` 新增统一检测函数 `checkForUpdatesViaOss()`，macOS 与 Windows 的 `checkForUpdates` 都走它。
+- 删除 `checkForUpdatesMacFallback()`（GitHub API）与 Windows 的 `autoUpdater.checkForUpdates()` 调用。
+- 检测到新版本时按平台 + `process.arch` 从清单选取安装包 OSS 直链，作为 `downloadUrl` 下发，UI 复用现有「前往下载」流程（openExternal → 浏览器下载 dmg/exe → 用户手动安装）。
+- 不删除 electron-updater 依赖与 in-app 下载链路（`downloadUpdate`/`installUpdate`/`cancelUpdate` 及 UI 的 `downloading`/`downloaded` 状态保留）：方案 A 下这些路径不再被触发（available 总是带 `downloadUrl`，UI 只渲染「前往下载」按钮），但保留代码可为未来恢复 electron-updater feed（backlog #149）低门槛起死回生。
+
+否决 **方案 B**（CI 生成 electron-updater 兼容 `latest.yml`/`latest-arm64.yml` + `setFeedURL` 指向 OSS，保留 Windows 全自动更新）：需处理双 arch channel 文件语义、sha512、文件名映射，且 OSS 清单格式与 electron-updater 元数据是两套体系，改动面大；NSIS 本就 `oneClick: false` 需用户交互，in-app 下载收益有限。该课题与 backlog #149 合并留作后续演进。
+
+### 核心逻辑
+
+```
+OSS_UPDATE_MANIFEST_URL = "https://mengru-open-source.oss-cn-beijing.aliyuncs.com/spherse/latest.json"
+
+checkForUpdates(opts):
+  if (!app.isPackaged) → upToDate（dev 行为不变）
+  silent = opts.silent
+  fetch(OSS_UPDATE_MANIFEST_URL)          # Electron 主进程 Node fetch，无 CORS 限制
+  if (!res.ok) → error
+  manifest = json 解析（version/mac/win）
+  if (compareVersions(manifest.version, app.getVersion()) <= 0) → upToDate（silent 吞掉事件，行为不变）
+  → available：
+    version = manifest.version
+    releaseNotes = ""（清单无 notes，UI 自动隐藏）
+    downloadUrl =
+      darwin: process.arch === "arm64" ? mac.arm64 : mac.intel
+              # x64 Mac → intel 包；缺键 → undefined → UI 回退 in-app 分支（实际不触发）
+      win32:  process.arch === "arm64" ? (win.arm64 ?? win.x64 ?? win.setup)
+                                       : (win.x64 ?? win.setup)
+              # 旧清单 win.setup 兼容回退；x64 包在 ARM64 Windows 可模拟运行（与 landing 语义一致）
+    sendEvent("update-available", …)
+  catch → error（silent 吞掉）
+```
+
+### 附带修正
+
+- `UpdateChecker.tsx` error 状态的「前往 Releases」兜底按钮当前指向 GitHub Releases（国内同样难打开），改为 landing page（`https://mengrru.github.io/Spherse/`）——landing 有按平台/架构选包的下载按钮且自身带 GitHub 回退。
+
+## 接口与数据
+
+### OSS 清单类型（updater.ts 内新增，与 landing Manifest 对齐）
+
+```ts
+interface OssUpdateManifest {
+  version: string;
+  mac: { arm64?: string; intel?: string };
+  win: { x64?: string; arm64?: string; setup?: string };
+}
+```
+
+### 变更面
+
+| 文件 | 变更 |
+|---|---|
+| `packages/desktop/electron/updater.ts` | 新增 `OSS_UPDATE_MANIFEST_URL` 常量、`OssUpdateManifest` 类型、`checkForUpdatesViaOss()`；`checkForUpdates` 两平台统一走之；删除 `checkForUpdatesMacFallback`；`compareVersions` 不变 |
+| `packages/app/src/features/settings/UpdateChecker.tsx` | error 兜底链接 GitHub Releases → landing page |
+| `packages/desktop/electron/updater.test.ts` | 重写检测用例（见测试策略） |
+
+不改动：`host-bridge.ts` 契约（`UpdateState`/`UpdateEvent` 已有 `downloadUrl?` 字段）、`preload.ts`、`main.ts`（启动静默检查调用不变）、electron-builder.yml publish 配置（未来恢复 feed 用）、CI（`publish-oss` 已自动维护清单）。
+
+## 测试策略
+
+`updater.test.ts`（vitest，mock `electron`、`electron-updater`、global fetch、`app.getVersion`）：
+
+1. macOS arm64：清单 version 更高 → `update-available` 事件携带 `mac.arm64` URL。
+2. macOS x64：同上 → 携带 `mac.intel` URL。
+3. Windows x64：清单 version 更高 → 携带 `win.x64` URL。
+4. Windows arm64 且清单含 arm64 → 携带 `win.arm64`；清单缺 arm64 → 回退 `win.x64`；旧清单仅 `win.setup` → 回退 `win.setup`。
+5. 版本相等 / 清单版本更低 → `update-not-available`。
+6. fetch 非 200 / JSON 非法 → `update-error`。
+7. dev 模式（`app.isPackaged=false`）→ upToDate 且不发 fetch。
+8. silent=true 时所有分支不 sendEvent（静默语义不变）。
+9. `compareVersions` 既有用例保留。
+
+`UpdateChecker.structure.test.ts`：error 兜底链接断言更新为 landing page。
+
+回归：`npm run verify`（desktop 测试 + app 测试 + i18n + lint）。
+
+## 风险
+
+- **OSS 单点依赖**：清单不可用/欠费时检测失败，与现状（GitHub 失败）等价，但 OSS 由作者自控、可观测性更好；landing 已同源依赖，风险已存在且被接受。
+- **存量旧版 app**：仍指向 GitHub 的旧版本用户无法收到引导——当前版本 0.1.19、用户量极小（早期阶段），可接受。
+- **Windows in-app 全自动更新事实下线**：由「前往下载」引导替代；NSIS 本就非 oneClick，损失有限；恢复路径已在 backlog #149 记录。
+- **Mac x64 机器缺 intel 键**（极旧清单）：`downloadUrl` 为 undefined → UI 回退渲染「下载」按钮，点击后进入不可用的 in-app 路径（electron-updater 报 error）——UI 已有 error 展示与重试，不静默失败；实际清单始终含 intel 键（CI 必需资产校验），触发概率≈0。
+- **清单 version 非法**（如空串）：`compareVersions` NaN 分支返回 0 → 视为无更新，安全侧退化。

--- a/packages/app/src/features/settings/UpdateChecker.structure.test.ts
+++ b/packages/app/src/features/settings/UpdateChecker.structure.test.ts
@@ -58,6 +58,12 @@ describe("UpdateChecker structure", () => {
     expect(source).toContain("acceptDownload");
   });
 
+  it("error fallback opens the landing page (not GitHub releases)", () => {
+    // 检测失败兜底跳 landing page（含平台/架构选包，国内可达），不再指向 GitHub
+    expect(source).toContain("https://spherse.mengru.work/");
+    expect(source).not.toContain("github.com/mengrru/Spherse/releases");
+  });
+
   it("renders a downloaded dialog with restart actions", () => {
     expect(source).toContain('"downloaded"');
     expect(source).toContain("acceptRestart");

--- a/packages/app/src/features/settings/UpdateChecker.structure.test.ts
+++ b/packages/app/src/features/settings/UpdateChecker.structure.test.ts
@@ -62,6 +62,8 @@ describe("UpdateChecker structure", () => {
     // 检测失败兜底跳 landing page（含平台/架构选包，国内可达），不再指向 GitHub
     expect(source).toContain("https://spherse.mengru.work/");
     expect(source).not.toContain("github.com/mengrru/Spherse/releases");
+    // 兑底按钮文案 key 不再叫 gotoReleases（实际指向官网下载页，避免文案与链接不一致）
+    expect(source).not.toContain("gotoReleases");
   });
 
   it("renders a downloaded dialog with restart actions", () => {

--- a/packages/app/src/features/settings/UpdateChecker.tsx
+++ b/packages/app/src/features/settings/UpdateChecker.tsx
@@ -68,7 +68,7 @@ export function UpdateChecker() {
                   void bridge.openExternal("https://spherse.mengru.work/")
                 }
               >
-                {t("settings.about.gotoReleases")}
+                {t("settings.about.gotoDownloadPage")}
               </Button>
             </div>
           </div>

--- a/packages/app/src/features/settings/UpdateChecker.tsx
+++ b/packages/app/src/features/settings/UpdateChecker.tsx
@@ -65,9 +65,7 @@ export function UpdateChecker() {
               <Button
                 variant="outline"
                 onClick={() =>
-                  void bridge.openExternal(
-                    "https://github.com/mengrru/Spherse/releases/"
-                  )
+                  void bridge.openExternal("https://spherse.mengru.work/")
                 }
               >
                 {t("settings.about.gotoReleases")}

--- a/packages/desktop/electron/updater.test.ts
+++ b/packages/desktop/electron/updater.test.ts
@@ -1,22 +1,101 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { appMock, events, autoUpdaterMock } = vi.hoisted(() => {
+  const appMock = {
+    isPackaged: false,
+    getVersion: () => "0.1.0",
+  };
+  const events: Array<Record<string, unknown>> = [];
+  const autoUpdaterMock = {
+    autoDownload: false,
+    on: vi.fn(),
+    checkForUpdates: vi.fn(),
+  };
+  return { appMock, events, autoUpdaterMock };
+});
 
 vi.mock("electron", () => ({
-  app: { isPackaged: false, getVersion: () => "0.0.0" },
+  app: appMock,
 }));
 vi.mock("electron-updater", () => ({
   default: {
-    autoUpdater: {
-      autoDownload: false,
-      on: () => {},
-    },
+    autoUpdater: autoUpdaterMock,
     CancellationToken: class {},
   },
 }));
 vi.mock("./window.js", () => ({
-  getMainWindow: () => null,
+  getMainWindow: () => ({
+    webContents: {
+      send: (_type: string, event: Record<string, unknown>) => {
+        events.push(event);
+      },
+    },
+  }),
 }));
 
-import { compareVersions } from "./updater";
+import {
+  compareVersions,
+  createUpdater,
+  resolveDownloadUrlFromManifest,
+  updater,
+  type OssUpdateManifest,
+} from "./updater";
+
+const MANIFEST_URL =
+  "https://mengru-open-source.oss-cn-beijing.aliyuncs.com/spherse/latest.json";
+
+const manifest: OssUpdateManifest = {
+  version: "0.2.0",
+  mac: {
+    arm64: "https://oss/spherse/releases/0.2.0/Spherse-0.2.0-arm64.dmg",
+    intel: "https://oss/spherse/releases/0.2.0/Spherse-0.2.0-intel.dmg",
+  },
+  win: {
+    x64: "https://oss/spherse/releases/0.2.0/Spherse-Setup-0.2.0-x64.exe",
+    arm64: "https://oss/spherse/releases/0.2.0/Spherse-Setup-0.2.0-arm64.exe",
+  },
+};
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  events.length = 0;
+  appMock.isPackaged = true;
+  appMock.getVersion = () => "0.1.0";
+  autoUpdaterMock.checkForUpdates.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mockManifestResponse(body: unknown, ok = true, status = 200): void {
+  fetchMock.mockResolvedValueOnce({
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  });
+}
+
+/** 临时切换 process.platform/arch（测试后还原，避免跨用例污染） */
+async function withProcess(
+  platform: NodeJS.Platform,
+  arch: string,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const origPlatform = process.platform;
+  const origArch = process.arch;
+  Object.defineProperty(process, "platform", { value: platform });
+  Object.defineProperty(process, "arch", { value: arch });
+  try {
+    await fn();
+  } finally {
+    Object.defineProperty(process, "platform", { value: origPlatform });
+    Object.defineProperty(process, "arch", { value: origArch });
+  }
+}
 
 describe("compareVersions", () => {
   it("returns 0 for equal versions", () => {
@@ -48,5 +127,207 @@ describe("compareVersions", () => {
   it("returns 0 when parsing fails (NaN guard)", () => {
     expect(compareVersions("beta", "1.0.0")).toBe(0);
     expect(compareVersions("1.0.0", "invalid")).toBe(0);
+  });
+});
+
+describe("resolveDownloadUrlFromManifest", () => {
+  it("darwin arm64 selects mac.arm64", () => {
+    expect(
+      resolveDownloadUrlFromManifest(manifest, "darwin", "arm64"),
+    ).toBe(manifest.mac?.arm64);
+  });
+
+  it("darwin x64 selects mac.intel", () => {
+    expect(
+      resolveDownloadUrlFromManifest(manifest, "darwin", "x64"),
+    ).toBe(manifest.mac?.intel);
+  });
+
+  it("darwin falls back to the other arch key when the preferred one is missing", () => {
+    const m: OssUpdateManifest = {
+      version: "0.2.0",
+      mac: { intel: "https://oss/intel.dmg" },
+    };
+    expect(resolveDownloadUrlFromManifest(m, "darwin", "arm64")).toBe(
+      "https://oss/intel.dmg",
+    );
+    expect(resolveDownloadUrlFromManifest(m, "darwin", "x64")).toBe(
+      "https://oss/intel.dmg",
+    );
+  });
+
+  it("darwin returns undefined when mac section is missing entirely", () => {
+    expect(
+      resolveDownloadUrlFromManifest(
+        { version: "0.2.0" },
+        "darwin",
+        "arm64",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("win32 x64 selects win.x64", () => {
+    expect(
+      resolveDownloadUrlFromManifest(manifest, "win32", "x64"),
+    ).toBe(manifest.win?.x64);
+  });
+
+  it("win32 arm64 prefers win.arm64 and falls back to x64", () => {
+    expect(
+      resolveDownloadUrlFromManifest(manifest, "win32", "arm64"),
+    ).toBe(manifest.win?.arm64);
+    const noArm64: OssUpdateManifest = {
+      version: "0.2.0",
+      win: { x64: "https://oss/x64.exe" },
+    };
+    expect(
+      resolveDownloadUrlFromManifest(noArm64, "win32", "arm64"),
+    ).toBe("https://oss/x64.exe");
+  });
+
+  it("win32 falls back to legacy win.setup key", () => {
+    const legacy: OssUpdateManifest = {
+      version: "0.2.0",
+      win: { setup: "https://oss/setup.exe" },
+    };
+    expect(resolveDownloadUrlFromManifest(legacy, "win32", "x64")).toBe(
+      "https://oss/setup.exe",
+    );
+    expect(resolveDownloadUrlFromManifest(legacy, "win32", "arm64")).toBe(
+      "https://oss/setup.exe",
+    );
+  });
+
+  it("returns undefined on unknown platform", () => {
+    expect(
+      resolveDownloadUrlFromManifest(manifest, "linux", "x64"),
+    ).toBeUndefined();
+  });
+});
+
+describe("updater.checkForUpdates (OSS manifest source)", () => {
+  it("dev mode short-circuits to upToDate without fetching", async () => {
+    appMock.isPackaged = false;
+    await updater.checkForUpdates({ silent: false });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(events).toEqual([{ type: "update-not-available" }]);
+    expect(updater.getState()).toEqual({ status: "upToDate" });
+  });
+
+  it("darwin: newer manifest version emits update-available with OSS downloadUrl", async () => {
+    mockManifestResponse(manifest);
+    await withProcess("darwin", "arm64", () =>
+      updater.checkForUpdates({ silent: false }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(MANIFEST_URL);
+    expect(events).toEqual([
+      {
+        type: "update-available",
+        version: "0.2.0",
+        releaseNotes: "",
+        downloadUrl: manifest.mac?.arm64,
+      },
+    ]);
+    expect(updater.getState()).toEqual({
+      status: "available",
+      version: "0.2.0",
+      releaseNotes: "",
+      downloadUrl: manifest.mac?.arm64,
+    });
+  });
+
+  it("win32 x64: emits update-available with x64 installer URL", async () => {
+    mockManifestResponse(manifest);
+    await withProcess("win32", "x64", () =>
+      updater.checkForUpdates({ silent: false }),
+    );
+    expect(events).toEqual([
+      {
+        type: "update-available",
+        version: "0.2.0",
+        releaseNotes: "",
+        downloadUrl: manifest.win?.x64,
+      },
+    ]);
+  });
+
+  it("equal or older manifest version emits update-not-available", async () => {
+    mockManifestResponse({ ...manifest, version: "0.1.0" });
+    await updater.checkForUpdates({ silent: false });
+    expect(events).toEqual([{ type: "update-not-available" }]);
+    expect(updater.getState()).toEqual({ status: "upToDate" });
+  });
+
+  it("manifest missing version degrades safely to update-not-available", async () => {
+    mockManifestResponse({ mac: manifest.mac, win: manifest.win });
+    await updater.checkForUpdates({ silent: false });
+    expect(events).toEqual([{ type: "update-not-available" }]);
+  });
+
+  it("non-200 manifest response emits update-error", async () => {
+    mockManifestResponse(null, false, 503);
+    await updater.checkForUpdates({ silent: false });
+    expect(events).toEqual([
+      { type: "update-error", message: "OSS manifest responded 503" },
+    ]);
+    expect(updater.getState()).toEqual({
+      status: "error",
+      errorMessage: "OSS manifest responded 503",
+    });
+  });
+
+  it("invalid JSON emits update-error", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new Error("Unexpected token <")),
+    });
+    await updater.checkForUpdates({ silent: false });
+    expect(events).toEqual([
+      { type: "update-error", message: "Unexpected token <" },
+    ]);
+  });
+
+  it("silent check still notifies on available but swallows not-available / error", async () => {
+    // available 即使 silent 也通知（启动静默检查的目的就是发现新版弹窗），
+    // silent 只吞掉 not-available / error 噪音（与原 mac fallback 语义一致）
+    mockManifestResponse(manifest);
+    await withProcess("darwin", "arm64", () =>
+      updater.checkForUpdates({ silent: true }),
+    );
+    expect(events).toEqual([
+      {
+        type: "update-available",
+        version: "0.2.0",
+        releaseNotes: "",
+        downloadUrl: manifest.mac?.arm64,
+      },
+    ]);
+
+    events.length = 0;
+    mockManifestResponse({ ...manifest, version: "0.1.0" });
+    await updater.checkForUpdates({ silent: true });
+    expect(events).toEqual([]);
+
+    mockManifestResponse(null, false, 500);
+    await updater.checkForUpdates({ silent: true });
+    expect(events).toEqual([]);
+  });
+
+  it("never calls electron-updater's GitHub feed (regression guard)", async () => {
+    mockManifestResponse(manifest);
+    await updater.checkForUpdates({ silent: false });
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled();
+  });
+});
+
+describe("createUpdater", () => {
+  it("exposes the full Updater interface", () => {
+    const u = createUpdater(() => null);
+    expect(typeof u.checkForUpdates).toBe("function");
+    expect(typeof u.downloadUpdate).toBe("function");
+    expect(typeof u.installUpdate).toBe("function");
+    expect(typeof u.cancelUpdate).toBe("function");
+    expect(typeof u.getState).toBe("function");
   });
 });

--- a/packages/desktop/electron/updater.test.ts
+++ b/packages/desktop/electron/updater.test.ts
@@ -214,6 +214,14 @@ describe("updater.checkForUpdates (OSS manifest source)", () => {
     expect(updater.getState()).toEqual({ status: "upToDate" });
   });
 
+  it("dev mode silent check emits nothing (startup silent check in dev)", async () => {
+    appMock.isPackaged = false;
+    await updater.checkForUpdates({ silent: true });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+    expect(updater.getState()).toEqual({ status: "upToDate" });
+  });
+
   it("darwin: newer manifest version emits update-available with OSS downloadUrl", async () => {
     mockManifestResponse(manifest);
     await withProcess("darwin", "arm64", () =>

--- a/packages/desktop/electron/updater.ts
+++ b/packages/desktop/electron/updater.ts
@@ -5,6 +5,43 @@ const { autoUpdater, CancellationToken } = electronUpdater;
 import type { UpdateState, UpdateEvent } from "./types.js";
 import { getMainWindow } from "./window.js";
 
+// 更新检测源：CI publish-oss job 每次发版自动维护的 OSS 清单（国内可达，
+// 与 landing page 下载按钮同源）。替代此前 GitHub API / electron-updater
+// GitHub feed（后者 latest.yml 自 ba8c049 起不再上传，检测必然 404）。
+const OSS_UPDATE_MANIFEST_URL =
+  "https://mengru-open-source.oss-cn-beijing.aliyuncs.com/spherse/latest.json";
+
+/**
+ * OSS latest.json 清单结构（与 landing `resolveDownloadUrl` / CI `publish-oss`
+ * 生成端对齐；`win.setup` 为旧版清单键名，保留兼容回退）。
+ */
+export interface OssUpdateManifest {
+  version: string;
+  mac?: { arm64?: string; intel?: string };
+  win?: { x64?: string; arm64?: string; setup?: string };
+}
+
+export function resolveDownloadUrlFromManifest(
+  manifest: OssUpdateManifest,
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string | undefined {
+  if (platform === "darwin") {
+    // x64 Mac 跑的是 intel 包（反之亦然，缺键时互为回退）；全缺 → undefined
+    return arch === "arm64"
+      ? (manifest.mac?.arm64 ?? manifest.mac?.intel)
+      : (manifest.mac?.intel ?? manifest.mac?.arm64);
+  }
+  if (platform === "win32") {
+    // x64 包在 ARM64 Windows 可模拟运行（与 landing 语义一致）
+    if (arch === "arm64") {
+      return manifest.win?.arm64 ?? manifest.win?.x64 ?? manifest.win?.setup;
+    }
+    return manifest.win?.x64 ?? manifest.win?.setup;
+  }
+  return undefined;
+}
+
 autoUpdater.autoDownload = false;
 autoUpdater.autoInstallOnAppQuit = false;
 
@@ -96,27 +133,22 @@ export function createUpdater(getWindow: () => BrowserWindow | null): Updater {
     sendEvent({ type: "update-error", message: errorMessage });
   });
 
-  async function checkForUpdatesMacFallback(): Promise<void> {
+  async function checkForUpdatesViaOss(): Promise<void> {
     currentState = { status: "checking" };
     try {
-      const res = await fetch(
-        "https://api.github.com/repos/mengrru/Spherse/releases/latest",
-        { headers: { "User-Agent": "Spherse-Updater" } },
-      );
+      const res = await fetch(OSS_UPDATE_MANIFEST_URL);
       if (!res.ok) {
-        throw new Error(`GitHub API responded ${res.status}`);
+        throw new Error(`OSS manifest responded ${res.status}`);
       }
-      const data = (await res.json()) as {
-        tag_name?: string;
-        body?: string;
-        html_url?: string;
-      };
-      const tagName = data.tag_name ?? "";
-      const version = tagName.replace(/^v/, "");
+      const data = (await res.json()) as Partial<OssUpdateManifest>;
+      const version = typeof data.version === "string" ? data.version : "";
       const current = app.getVersion();
       if (compareVersions(version, current) > 0) {
-        const releaseNotes = data.body ?? "";
-        const downloadUrl = data.html_url;
+        const downloadUrl = resolveDownloadUrlFromManifest(
+          data as OssUpdateManifest,
+        );
+        // OSS 清单无 release notes，留空由 UI 自动隐藏
+        const releaseNotes = "";
         currentState = {
           status: "available",
           version,
@@ -159,12 +191,10 @@ export function createUpdater(getWindow: () => BrowserWindow | null): Updater {
         return;
       }
       silent = opts.silent;
-      if (process.platform === "darwin") {
-        await checkForUpdatesMacFallback();
-        return;
-      }
-      currentState = { status: "checking" };
-      await autoUpdater.checkForUpdates();
+      // mac/win 统一走 OSS 清单检测 + 引导浏览器下载（前往下载）。
+      // electron-updater 的 GitHub feed 自 ba8c049 起无 latest.yml，不再使用；
+      // 其 in-app 下载 API 保留给未来恢复 feed（backlog #149）。
+      await checkForUpdatesViaOss();
     },
 
     async downloadUpdate(): Promise<void> {

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -109,7 +109,7 @@ export const en: Record<TranslationKey, string> = {
   "settings.about.upToDate": "Up to date",
   "settings.about.checkFailed": "Update check failed, please try again later",
   "settings.about.retry": "Retry",
-  "settings.about.gotoReleases": "Download from GitHub Releases",
+  "settings.about.gotoDownloadPage": "Download from the website",
   "settings.update.newVersion": "New version available v{version}",
   "settings.update.releaseNotes": "Release notes",
   "settings.update.download": "Update now",

--- a/packages/i18n/src/locales/zh-CN.ts
+++ b/packages/i18n/src/locales/zh-CN.ts
@@ -216,8 +216,8 @@ export const zhCN = {
   "settings.about.checkFailed": "检查更新失败，请稍后重试",
   // error 态的重试按钮
   "settings.about.retry": "重试",
-  // error 态引导用户手动去 GitHub releases 页面下载新版本的按钮
-  "settings.about.gotoReleases": "前往 GitHub Releases 下载",
+  // error 态引导用户前往官网下载页（landing page，按平台/架构自动选包）手动下载新版本的按钮
+  "settings.about.gotoDownloadPage": "前往官网下载",
   // 更新确认弹窗标题，{version} 为新版本号
   "settings.update.newVersion": "发现新版本 v{version}",
   // 更新确认弹窗中 release notes 区域标题

--- a/packages/i18n/src/locales/zh-TW.ts
+++ b/packages/i18n/src/locales/zh-TW.ts
@@ -109,7 +109,7 @@ export const zhTW: Record<TranslationKey, string> = {
   "settings.about.upToDate": "已是最新版本",
   "settings.about.checkFailed": "檢查更新失敗，請稍後重試",
   "settings.about.retry": "重試",
-  "settings.about.gotoReleases": "前往 GitHub Releases 下載",
+  "settings.about.gotoDownloadPage": "前往官網下載",
   "settings.update.newVersion": "發現新版本 v{version}",
   "settings.update.releaseNotes": "更新內容",
   "settings.update.download": "立即更新",


### PR DESCRIPTION
## 问题
app 内「检查更新」总是失败：
- mac 走 GitHub API（国内不可达）
- win 走 electron-updater GitHub feed（latest.yml 自 ba8c049 起不再上传，必然 404）

## 方案（design doc：docs/dev/infra/2026-08-17-app-update-oss-source/design.md）
- mac/win 统一 fetch OSS 镜像清单 https://mengru-open-source.oss-cn-beijing.aliyuncs.com/spherse/latest.json（CI publish-oss 每次发版自动维护）
- compareVersions 判定新版，按 platform/arch 选取安装包 OSS 直链作 downloadUrl，UI 复用既有「前往下载」引导浏览器下载
- win 保留旧 win.setup 键兼容回退；darwin arch 缺键互为回退
- electron-updater in-app 下载链路保留不删（backlog #149 未来恢复 feed）
- error 兜底链接 GitHub Releases → landing page（spherse.mengru.work），三语文案同步「前往官网下载」

## 测试
- updater.test.ts 重写：OSS 检测流程 9 条 + resolveDownloadUrlFromManifest 8 条 + compareVersions 7 条保留
- structure test 锁死兜底链接与 i18n key
- root verify 全绿（lint/build/单测/i18n）
- self-review（pi sub agent）：0 Critical，1 Important（文案与链接不符）已修复（8ba4ed2）