### PR TITLE
fix: restore 时为被中断的 toolCall 合成 toolResult

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -10,6 +10,7 @@
 
 ## 代码质量
 
+- [x] **restore 时补齐被中断的 toolCall（孤儿 toolCall 自愈）**：工具执行中途崩溃/退出后，assistant 消息（含 toolCall）已落库而 toolResult 未落库，恢复后会话永久不可用——下次 prompt 被 provider 以 tool_use/tool_result 配对违规拒绝，且 `retryLastTurn` 的 `stopReason === "error"` 守卫不匹配（消息以 `toolUse` 正常结束）无法自救。修复：`initForRestore` 构造 initialLog 后经 `synthesizeInterruptedToolResults`（`session/compactor.ts` 纯函数，参考已废弃 event log 分支的 repairLog 思路）为尾部 assistant 消息中未应答的 toolCall 合成 `isError` toolResult 并持久化（幂等，二次 restore 不重复合成）。参见 `docs/dev/bugfix/2026-08-20-restore-orphaned-toolcall/design.md`
 - [ ] **审批卡 abort/run 结束后 pending 态残留**：run 被中断（`rejectAll` 不发 `control_resolved`）时，`run_command` 的 pending_approval CommandCard 与 `manage_agent`/`manage_trigger` 的 pending ApprovalCard 仍保留可交互按钮，点击后静默无效（bus 对未知 requestId 忽略）。ask_user 的 QuestionCard 已在 `run_status inactive` 时由 reducer 清除（`clearPendingQuestionCards`），approval 侧应复用同款收敛（terminalize 或清除），并补 reducer 测试。
 
 - [x] **Chat 前端状态边界拆分**：将 `features/chat/runtime/streaming-store.ts` 中的 WebSocket、心跳、重连和连接期对账提取为 per-session `ChatSessionRuntime`；Zustand 仅保留可观察状态与公开 actions，transport runtime 由 registry 管理；将纯数据逻辑收纳到 `features/chat/model/`，由 reducer、历史投影和 tool/card 投影模块分别负责，并以 `connectionStatus` 替代 `wsConnecting` 布尔值。参见 `docs/dev/bugfix/2026-08-04-chat-ws-lifecycle/design.md`

--- a/docs/dev/bugfix/2026-08-20-restore-orphaned-toolcall/design.md
+++ b/docs/dev/bugfix/2026-08-20-restore-orphaned-toolcall/design.md
@@ -1,0 +1,34 @@
+# Restore 时补齐被中断的 toolCall（孤儿 toolCall 自愈）
+
+- 日期：2026-08-20
+- 影响文件：`packages/core/src/session/compactor.ts`、`packages/core/src/session/agent-runner.ts`
+
+## 问题
+
+会话在工具执行中途崩溃/退出时，assistant 消息（含 toolCall 块）已在 `message_end` 落库，但对应 toolResult 未落库。恢复路径存在两个缺口：
+
+1. `initForRestore` 的无 compaction 分支 `logFromRows` 完全不做 sanitize；compaction 分支的 `sanitizeToolCallPairs` 只删孤儿 toolResult（有 result 无 call），**不补孤儿 toolCall**（有 call 无 result）
+2. 恢复后该会话永久不可用：
+   - 下次 `sendMessage` 时孤儿 toolCall 违反 provider 的 tool_use/tool_result 配对约束，请求被拒（pi-agent-core 文档明确该场景）
+   - `retryLastTurn` 守卫 `stopReason === "error"` 不匹配（该 assistant 消息以 `toolUse` 正常结束），无法通过重试弹掉
+   - 用户只能弃用该会话
+
+## 方案
+
+参考已废弃的 event log 分支（`feat/core-event-log-refactor`）中 `repairLog` 的思路，在新内核的最小落点上实现：
+
+- **纯函数** `synthesizeInterruptedToolResults(log: MessageLog): AgentMessage[]`（`session/compactor.ts`）：
+  - 扫描 log，收集全部已应答的 `toolCallId`，记录最后一个含 toolCall 的 assistant 消息
+  - 对其中未应答的 toolCall 生成合成 toolResult（`isError: true`，文案 "The tool call was interrupted and did not execute."）
+  - 只处理尾部 assistant 消息：正常运行下孤儿只可能出现在尾部（pi 的 loop 要求 toolResult 齐了才会进入下一轮）；中段孤儿属 DB 损坏，不在本次范围
+- **接线**（`AgentRunner.initForRestore`）：构造 initialLog 后（两条路径统一）调用该函数，对每条合成消息 `appendMessage` 持久化并以真实 dbId `appendEntry`
+
+## 设计取舍
+
+- **持久化而非仅内存合成**：DB 自愈，所有读取方（UI 历史 `getRecentTurns`、status 计算、未来 compaction 锚点）看到一致故事；幂等——二次 restore 时 toolCall 已有应答，不再合成
+- **不删除带孤儿 toolCall 的 assistant 消息**：无 compaction 路径保留 error assistant 消息是既有语义（retry-after-restore 依赖 `stopReason === "error"` 的最后一条消息存在），删除会破坏重试
+
+## 验证
+
+- `agent-runner.test.ts` 新增：部分应答场景（2 toolCall 1 result）合成 + 落库 + dbId 有效 + 二次 restore 幂等；完整应答场景不合成
+- 全量 core 测试通过（model-providers UA 测试 1 例失败为 HEAD 存量问题，与本次无关）；server 测试失败数与 HEAD 完全一致（存量）

--- a/docs/dev/bugfix/2026-08-20-restore-orphaned-toolcall/plan.md
+++ b/docs/dev/bugfix/2026-08-20-restore-orphaned-toolcall/plan.md
@@ -1,0 +1,7 @@
+# 实施计划：restore 孤儿 toolCall 自愈
+
+1. [x] 失败测试：`agent-runner.test.ts` 补两条用例（部分应答 → 合成 + 持久化 + 幂等；完整应答 → 不动）
+2. [x] 纯函数 `synthesizeInterruptedToolResults` 落 `session/compactor.ts`
+3. [x] `AgentRunner.initForRestore` 接线（合成 → appendMessage → appendEntry）
+4. [x] core 全量测试 + lint + server 测试对账（失败均为存量）
+5. [x] bugfix 文档 + backlog 条目

--- a/packages/core/src/__tests__/session/agent-runner.test.ts
+++ b/packages/core/src/__tests__/session/agent-runner.test.ts
@@ -241,6 +241,82 @@ describe("AgentRunner context engineering", () => {
     expect(agent.state.messages[0].content).toContain("hello world");
   });
 
+  it("restore synthesizes toolResult for interrupted tool call and persists it", async () => {
+    const agentStore = getAgentStore(runtime, agentId);
+    const sessionId = agentStore.sessions.createSession();
+
+    const userMsg = { role: "user", content: "run the tools", timestamp: Date.now() };
+    const assistantMsg = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "calling tools" },
+        { type: "toolCall", id: "tc-1", name: "read_file", arguments: { path: "a.md" } },
+        { type: "toolCall", id: "tc-2", name: "read_file", arguments: { path: "b.md" } },
+      ],
+      stopReason: "toolUse",
+      timestamp: Date.now(),
+    };
+    const answeredResult = {
+      role: "toolResult",
+      toolCallId: "tc-1",
+      toolName: "read_file",
+      content: [{ type: "text", text: "content of a" }],
+      timestamp: Date.now(),
+    };
+    agentStore.sessions.appendMessage(sessionId, userMsg);
+    agentStore.sessions.appendMessage(sessionId, assistantMsg);
+    agentStore.sessions.appendMessage(sessionId, answeredResult);
+
+    const runner = await AgentRunner.initForRestore(deps, agentId, sessionId);
+    const messages = agentOf(runner).state.messages;
+
+    const synthesized = messages.find((m: any) => m.role === "toolResult" && m.toolCallId === "tc-2");
+    expect(synthesized).toBeDefined();
+    expect(synthesized.isError).toBe(true);
+    expect(synthesized.content[0].text).toContain("interrupted");
+
+    const persisted = agentStore.sessions.getSessionMessages(sessionId);
+    const persistedSynthetic = persisted.find((m: any) => m.role === "toolResult" && m.toolCallId === "tc-2");
+    expect(persistedSynthetic).toBeDefined();
+
+    const ids = liveIdsOf(runner);
+    expect(ids[ids.length - 1]).toBeGreaterThan(0);
+
+    const restored2 = await AgentRunner.initForRestore(deps, agentId, sessionId);
+    const messages2 = agentOf(restored2).state.messages;
+    const syntheticCount = messages2.filter((m: any) => m.role === "toolResult" && m.toolCallId === "tc-2").length;
+    expect(syntheticCount).toBe(1);
+  });
+
+  it("restore leaves fully answered tool calls untouched", async () => {
+    const agentStore = getAgentStore(runtime, agentId);
+    const sessionId = agentStore.sessions.createSession();
+
+    const userMsg = { role: "user", content: "run the tool", timestamp: Date.now() };
+    const assistantMsg = {
+      role: "assistant",
+      content: [
+        { type: "toolCall", id: "tc-1", name: "read_file", arguments: { path: "a.md" } },
+      ],
+      stopReason: "toolUse",
+      timestamp: Date.now(),
+    };
+    const answeredResult = {
+      role: "toolResult",
+      toolCallId: "tc-1",
+      toolName: "read_file",
+      content: [{ type: "text", text: "content of a" }],
+      timestamp: Date.now(),
+    };
+    agentStore.sessions.appendMessage(sessionId, userMsg);
+    agentStore.sessions.appendMessage(sessionId, assistantMsg);
+    agentStore.sessions.appendMessage(sessionId, answeredResult);
+
+    const runner = await AgentRunner.initForRestore(deps, agentId, sessionId);
+    expect(agentOf(runner).state.messages.length).toBe(3);
+    expect(agentStore.sessions.getSessionMessages(sessionId).length).toBe(3);
+  });
+
   it("restoreSession with compaction restores digest + tail", async () => {
     const agentStore = getAgentStore(runtime, agentId);
     const sessionId = agentStore.sessions.createSession();

--- a/packages/core/src/session/agent-runner.ts
+++ b/packages/core/src/session/agent-runner.ts
@@ -20,7 +20,7 @@ import type { RuntimeDeps } from "./runtime.js";
 import { logEventMiddleware, persistEventMiddleware } from "./event-middlewares.js";
 import { createAttachmentSanitizer } from "../attachments/sanitizer.js";
 import { composeTurnHooks, type TurnHooks } from "../kernel/turn-hooks.js";
-import { logFromCompaction, logFromRows } from "./compactor.js";
+import { logFromCompaction, logFromRows, synthesizeInterruptedToolResults } from "./compactor.js";
 import { readCurrentTokens } from "../context/token-estimate.js";
 import {
   buildAgent,
@@ -89,7 +89,7 @@ export class AgentRunner {
     if (!session) throw new NotFoundError(`Session "${sessionId}" not found`);
 
     const latest = agentStore.sessions.getLatestCompaction(sessionId);
-    const initialLog = latest
+    let initialLog = latest
       ? logFromCompaction(
           latest.anchorMessageId,
           latest.digestContent,
@@ -99,6 +99,11 @@ export class AgentRunner {
             .map((r) => ({ id: r.id, message: r.message })),
         )
       : logFromRows(agentStore.sessions.getSessionMessagesWithIds(sessionId));
+
+    for (const message of synthesizeInterruptedToolResults(initialLog)) {
+      const dbId = agentStore.sessions.appendMessage(sessionId, message);
+      initialLog = appendEntry(initialLog, message, dbId);
+    }
 
     return AgentRunner.init(deps, agentId, sessionId, { initialLog });
   }

--- a/packages/core/src/session/compactor.ts
+++ b/packages/core/src/session/compactor.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { Message } from "@earendil-works/pi-ai";
+import type { Message, ToolCall } from "@earendil-works/pi-ai";
 import {
   appendEntry,
   createLog,
@@ -9,6 +9,40 @@ import {
 import { sanitizeToolCallPairs, wrapDigestContent } from "../context/compaction.js";
 export function logFromRows(rows: Array<{ id: number; message: AgentMessage }>): MessageLog {
   return createLog(rows.map((r) => ({ dbId: r.id, message: r.message })));
+}
+
+const INTERRUPTED_TOOL_TEXT = "The tool call was interrupted and did not execute.";
+
+export function synthesizeInterruptedToolResults(log: MessageLog): AgentMessage[] {
+  const answered = new Set<string>();
+  let lastToolCallAssistant: { toolCalls: ToolCall[] } | null = null;
+
+  for (const entry of log.entries) {
+    const message = entry.message as Message;
+    if (message.role === "toolResult") {
+      answered.add(message.toolCallId);
+    } else if (message.role === "assistant") {
+      const toolCalls = message.content.filter(
+        (block): block is ToolCall => block.type === "toolCall",
+      );
+      if (toolCalls.length > 0) lastToolCallAssistant = { toolCalls };
+    }
+  }
+  if (!lastToolCallAssistant) return [];
+
+  const unanswered = lastToolCallAssistant.toolCalls.filter((c) => !answered.has(c.id));
+  const now = Date.now();
+  return unanswered.map((call) => {
+    const message = {
+      role: "toolResult",
+      toolCallId: call.id,
+      toolName: call.name,
+      content: [{ type: "text", text: INTERRUPTED_TOOL_TEXT }],
+      isError: true,
+      timestamp: now,
+    } as unknown as AgentMessage;
+    return message;
+  });
 }
 
 export function logFromCompaction(


### PR DESCRIPTION
## 问题

会话在工具执行中途崩溃/退出时，assistant 消息（含 toolCall 块）已在 `message_end` 落库，但对应 toolResult 未落库。此后该会话**永久不可用**：

- 下次 `sendMessage` 时孤儿 toolCall 违反 provider 的 tool_use/tool_result 配对约束，请求被拒（pi-agent-core 明确该场景）
- `retryLastTurn` 守卫 `stopReason === "error"` 不匹配（该消息以 `toolUse` 正常结束），无法通过重试自救
- 现有 `sanitizeToolCallPairs` 只删孤儿 toolResult（有 result 无 call），不补孤儿 toolCall（有 call 无 result）

## 方案

参考已废弃 event log 分支中 `repairLog` 的思路，在现有架构的最小落点实现：

- 纯函数 `synthesizeInterruptedToolResults(log)`（`session/compactor.ts`）：为最后一个含 toolCall 的 assistant 消息中未应答的 toolCall 生成合成 toolResult（`isError: true`）
- `AgentRunner.initForRestore` 构造 initialLog 后（compaction / 无 compaction 两路径统一）合成并 `appendMessage` 持久化，以真实 dbId 挂入 MessageLog
- 持久化 = DB 自愈 + 幂等（二次 restore 时 toolCall 已有应答，不再合成）；UI 历史、status 计算、compaction 锚点等所有读取方看到一致故事

## 验证

- [x] 新增测试：部分应答（2 call 1 result）→ 合成 + 落库 + dbId 有效 + 二次 restore 幂等；完整应答 → 不动
- [x] core 全量测试（仅 model-providers UA 1 例失败为 HEAD 存量问题，`git stash` 对比确认）
- [x] server 测试失败数与 HEAD 完全一致（存量）
- [x] lint 0 error（16 warning 均为存量 react-refresh）

## 文档

- `docs/dev/bugfix/2026-08-20-restore-orphaned-toolcall/`（design + plan）
- backlog 新增 `[x]` 条目