### PR TITLE
fix: session list 切换项目后偶发全部展开

### DIFF
--- a/docs/dev/bugfix/2026-08-28-agent-session-list-expanded-on-project-switch/design.md
+++ b/docs/dev/bugfix/2026-08-28-agent-session-list-expanded-on-project-switch/design.md
@@ -1,0 +1,40 @@
+# Agent Panel Session List 切换项目后偶发全部展开
+
+## 现象
+
+切换项目时，agent panel 的 session list 中所有 agent group 有概率全部变为展开状态，且无法自愈（初始折叠态不再恢复）。
+
+## 排查结论
+
+折叠状态由 zustand store `useAgentSessionListUiStore` 按项目持久化（`collapsedAgentIdsByProject[projectId]`，语义为 **collapsed 集合，空集合 = 全展开**），设计上「切换项目不重置、关闭项目才清除」。`useCollapsedAgents` 内三个 effect 协作：
+
+- 初始化：该项目无 entry 且 agents 非空时，写入 `computeInitialCollapsedAgentIds`（全部折叠、仅 active agent 展开）
+- 剪枝：从 collapsed 集合中剔除当前 agents 里不存在的 id
+- 边沿展开：activeAgentId 变化时展开其所属 agent
+
+问题出在**剪枝 effect 与 react-query 缓存生命周期不对称**：
+
+1. 用户访问过项目 B（collapsed 集合已初始化且非空）后切到项目 A，B 的 agents query 变为 inactive
+2. `queries/client.ts` 只覆盖了 `staleTime: Infinity` / `retry: 1`，未设 `gcTime`（react-query 默认 5 分钟），inactive 超过 5 分钟后 B 的 agents 缓存被 GC
+3. 切回 B 的第一帧 `agentsQuery.data === undefined` → `useProjectCatalog` 返回 `agents = EMPTY_AGENTS`
+4. 剪枝 effect 以空 `validAgentIds` 运行，把「数据未就绪」误判为「agents 全部被删除」→ `setCollapsedAgentIds(B, [])`，折叠集合被清空
+5. agents 重新加载完成后，空集合仍是合法的「已初始化」状态（`!== undefined`），初始化 effect 永不重跑 → 所有 AgentGroup（`Collapsible open={!collapsed}`）永久展开
+
+「有概率」的来源：仅在离开项目超过 gcTime（或 `useApiClient` 瞬时返回 null 导致 query disabled）的窗口内触发；5 分钟内切回时缓存仍在，agents 立即非空，剪枝无害。
+
+## 修复方案
+
+把空 agents 快照视为「目录数据未就绪」而非「agents 全部被删除」，剪枝在此时跳过：
+
+- `use-collapsed-agents-helpers.ts` 新增纯函数 `pruneCollapsedAgentIds(currentCollapsed, agents)`：agents 为空时返回 `null`（不剪枝）；否则返回剔除失效 id 后的集合，无变化时返回 `null`（filter 只删不增，size 不变即无变化）
+- `use-collapsed-agents.ts` 剪枝 effect 改用该 helper
+
+刻意不改的备选方案：
+
+- 在 `useProjectCatalog` 暴露 agents 专属 `isPending` 以精确区分「未就绪」与「真空」：能覆盖同样的窗口，但需要扩展 hook 签名与数据链路；「空快照跳过」已覆盖所有 transient empty 场景（GC、refetch 中、client 为 null），代价仅为「项目 agents 真的被删光时 collapsed 集合残留 inert id」——无 UI 影响（无 agent 可渲染），新建 agent 默认展开反而符合直觉
+- 给 `queries/client.ts` 设全局 `gcTime: Infinity`：能消除 GC 窗口，但治标不治本（client null / 其他 transient empty 路径仍会踩中），且改变全 app 的缓存语义，影响面过大
+
+## 影响面
+
+- app：`features/agent-session-list/hooks/use-collapsed-agents-helpers.ts`（新增 `pruneCollapsedAgentIds`）、`use-collapsed-agents.ts`（剪枝 effect 改造）、`use-collapsed-agents-helpers.test.ts`（含「空 agents 快照不清空 collapsed 集合」回归用例）
+- 其余 package 无变更；store 结构、初始化/边沿展开语义不变

--- a/packages/app/src/features/agent-session-list/hooks/use-collapsed-agents-helpers.test.ts
+++ b/packages/app/src/features/agent-session-list/hooks/use-collapsed-agents-helpers.test.ts
@@ -42,6 +42,10 @@ describe("pruneCollapsedAgentIds", () => {
     expect(pruneCollapsedAgentIds(new Set(["agent-1", "agent-2"]), [])).toBeNull();
   });
 
+  it("returns null when the collapsed set is empty", () => {
+    expect(pruneCollapsedAgentIds(new Set(), agents)).toBeNull();
+  });
+
   it("does not mutate the input set", () => {
     const input = new Set(["agent-1", "agent-2"]);
     pruneCollapsedAgentIds(input, [{ id: "agent-1" }]);

--- a/packages/app/src/features/agent-session-list/hooks/use-collapsed-agents-helpers.test.ts
+++ b/packages/app/src/features/agent-session-list/hooks/use-collapsed-agents-helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { computeInitialCollapsedAgentIds, expandActiveAgent } from "./use-collapsed-agents-helpers";
+import {
+  computeInitialCollapsedAgentIds,
+  expandActiveAgent,
+  pruneCollapsedAgentIds,
+} from "./use-collapsed-agents-helpers";
 
 const agents = [{ id: "agent-1" }, { id: "agent-2" }, { id: "agent-3" }];
 
@@ -20,6 +24,28 @@ describe("computeInitialCollapsedAgentIds", () => {
     expect(computeInitialCollapsedAgentIds(agents, "missing")).toEqual(
       new Set(["agent-1", "agent-2", "agent-3"]),
     );
+  });
+});
+
+describe("pruneCollapsedAgentIds", () => {
+  it("removes ids of agents no longer present", () => {
+    expect(pruneCollapsedAgentIds(new Set(["agent-1", "agent-2"]), [{ id: "agent-1" }])).toEqual(
+      new Set(["agent-1"]),
+    );
+  });
+
+  it("returns null when nothing to prune", () => {
+    expect(pruneCollapsedAgentIds(new Set(["agent-1"]), agents)).toBeNull();
+  });
+
+  it("treats an empty agents snapshot as data-not-ready and keeps the collapsed set", () => {
+    expect(pruneCollapsedAgentIds(new Set(["agent-1", "agent-2"]), [])).toBeNull();
+  });
+
+  it("does not mutate the input set", () => {
+    const input = new Set(["agent-1", "agent-2"]);
+    pruneCollapsedAgentIds(input, [{ id: "agent-1" }]);
+    expect(input).toEqual(new Set(["agent-1", "agent-2"]));
   });
 });
 

--- a/packages/app/src/features/agent-session-list/hooks/use-collapsed-agents-helpers.ts
+++ b/packages/app/src/features/agent-session-list/hooks/use-collapsed-agents-helpers.ts
@@ -5,6 +5,16 @@ export function computeInitialCollapsedAgentIds(
   return new Set(agents.filter((agent) => agent.id !== activeAgentId).map((agent) => agent.id));
 }
 
+export function pruneCollapsedAgentIds(
+  currentCollapsed: ReadonlySet<string>,
+  agents: ReadonlyArray<{ id: string }>,
+): Set<string> | null {
+  if (agents.length === 0) return null;
+  const validAgentIds = new Set(agents.map((agent) => agent.id));
+  const next = new Set([...currentCollapsed].filter((id) => validAgentIds.has(id)));
+  return next.size === currentCollapsed.size ? null : next;
+}
+
 export function expandActiveAgent(
   currentCollapsed: ReadonlySet<string>,
   activeAgentId: string | null,

--- a/packages/app/src/features/agent-session-list/hooks/use-collapsed-agents.ts
+++ b/packages/app/src/features/agent-session-list/hooks/use-collapsed-agents.ts
@@ -1,7 +1,11 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { AgentSummary } from "../../../lib/types";
 import { useAgentSessionListUiStore } from "../store";
-import { computeInitialCollapsedAgentIds, expandActiveAgent, pruneCollapsedAgentIds } from "./use-collapsed-agents-helpers";
+import {
+  computeInitialCollapsedAgentIds,
+  expandActiveAgent,
+  pruneCollapsedAgentIds,
+} from "./use-collapsed-agents-helpers";
 
 const EMPTY_COLLAPSED_AGENT_IDS = new Set<string>();
 

--- a/packages/app/src/features/agent-session-list/hooks/use-collapsed-agents.ts
+++ b/packages/app/src/features/agent-session-list/hooks/use-collapsed-agents.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { AgentSummary } from "../../../lib/types";
 import { useAgentSessionListUiStore } from "../store";
-import { computeInitialCollapsedAgentIds, expandActiveAgent } from "./use-collapsed-agents-helpers";
+import { computeInitialCollapsedAgentIds, expandActiveAgent, pruneCollapsedAgentIds } from "./use-collapsed-agents-helpers";
 
 const EMPTY_COLLAPSED_AGENT_IDS = new Set<string>();
 
@@ -23,13 +23,9 @@ export function useCollapsedAgents(projectId: string, agents: AgentSummary[], ac
 
   useEffect(() => {
     if (!collapsedInitialized) return;
-    const validAgentIds = new Set(agents.map((agent) => agent.id));
-    const nextCollapsedAgentIds = [...collapsedAgentIds!].filter((id) => validAgentIds.has(id));
-    const changed =
-      nextCollapsedAgentIds.length !== collapsedAgentIds!.size ||
-      nextCollapsedAgentIds.some((id) => !collapsedAgentIds!.has(id));
-    if (changed) {
-      setCollapsedAgentIds(projectId, nextCollapsedAgentIds);
+    const next = pruneCollapsedAgentIds(collapsedAgentIds!, agents);
+    if (next) {
+      setCollapsedAgentIds(projectId, next);
     }
   }, [collapsedInitialized, agents, collapsedAgentIds, projectId, setCollapsedAgentIds]);
 


### PR DESCRIPTION
## 根因

折叠态存于 zustand（collapsed 集合，按项目分键），agents 数据来自 react-query。切换项目不重置折叠 store，但离开超过 gcTime（默认 5 分钟，`queries/client.ts` 未覆盖）后 inactive 的 agents query 被 GC；切回时第一帧 `agents = []`，剪枝 effect 把「数据未就绪」误判为「agents 全部被删除」，清空 collapsed 集合——空集合仍是「已初始化」，初始折叠永不恢复 → 全部永久展开。

## 修复

- `pruneCollapsedAgentIds` 纯函数：agents 为空快照视为「数据未就绪」返回 null 不剪枝，只在拿到非空快照后剔除失效 id（filter 只删不增，size 不变即无变化）
- 剪枝 effect 改用该 helper；补 5 个测试用例（含「空 agents 快照不清空集合」回归）

分析文档：`docs/dev/bugfix/2026-08-28-agent-session-list-expanded-on-project-switch/design.md`

## Code Review Report

分级：critical 0 / important 0 / medium 0 / minor 2

| 级别 | 发现 | 处理 |
|---|---|---|
| minor | 缺「空 collapsed 集合 + 非空 agents」边界用例 | 已修（9b92c37） |
| minor | `use-collapsed-agents.ts` import 行超长，风格不一致 | 已修（9b92c37） |

未修说明：
- 「未验证疑点：新建 agent 复用已删 agent id 会继承残留折叠态」— 后果仅单个 group 初始折叠且可手动展开，属理论性问题，不修
- 备选方案（暴露 `isPending`、全局 `gcTime: Infinity`）不采用的理由见 design doc「修复方案」节

## 验证

- `npm test --workspace=packages/app`：115 files / 1016 tests 全过
- `npm run lint --workspace=packages/app`：0 errors（15 warnings 为基线已有）
- `npm run typecheck --workspace=packages/app`：通过

## Doc-sync

| 项 | 结果 |
|---|---|
| project-structure.md | 无影响（未新增/移动结构性文件，bugfix 目录已有类别记录） |
| architecture / ADR | 无影响（renderer 局部 UI 状态修复，无边界/契约变更） |
| data-conventions / glossary | 无影响（内存 store，无持久化格式变更） |
| app README | 无影响（无新包级规范） |
| i18n / theme / presets | 无影响（无 UI 文案与样式变更） |
| backlog | 无此 bug 条目，无需删除 |
| bugfix 分析文档 | 已落盘 `docs/dev/bugfix/2026-08-28-agent-session-list-expanded-on-project-switch/design.md` |