### PR TITLE
chore: 启用全包 typecheck 并清零现有类型错误

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,15 @@ npm run lint --workspace=packages/app    # 单 workspace lint
 
 提交前会通过 Husky pre-commit 钩子自动执行 `npm run lint`，lint 不通过则阻塞提交。钩子不会自动修改或暂存文件，需手动运行 `npm run lint:fix` 修复。
 
+**Typecheck 命令**：
+
+```bash
+npm run typecheck                             # 全仓库类型检查（所有 workspace）
+npm run typecheck --workspace=packages/app    # 单 workspace 类型检查
+```
+
+renderer 侧（app/web/landing）的 vite/vitest 构建不做类型检查，类型错误只能通过 typecheck 发现。全包 typecheck 依赖 Node 侧包（i18n/presets/sdk/core/server）的 `dist` 类型产物，需在 `npm run build` 之后执行；`npm run verify` 已按 lint → build → typecheck → test 顺序串好。
+
 **测试命令**：
 
 ```bash
@@ -66,7 +75,7 @@ npm test --workspace=packages/server        # 运行 server/API contract 测试
 npm test --workspace=packages/i18n           # 运行 i18n 测试
 npm test --workspace=packages/app           # 运行前端 store/组件相关测试
 npm test --workspace=packages/desktop       # 运行 Electron 主进程 / IPC 相关测试
-npm run verify                              # lint + build + unit tests + i18n check
+npm run verify                              # lint + build + typecheck + unit tests + i18n check
 npm run verify:e2e                          # verify + Electron E2E
 ```
 

--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -172,7 +172,7 @@
 
 - [x] **本地验证流水线**：新增 root `npm run verify` 覆盖 lint/build/core+i18n+app unit tests/i18n check，新增 `npm run verify:e2e` 在此基础上运行 app E2E。
 - [x] **PR build pipeline**：新增 `.github/workflows/pr-build.yml`，`pull_request` 触发（`paths-ignore` 跳过纯文档变更），复用 root `npm run verify`（lint/build/单测/i18n check）在合并前自动验证，避免把 lint/类型/单测问题带进 dev/main。
-- [ ] **app 包类型检查纳入 verify**：`packages/app` 的 build 走 `electron-vite build`，只做转译不做类型检查；`tsconfig.node.json`（electron 目录）与 `tsconfig.json`（renderer）的类型错误会被静默放过（如 schema 变更后遗留的 `settings.defaultModel` 读取）。应新增 `npm run typecheck`（`tsc --noEmit` 双 project）并纳入 root `npm run verify`，防止类型错误漏到运行时。
+- [x] **app 包类型检查纳入 verify**：`packages/app` 的 build 走 `electron-vite build`，只做转译不做类型检查；`tsconfig.node.json`（electron 目录）与 `tsconfig.json`（renderer）的类型错误会被静默放过（如 schema 变更后遗留的 `settings.defaultModel` 读取）。应新增 `npm run typecheck`（`tsc --noEmit` 双 project）并纳入 root `npm run verify`，防止类型错误漏到运行时。
 - [ ] **React DOM 组件测试工具链**：为 `packages/app` 引入组件级测试基础设施（如 Testing Library + user-event + jsdom/happy-dom），用于测试 React 组件渲染、ARIA 状态、用户交互和菜单/折叠等局部 UI 行为，补足当前 Vitest 单测与 Playwright E2E 之间的测试层级。
 - [x] **electron-builder 打包**：配置生产构建和跨平台打包
 - [x] **dev/prod 环境隔离**：通过 bootstrap 入口引导文件将 dev 模式的 userData 重定向到独立目录，实现 dev 和 prod 数据完全隔离、可同时运行

--- a/docs/official/project-structure.md
+++ b/docs/official/project-structure.md
@@ -361,7 +361,7 @@ spherse/
 ├── .github/
 │   └── workflows/
 │       ├── build-and-release.yml     # Git tag 触发的 CI：mac/win 并行构建 + GitHub Releases 发布 + OSS 镜像/latest.json + 末尾 dispatch deploy-pages 联动 web 部署
-│       ├── pr-build.yml              # PR 触发的 CI：checkout + npm ci + npm run verify（lint/build/单测/i18n check）
+│       ├── pr-build.yml              # PR 触发的 CI：checkout + npm ci + npm run verify（lint/build/typecheck/单测/i18n check）
 │       └── deploy-pages.yml          # main 分支 landing/web/i18n 变更或发版流水线 workflow_dispatch 触发的 CI：构建并部署到 GitHub Pages
 ├── .husky/
 │   └── pre-commit                    # Husky pre-commit 钩子（执行 npm run lint）

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "build:web": "npm run build --workspace=@spherse/i18n && npm run build --workspace=@spherse/presets && npm run build --workspace=@spherse/sdk && npm run build --workspace=@spherse/core && npm run build --workspace=@spherse/server && npm run build --workspace=packages/web",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "verify": "npm run lint && npm run build && npm test --workspace=packages/core && npm test --workspace=packages/server && npm test --workspace=packages/sdk && npm test --workspace=packages/i18n && npm test --workspace=packages/app && npm test --workspace=packages/desktop && npm test --workspace=packages/landing && npm run check:i18n",
+    "typecheck": "npm run typecheck --workspaces",
+    "verify": "npm run lint && npm run build && npm run typecheck && npm test --workspace=packages/core && npm test --workspace=packages/server && npm test --workspace=packages/sdk && npm test --workspace=packages/i18n && npm test --workspace=packages/app && npm test --workspace=packages/desktop && npm test --workspace=packages/landing && npm run check:i18n",
     "verify:e2e": "npm run verify && npm run test:e2e --workspace=packages/desktop",
     "prepare": "husky"
   },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "pretest": "npm run build --workspace=@spherse/i18n",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },

--- a/packages/app/src/features/agent-session-list/index.tsx
+++ b/packages/app/src/features/agent-session-list/index.tsx
@@ -46,7 +46,7 @@ export function AgentSessionList() {
   const { t } = useI18n();
   const { sessionId: activeSessionId = null } = useParams();
   const navigate = useNavigate();
-  const { kind: hostKind } = useHostBridge();
+  const { kind: hostKind, openExternal } = useHostBridge();
   const { projectId } = useProjectCtx();
   const client = useApiClient(projectId);
   const agentDialogEnabled = useFeature("agent-dialog");
@@ -137,10 +137,10 @@ export function AgentSessionList() {
     deleteSession: (session) => setDialog({ kind: "delete-session", session }),
     renameSession: handleRenameSession,
     floatSession: (s) => {
-      dispatchAction("floatSession", { sessionId: s.id }, { navigate, projectId, hostKind });
+      dispatchAction("floatSession", { sessionId: s.id }, { navigate, projectId, hostKind, client, openExternal });
     },
     cancelFloat: () => {
-      dispatchAction("unfloatSession", {}, { navigate, projectId, hostKind });
+      dispatchAction("unfloatSession", {}, { navigate, projectId, hostKind, client, openExternal });
     },
     exportSession: handleExportSession,
     showSessionStatus: (session) => setDialog({ kind: "session-status", session }),

--- a/packages/app/src/features/browser/store.test.ts
+++ b/packages/app/src/features/browser/store.test.ts
@@ -143,7 +143,7 @@ describe("useBrowserStore", () => {
 
   it("persists state to localStorage", () => {
     useBrowserStore.getState().openFloat("project-1", "http://localhost:3000");
-    const raw = (globalThis.localStorage.getItem as ReturnType<typeof vi.fn>)("spherse:floating-browser");
+    const raw = globalThis.localStorage.getItem("spherse:floating-browser");
     expect(raw).toBeTruthy();
     expect(JSON.parse(raw!)["project-1"]["http://localhost:3000"]).toBeDefined();
   });

--- a/packages/app/src/features/chat/Composer.test.tsx
+++ b/packages/app/src/features/chat/Composer.test.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProjectProvider } from "../../context/project-context";
 import { Composer } from "./Composer";
+import type { AttachedImage } from "./types";
 
 let host: HTMLDivElement;
 let root: ReturnType<typeof createRoot> | null = null;
@@ -41,7 +42,7 @@ function renderComposer(props: { streaming?: boolean; loading?: boolean }) {
   return { onSend, onAbort };
 }
 
-function rerenderComposer(props: { streaming?: boolean; loading?: boolean }, onSend: ReturnType<typeof vi.fn>, onAbort: ReturnType<typeof vi.fn>) {
+function rerenderComposer(props: { streaming?: boolean; loading?: boolean }, onSend: (message: string, image?: AttachedImage) => boolean, onAbort: () => void) {
   act(() => {
     root!.render(
       <ProjectProvider projectId="p1" projectRoot="/tmp/p1">

--- a/packages/app/src/features/chat/model/agent-event-parse.test.ts
+++ b/packages/app/src/features/chat/model/agent-event-parse.test.ts
@@ -240,7 +240,7 @@ describe("parseAgentEvent", () => {
     const result = parseAgentEvent({
       type: "message_start",
       message: { role: "assistant", content: [] },
-    });
+    } as unknown as ChatServerEvent);
     expect(result.type).toBe("message_start");
     expect(result).toHaveProperty("message");
   });
@@ -253,7 +253,7 @@ describe("parseAgentEvent", () => {
     expect(result).toHaveProperty("message");
   });
   it("replaces invalid message payload with fallback", () => {
-    const result = parseAgentEvent({ type: "message_start", message: null });
+    const result = parseAgentEvent({ type: "message_start", message: null } as unknown as ChatServerEvent);
     expect(result.type).toBe("message_start");
     expect(result).toHaveProperty("message.role", "user");
   });
@@ -264,7 +264,7 @@ describe("parseAgentEvent", () => {
         { role: "user", content: "hi", timestamp: 1 },
         { role: "totally-bogus" },
       ],
-    });
+    } as unknown as ChatServerEvent);
     expect(result.type).toBe("agent_end");
     if (result.type === "agent_end") {
       expect(result.messages).toHaveLength(2);
@@ -289,7 +289,7 @@ describe("parseAgentEvent", () => {
         { role: "toolResult", toolCallId: "tc1", toolName: "x" },
         { role: "user", content: "junk" },
       ],
-    });
+    } as unknown as ChatServerEvent);
     if (result.type === "turn_end") {
       expect(result.toolResults).toHaveLength(1);
       expect(result.toolResults[0].toolCallId).toBe("tc1");

--- a/packages/app/src/features/chat/model/approval-notice.test.ts
+++ b/packages/app/src/features/chat/model/approval-notice.test.ts
@@ -266,7 +266,7 @@ describe("collectPendingApprovals", () => {
         messages: [
           { role: "user", content: "hello" },
           { role: "assistant", content: "no tools" },
-        ],
+        ] satisfies ChatMessage[],
       },
     };
 

--- a/packages/app/src/features/text-selection-session/StartSessionPopover.tsx
+++ b/packages/app/src/features/text-selection-session/StartSessionPopover.tsx
@@ -8,6 +8,7 @@ import { Textarea } from "../../components/ui/textarea";
 import { useDismissable } from "../../hooks/useDismissable";
 import { dispatchAction } from "../../ui-sdk";
 import { useHostBridge } from "../../context/host-bridge-context";
+import { useApiClient } from "../../lib/use-connection";
 
 interface StartSessionPopoverProps {
   selectedText: string;
@@ -65,7 +66,8 @@ export function StartSessionPopover({
   const ref = useRef<HTMLDivElement>(null);
   const { t } = useI18n();
   const navigate = useNavigate();
-  const { kind: hostKind } = useHostBridge();
+  const { kind: hostKind, openExternal } = useHostBridge();
+  const client = useApiClient(projectId);
   useDismissable({ ref, onDismiss: onClose });
 
   const previewText =
@@ -79,7 +81,7 @@ export function StartSessionPopover({
     const parts = [t("text-selection.promptPrefix", { path: sourcePath, text: quotedText })];
     if (trimmedComment) parts.push(`\n\n${trimmedComment}`);
     const message = parts.join("");
-    dispatchAction("sendMessage", { sessionId, message }, { navigate, projectId, hostKind });
+    dispatchAction("sendMessage", { sessionId, message }, { navigate, projectId, hostKind, client, openExternal });
     onClose();
   };
 

--- a/packages/app/src/features/user-file-panel/index.tsx
+++ b/packages/app/src/features/user-file-panel/index.tsx
@@ -64,7 +64,7 @@ export function UserFilePanel() {
               onFloatFile={
                 floatEnabled
                   ? (path) => {
-                      const ctx = { navigate, projectId, hostKind: bridge.kind };
+                      const ctx = { navigate, projectId, hostKind: bridge.kind, client: null, openExternal: bridge.openExternal };
                       if (floatedFilePaths.has(path)) dispatchAction("unfloatContent", { path }, ctx);
                       else dispatchAction("floatContent", { path }, ctx);
                     }

--- a/packages/app/src/stores/bus-store.test.ts
+++ b/packages/app/src/stores/bus-store.test.ts
@@ -261,7 +261,7 @@ describe("bus-store", () => {
 
     // Strictly greater: catching a regression where onopen stops updating
     // resumedAt (fake timers freeze the clock, so advance first).
-    expect(useBusStore.getState().resumedAt).toBeGreaterThan(firstResumedAt);
+    expect(useBusStore.getState().resumedAt).toBeGreaterThan(firstResumedAt!);
   });
 
   it("teardown resets resumedAt", async () => {

--- a/packages/app/src/ui-sdk/handlers/create-session.test.ts
+++ b/packages/app/src/ui-sdk/handlers/create-session.test.ts
@@ -97,7 +97,6 @@ describe("createSession action", () => {
   it("resolves agentSlug from cached agents without listing", async () => {
     mockGetState.mockReturnValue({
       projects: { "proj-1": { agents: [{ id: "id-writer", slug: "writer-a1b2c3" }] } },
-      createSession: mockCreateSession,
     });
     const client = makeClient(async () => []);
     await dispatchAction(
@@ -149,7 +148,6 @@ describe("createSession action", () => {
   it("prefers agentId when both agentId and agentSlug are provided", async () => {
     mockGetState.mockReturnValue({
       projects: { "proj-1": { agents: [{ id: "id-writer", slug: "writer-a1b2c3" }] } },
-      createSession: mockCreateSession,
     });
     const client = makeClient(async () => []);
     await dispatchAction(
@@ -164,7 +162,6 @@ describe("createSession action", () => {
   it("falls through to slug resolution when agentId is an empty string", async () => {
     mockGetState.mockReturnValue({
       projects: { "proj-1": { agents: [{ id: "id-writer", slug: "writer-a1b2c3" }] } },
-      createSession: mockCreateSession,
     });
     const client = makeClient(async () => []);
     await dispatchAction(

--- a/packages/app/src/ui-sdk/types.ts
+++ b/packages/app/src/ui-sdk/types.ts
@@ -5,11 +5,11 @@ import type { HostKind } from "../lib/host-bridge";
 export interface ActionContext {
   navigate: NavigateFunction;
   projectId: string;
-  client?: ApiClient;
+  client: ApiClient | null;
   source?: MessageEventSource | null;
   requestId?: string;
   hostKind: HostKind;
-  openExternal?: (url: string) => Promise<void>;
+  openExternal: (url: string) => Promise<void>;
 }
 
 export type ActionHandler<P = Record<string, unknown>> = (

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
     "pretest": "npm rebuild better-sqlite3",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/desktop/electron/fix-path.test.ts
+++ b/packages/desktop/electron/fix-path.test.ts
@@ -4,7 +4,7 @@ vi.mock("electron", () => ({
   app: { isPackaged: false },
 }));
 
-import { parseShellPathOutput, mergePath, fixPath } from "./fix-path";
+import { parseShellPathOutput, mergePath, fixPath } from "./fix-path.js";
 
 describe("parseShellPathOutput", () => {
   it("returns PATH entries from a clean single-line output", () => {

--- a/packages/desktop/electron/ipc/context-menu.test.ts
+++ b/packages/desktop/electron/ipc/context-menu.test.ts
@@ -36,9 +36,8 @@ describe("buildEditMenuTemplate", () => {
   it("disables items whose editFlag is false/absent", () => {
     const template = buildEditMenuTemplate("en", {});
     const labeled = template.filter(
-      (i): i is { role: string; label: string; enabled?: boolean } =>
-        "role" in i && "label" in i,
-    );
+      (i) => "role" in i && "label" in i,
+    ) as Array<{ role: string; label: string; enabled?: boolean }>;
     expect(labeled.every((i) => i.enabled === false)).toBe(true);
   });
 
@@ -49,9 +48,8 @@ describe("buildEditMenuTemplate", () => {
     });
     const find = (role: string) =>
       template.find(
-        (i): i is { role: string; label: string; enabled?: boolean } =>
-          "role" in i && (i as { role: string }).role === role,
-      );
+        (i) => "role" in i && (i as { role: string }).role === role,
+      ) as { role: string; label: string; enabled?: boolean } | undefined;
 
     expect(find("copy")?.label).toBe("复制");
     expect(find("paste")?.label).toBe("粘贴");

--- a/packages/desktop/electron/ipc/context-menu.ts
+++ b/packages/desktop/electron/ipc/context-menu.ts
@@ -37,6 +37,6 @@ export function setupContextMenu(win: BrowserWindow): void {
     if (!props.isEditable) return;
     const locale = normalizeLocale(getLocale());
     const menu = Menu.buildFromTemplate(buildEditMenuTemplate(locale, props.editFlags));
-    menu.popup(win);
+    menu.popup({ window: win });
   });
 }

--- a/packages/desktop/electron/ipc/mobile.ts
+++ b/packages/desktop/electron/ipc/mobile.ts
@@ -1,5 +1,5 @@
 import { ipcMain, type BrowserWindow } from "electron";
-import type { MobileAccessEvent, MobileAccessState, MobileTunnelMode } from "@spherse/app/src/lib/host-bridge";
+import type { MobileAccessEvent, MobileAccessState, MobileTunnelMode } from "../../../app/src/lib/host-bridge.js";
 import { getTunnelManager } from "../tunnel/manager.js";
 import {
   getMobileAccess,

--- a/packages/desktop/electron/preload.ts
+++ b/packages/desktop/electron/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from "electron";
 import type { ElectronAPI, UpdateEvent } from "./types.js";
-import type { MobileAccessEvent } from "@spherse/app/src/lib/host-bridge";
+import type { MobileAccessEvent } from "../../app/src/lib/host-bridge.js";
 
 const UPDATE_EVENT_CHANNELS = [
   "update-available",

--- a/packages/desktop/electron/settings.test.ts
+++ b/packages/desktop/electron/settings.test.ts
@@ -16,7 +16,7 @@ vi.mock("electron", () => ({
   nativeTheme: { themeSource: "system" },
 }));
 
-import { maskModelGroup, mergeModelGroup, getMaskedSettings, saveSettings, settingsStore, getMobileAccess, setMobileAccess } from "./settings";
+import { maskModelGroup, mergeModelGroup, getMaskedSettings, saveSettings, settingsStore, getMobileAccess, setMobileAccess } from "./settings.js";
 import { getAppModelCatalog } from "./model-catalog.js";
 
 describe("mergeModelGroup sampling passthrough", () => {

--- a/packages/desktop/electron/types.ts
+++ b/packages/desktop/electron/types.ts
@@ -10,7 +10,7 @@ import type {
   ThemeMode,
   UpdateEvent,
   UpdateState,
-} from "@spherse/app/src/lib/host-bridge";
+} from "../../app/src/lib/host-bridge.js";
 
 export type {
   MobileAccessEvent,

--- a/packages/desktop/electron/updater.test.ts
+++ b/packages/desktop/electron/updater.test.ts
@@ -39,7 +39,7 @@ import {
   resolveDownloadUrlFromManifest,
   updater,
   type OssUpdateManifest,
-} from "./updater";
+} from "./updater.js";
 
 const MANIFEST_URL =
   "https://mengru-open-source.oss-cn-beijing.aliyuncs.com/spherse/latest.json";

--- a/packages/desktop/electron/updater.ts
+++ b/packages/desktop/electron/updater.ts
@@ -2,6 +2,7 @@ import { app } from "electron";
 import type { BrowserWindow } from "electron";
 import electronUpdater from "electron-updater";
 const { autoUpdater, CancellationToken } = electronUpdater;
+type CancellationTokenType = electronUpdater.CancellationToken;
 import type { UpdateState, UpdateEvent } from "./types.js";
 import { getMainWindow } from "./window.js";
 
@@ -76,7 +77,7 @@ export function compareVersions(a: string, b: string): number {
 export function createUpdater(getWindow: () => BrowserWindow | null): Updater {
   let currentState: UpdateState = { status: "idle" };
   let silent = false;
-  let activeCancellationToken: CancellationToken | null = null;
+  let activeCancellationToken: CancellationTokenType | null = null;
 
   function sendEvent(event: UpdateEvent): void {
     getWindow()?.webContents.send(event.type, event);

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -8,6 +8,7 @@
     "build": "electron-vite build",
     "dev": "electron-vite dev",
     "preview": "electron-vite preview",
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.node.json",
     "pretest": "npm run build --workspace=@spherse/i18n",
     "test": "vitest run",
     "pretest:e2e": "node ../../scripts/rebuild-native.mjs",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "check": "node scripts/check-i18n.mjs",

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest run",
     "lint": "eslint ."

--- a/packages/presets/package.json
+++ b/packages/presets/package.json
@@ -10,11 +10,16 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist", "templates", "skills"],
+  "files": [
+    "dist",
+    "templates",
+    "skills"
+  ],
   "scripts": {
     "prebuild": "node scripts/sync-templates.mjs",
     "build": "tsc",
     "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "node scripts/build.mjs && tsc",
     "dev": "node scripts/build.mjs && node scripts/dev.mjs",
+    "typecheck": "tsc --noEmit",
     "pretest": "node scripts/build.mjs",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run src",
     "test:watch": "vitest src",
     "lint": "eslint .",

--- a/packages/server/src/contracts/index.ts
+++ b/packages/server/src/contracts/index.ts
@@ -51,6 +51,7 @@ export type {
   SessionInfoContract,
   SessionListResponse,
   SessionListPageResponse,
+  ProjectSessionListResponse,
   SessionCreateResponse,
   SessionRenameRequest,
   SessionMessagesResponse,
@@ -66,6 +67,8 @@ export type {
   ContentCreateRequest,
   ContentSaveRequest,
 } from "./content.js";
+
+export type { DataReadResponseContract } from "./data.js";
 
 export type { FileTreeResponse } from "./file-tree.js";
 
@@ -84,6 +87,7 @@ export type {
   TriggerEntryContract,
   TriggerInfoEntryContract,
   TriggerListResponse,
+  ProjectTriggerListResponse,
   TriggerCreateRequest,
   TriggerUpdateRequest,
   TriggerLogEntryContract,
@@ -122,4 +126,5 @@ export type {
   BusClientMessage,
   TriggerServerEvent,
   AgentUpdatedEvent,
+  FsWatchChangeEvent,
 } from "./bus.js";

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"


### PR DESCRIPTION
## 背景

renderer 侧（app/web/landing）的 vite/vitest 构建不做类型检查，desktop electron-vite 同理，类型错误一直被静默放过（对应 backlog 条目：app 包类型检查纳入 verify）。实测全仓共约 40 个去重类型错误。

## 改动

**修复类型错误（40 → 0）**
- `server/contracts/index.ts`：barrel 补导出 `ProjectSessionListResponse`、`ProjectTriggerListResponse`、`DataReadResponseContract`、`FsWatchChangeEvent`——app 侧引用失败导致 11 处错误及 queries 级联 implicit any
- `app/ui-sdk/types.ts`：`ActionContext.client` 改 `ApiClient | null`、`openExternal` 收紧为必填；agent-session-list / StartSessionPopover / user-file-panel 内 dispatch 点补全 ctx
- app 测试文件：agent-event-parse（沿用 `as unknown as ChatServerEvent` 先例）、approval-notice（`satisfies`）、Composer（精确函数签名）、create-session（删除无消费的死代码）等
- desktop electron：3 处 `@spherse/app` 深导入改相对路径（type-only import，编译期擦除，零运行时风险）；3 处 test import 补 `.js` 扩展名；`menu.popup(win)` → `popup({ window: win })`；`CancellationToken` 加 type alias；context-menu.test 类型谓词改写

**typecheck 落地**
- 9 个包各新增 `typecheck` 脚本（desktop 覆盖 renderer + electron 双 tsconfig）
- root 新增 `npm run typecheck`（workspaces 聚合），并纳入 `verify`：lint → build → typecheck → test（typecheck 依赖 Node 侧包 dist 类型产物，故置于 build 之后）
- CI `pr-build.yml` 走 `npm run verify`，PR 阶段自动拦截类型错误

**文档**
- AGENTS.md 新增 Typecheck 命令区块
- docs/official/project-structure.md 同步 pr-build 说明
- backlog 对应条目勾选

## 验证

- `npm run typecheck`：9 包 0 错误
- `npm run lint`：0 error（16 个既有 warning）
- 测试：app 1012 / desktop 114 / server 252 全过
- `npm run build:desktop`：electron-vite 打包正常