### PR TITLE
chore: project queries 重构——按需订阅拆分与按域拆文件

### DIFF
--- a/packages/app/src/features/agent-mcp/McpDialog.tsx
+++ b/packages/app/src/features/agent-mcp/McpDialog.tsx
@@ -31,7 +31,7 @@ import {
   type McpServerDraft,
 } from "./mcp-form-helpers";
 import { McpServerForm } from "./McpServerForm";
-import { useProjectCatalog } from "../../queries/project";
+import { useProjectAgents } from "../../queries/project";
 
 interface McpDialogProps {
   open: boolean;
@@ -43,7 +43,7 @@ interface McpDialogProps {
 export function McpDialog({ open, onOpenChange, agentId, projectId }: McpDialogProps) {
   const { t } = useI18n();
   const client = useApiClient(projectId);
-  const { agents } = useProjectCatalog(projectId, client);
+  const { agents } = useProjectAgents(projectId, client);
   const agentName = agents.find((agent) => agent.id === agentId)?.name ?? "";
   const [servers, setServers] = useState<McpServerConfig[]>([]);
   const [loading, setLoading] = useState(false);

--- a/packages/app/src/features/agent-trigger/index.tsx
+++ b/packages/app/src/features/agent-trigger/index.tsx
@@ -36,7 +36,7 @@ import { EMPTY_RUNNING_TRIGGER_IDS } from "./constants";
 import { useI18n } from "@spherse/i18n/react";
 import { InfoIcon, PlusIcon } from "lucide-react";
 import { Button } from "../../components/ui/button";
-import { useProjectCatalog } from "../../queries/project";
+import { useProjectAgents } from "../../queries/project";
 
 interface TriggerDialogProps {
   open: boolean;
@@ -48,7 +48,7 @@ interface TriggerDialogProps {
 export function TriggerDialog({ open, onOpenChange, agentId, projectId }: TriggerDialogProps) {
   const { t } = useI18n();
   const client = useApiClient(projectId);
-  const { agents } = useProjectCatalog(projectId, client);
+  const { agents } = useProjectAgents(projectId, client);
   const { triggers, isPending } = useAgentTriggers(projectId, client, agentId);
   const runningTriggerIds = useTriggerStore(
     (s) => s.byProject[projectId]?.runningTriggerIdsByAgent?.[agentId] ?? EMPTY_RUNNING_TRIGGER_IDS,

--- a/packages/app/src/pages/ChatPage.tsx
+++ b/packages/app/src/pages/ChatPage.tsx
@@ -5,7 +5,7 @@ import { Chat } from "../features/chat";
 import { useProjectDataStore } from "../stores/project-data-store";
 import { useProjectCtx } from "../context/project-context";
 import { useApiClient } from "../lib/use-connection";
-import { useProjectCatalog, useProjectSession } from "../queries/project";
+import { useProjectAgents, useProjectSession } from "../queries/project";
 
 export function ChatPage() {
   const { sessionId = "" } = useParams();
@@ -13,7 +13,7 @@ export function ChatPage() {
   const navigate = useNavigate();
   const { t } = useI18n();
   const client = useApiClient(projectId);
-  const { agents } = useProjectCatalog(projectId, client);
+  const { agents } = useProjectAgents(projectId, client);
   const sessionQuery = useProjectSession(projectId, client, sessionId);
   const projectData = useProjectDataStore((s) => s.projects[projectId]);
   const consumeInitialMessage = useProjectDataStore((s) => s.consumeInitialMessage);

--- a/packages/app/src/queries/project.test.ts
+++ b/packages/app/src/queries/project.test.ts
@@ -118,6 +118,24 @@ describe("project queries", () => {
     expect(client.listSessionsPage).toHaveBeenCalledWith("agent-1", { limit: 10, offset: 1 });
   });
 
+  it("resets loadingMore and keeps paging intact when loading another page fails", async () => {
+    queryClient.setQueryData(projectQueryKeys.sessions("project-1"), {
+      sessions: [session("session-1")],
+      paging: { "agent-1": { hasMore: true, offset: 1, loadingMore: false } },
+    });
+    const client = {
+      listSessionsPage: vi.fn().mockRejectedValue(new Error("network down")),
+    } as unknown as ApiClient;
+
+    await loadMoreProjectSessions("project-1", client, "agent-1");
+
+    expect(
+      queryClient.getQueryData<{ paging: Record<string, { hasMore: boolean; offset: number; loadingMore: boolean }> }>(
+        projectQueryKeys.sessions("project-1"),
+      )?.paging["agent-1"],
+    ).toEqual({ hasMore: true, offset: 1, loadingMore: false });
+  });
+
   it("deletes a provided session without relying on a paginated lookup", async () => {
     const target = session("session-20");
     const client = { deleteSession: vi.fn().mockResolvedValue({ ok: true }) } as unknown as ApiClient;

--- a/packages/app/src/queries/project.ts
+++ b/packages/app/src/queries/project.ts
@@ -54,24 +54,41 @@ export async function fetchProjectSessionCatalog(
   };
 }
 
-export function useProjectCatalog(projectId: string, client: ApiClient | null) {
+export function useProjectAgents(projectId: string, client: ApiClient | null) {
   const agentsQuery = useQuery({
     queryKey: projectQueryKeys.agents(projectId),
     queryFn: () => client!.listAgents(),
     enabled: Boolean(projectId && client),
   });
-  const agents = agentsQuery.data ?? EMPTY_AGENTS;
+  return {
+    agents: agentsQuery.data ?? EMPTY_AGENTS,
+    loading: agentsQuery.isPending,
+    error: agentsQuery.error,
+  };
+}
+
+export function useProjectSessions(projectId: string, client: ApiClient | null) {
   const sessionsQuery = useQuery({
     queryKey: projectQueryKeys.sessions(projectId),
     queryFn: () => fetchProjectSessionCatalog(projectId, client!),
     enabled: Boolean(projectId && client),
   });
-
   return {
-    agents,
     sessions: sessionsQuery.data?.sessions ?? EMPTY_SESSIONS,
     sessionPaging: sessionsQuery.data?.paging ?? EMPTY_SESSION_PAGING,
-    loading: agentsQuery.isPending || sessionsQuery.isPending,
+    loading: sessionsQuery.isPending,
+    error: sessionsQuery.error,
+  };
+}
+
+export function useProjectCatalog(projectId: string, client: ApiClient | null) {
+  const agentsQuery = useProjectAgents(projectId, client);
+  const sessionsQuery = useProjectSessions(projectId, client);
+  return {
+    agents: agentsQuery.agents,
+    sessions: sessionsQuery.sessions,
+    sessionPaging: sessionsQuery.sessionPaging,
+    loading: agentsQuery.loading || sessionsQuery.loading,
     error: agentsQuery.error ?? sessionsQuery.error,
   };
 }

--- a/packages/app/src/queries/project/agents.ts
+++ b/packages/app/src/queries/project/agents.ts
@@ -1,0 +1,69 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ApiClient } from "../../lib/api";
+import { queryClient } from "../client";
+import { projectQueryKeys } from "../keys";
+import type { AgentSummary } from "../../lib/types";
+import { refreshProjectSessions } from "./sessions";
+
+const EMPTY_AGENTS: AgentSummary[] = [];
+
+export function useProjectAgents(projectId: string, client: ApiClient | null) {
+  const agentsQuery = useQuery({
+    queryKey: projectQueryKeys.agents(projectId),
+    queryFn: () => client!.listAgents(),
+    enabled: Boolean(projectId && client),
+  });
+  return {
+    agents: agentsQuery.data ?? EMPTY_AGENTS,
+    loading: agentsQuery.isPending,
+    error: agentsQuery.error,
+  };
+}
+
+export function getCachedAgents(projectId: string): AgentSummary[] {
+  return queryClient.getQueryData(projectQueryKeys.agents(projectId)) ?? EMPTY_AGENTS;
+}
+
+export async function ensureProjectAgents(projectId: string, client: ApiClient): Promise<AgentSummary[]> {
+  return queryClient.ensureQueryData({
+    queryKey: projectQueryKeys.agents(projectId),
+    queryFn: () => client.listAgents(),
+  });
+}
+
+export async function refreshProjectAgents(projectId: string): Promise<void> {
+  await queryClient.invalidateQueries({ queryKey: projectQueryKeys.agents(projectId) });
+}
+
+export async function createProjectAgent(
+  projectId: string,
+  client: ApiClient,
+  slug: string,
+  content: string,
+  themeContent?: string,
+): Promise<void> {
+  await client.createAgent(slug, content, themeContent);
+  await refreshProjectAgents(projectId);
+  await refreshProjectSessions(projectId);
+}
+
+export async function updateProjectAgent(
+  projectId: string,
+  client: ApiClient,
+  agentId: string,
+  content: string,
+  themeContent?: string,
+): Promise<void> {
+  await client.updateAgent(agentId, content, themeContent);
+  await refreshProjectAgents(projectId);
+}
+
+export async function deleteProjectAgent(
+  projectId: string,
+  client: ApiClient,
+  agentId: string,
+): Promise<void> {
+  await client.deleteAgent(agentId);
+  await refreshProjectAgents(projectId);
+  await refreshProjectSessions(projectId);
+}

--- a/packages/app/src/queries/project/index.ts
+++ b/packages/app/src/queries/project/index.ts
@@ -1,0 +1,38 @@
+import type { ApiClient } from "../../lib/api";
+import { useProjectAgents } from "./agents";
+import { useProjectSessions } from "./sessions";
+
+export { clearProjectQueries } from "./lifecycle";
+export {
+  createProjectAgent,
+  deleteProjectAgent,
+  ensureProjectAgents,
+  getCachedAgents,
+  refreshProjectAgents,
+  updateProjectAgent,
+  useProjectAgents,
+} from "./agents";
+export {
+  createProjectSession,
+  deleteProjectSession,
+  ensureProjectSession,
+  fetchProjectSessionCatalog,
+  getCachedSession,
+  loadMoreProjectSessions,
+  refreshProjectSessions,
+  renameProjectSession,
+  useProjectSession,
+  useProjectSessions,
+} from "./sessions";
+
+export function useProjectCatalog(projectId: string, client: ApiClient | null) {
+  const agentsQuery = useProjectAgents(projectId, client);
+  const sessionsQuery = useProjectSessions(projectId, client);
+  return {
+    agents: agentsQuery.agents,
+    sessions: sessionsQuery.sessions,
+    sessionPaging: sessionsQuery.sessionPaging,
+    loading: agentsQuery.loading || sessionsQuery.loading,
+    error: agentsQuery.error ?? sessionsQuery.error,
+  };
+}

--- a/packages/app/src/queries/project/index.ts
+++ b/packages/app/src/queries/project/index.ts
@@ -22,7 +22,6 @@ export {
   refreshProjectSessions,
   renameProjectSession,
   useProjectSession,
-  useProjectSessions,
 } from "./sessions";
 
 export function useProjectCatalog(projectId: string, client: ApiClient | null) {

--- a/packages/app/src/queries/project/lifecycle.ts
+++ b/packages/app/src/queries/project/lifecycle.ts
@@ -1,0 +1,18 @@
+import { queryClient } from "../client";
+import { projectQueryKeys } from "../keys";
+
+const projectGenerations = new Map<string, number>();
+
+export function getProjectGeneration(projectId: string): number {
+  return projectGenerations.get(projectId) ?? 0;
+}
+
+export function isCurrentProjectGeneration(projectId: string, generation: number): boolean {
+  return getProjectGeneration(projectId) === generation;
+}
+
+export function clearProjectQueries(projectId: string): void {
+  projectGenerations.set(projectId, getProjectGeneration(projectId) + 1);
+  void queryClient.cancelQueries({ queryKey: projectQueryKeys.all(projectId) });
+  queryClient.removeQueries({ queryKey: projectQueryKeys.all(projectId) });
+}

--- a/packages/app/src/queries/project/sessions.ts
+++ b/packages/app/src/queries/project/sessions.ts
@@ -1,34 +1,84 @@
 import { useQuery } from "@tanstack/react-query";
-import { ApiError, type ApiClient } from "../lib/api";
-import { queryClient } from "./client";
-import { projectQueryKeys } from "./keys";
-import type { AgentSummary, SessionInfo } from "../lib/types";
-import { useProjectDataStore } from "../stores/project-data-store";
+import { ApiError, type ApiClient } from "../../lib/api";
+import { queryClient } from "../client";
+import { projectQueryKeys } from "../keys";
+import type { SessionInfo } from "../../lib/types";
+import type { SessionListPageResponse } from "@spherse/server/contracts";
+import { useProjectDataStore } from "../../stores/project-data-store";
+import { ensureProjectAgents } from "./agents";
+import { getProjectGeneration, isCurrentProjectGeneration } from "./lifecycle";
 
 const SESSION_PAGE_SIZE = 10;
-const EMPTY_AGENTS: AgentSummary[] = [];
 const EMPTY_SESSIONS: SessionInfo[] = [];
 const EMPTY_SESSION_PAGING: Record<string, SessionPaging> = {};
 
-interface SessionPaging {
+export interface SessionPaging {
   hasMore: boolean;
   offset: number;
   loadingMore: boolean;
 }
 
-interface SessionCatalog {
+export interface SessionCatalog {
   sessions: SessionInfo[];
   paging: Record<string, SessionPaging>;
 }
 
-const projectGenerations = new Map<string, number>();
+type SessionPage = Pick<SessionListPageResponse, "items" | "hasMore">;
 
-function getProjectGeneration(projectId: string): number {
-  return projectGenerations.get(projectId) ?? 0;
+function toPaging(byAgent: Record<string, { hasMore: boolean; loaded: number }>): Record<string, SessionPaging> {
+  return Object.fromEntries(
+    Object.entries(byAgent).map(([agentId, cursor]) => [
+      agentId,
+      { hasMore: cursor.hasMore, offset: cursor.loaded, loadingMore: false },
+    ]),
+  );
 }
 
-function isCurrentProjectGeneration(projectId: string, generation: number): boolean {
-  return getProjectGeneration(projectId) === generation;
+function upsertSessionStart(catalog: SessionCatalog | undefined, session: SessionInfo): SessionCatalog {
+  return {
+    sessions: [session, ...(catalog?.sessions ?? []).filter((item) => item.id !== session.id)],
+    paging: catalog?.paging ?? {},
+  };
+}
+
+function replaceSession(catalog: SessionCatalog, sessionId: string, updated: SessionInfo): SessionCatalog {
+  return {
+    ...catalog,
+    sessions: catalog.sessions.map((item) => (item.id === sessionId ? updated : item)),
+  };
+}
+
+function removeSession(catalog: SessionCatalog, session: SessionInfo): SessionCatalog {
+  const paging = catalog.paging[session.agentId];
+  return {
+    ...catalog,
+    sessions: catalog.sessions.filter((item) => item.id !== session.id),
+    paging: paging
+      ? { ...catalog.paging, [session.agentId]: { ...paging, offset: Math.max(0, paging.offset - 1) } }
+      : catalog.paging,
+  };
+}
+
+function setPagingLoadingMore(catalog: SessionCatalog, agentId: string, loadingMore: boolean): SessionCatalog {
+  const paging = catalog.paging[agentId];
+  if (!paging) return catalog;
+  return { ...catalog, paging: { ...catalog.paging, [agentId]: { ...paging, loadingMore } } };
+}
+
+function appendSessionPage(
+  catalog: SessionCatalog,
+  agentId: string,
+  page: SessionPage,
+  previousOffset: number,
+): SessionCatalog {
+  const existingIds = new Set(catalog.sessions.map((session) => session.id));
+  return {
+    sessions: [...catalog.sessions, ...page.items.filter((session) => !existingIds.has(session.id))],
+    paging: {
+      ...catalog.paging,
+      [agentId]: { hasMore: page.hasMore, offset: previousOffset + page.items.length, loadingMore: false },
+    },
+  };
 }
 
 export async function fetchProjectSessionCatalog(
@@ -42,28 +92,9 @@ export async function fetchProjectSessionCatalog(
   const optimistic = cached?.sessions.filter(
     (session) => initialMessages[session.id] && !fetchedIds.has(session.id),
   ) ?? [];
-  const paging: Record<string, SessionPaging> = Object.fromEntries(
-    Object.entries(result.byAgent).map(([agentId, cursor]) => [
-      agentId,
-      { hasMore: cursor.hasMore, offset: cursor.loaded, loadingMore: false },
-    ]),
-  );
   return {
     sessions: [...optimistic, ...result.sessions],
-    paging,
-  };
-}
-
-export function useProjectAgents(projectId: string, client: ApiClient | null) {
-  const agentsQuery = useQuery({
-    queryKey: projectQueryKeys.agents(projectId),
-    queryFn: () => client!.listAgents(),
-    enabled: Boolean(projectId && client),
-  });
-  return {
-    agents: agentsQuery.data ?? EMPTY_AGENTS,
-    loading: agentsQuery.isPending,
-    error: agentsQuery.error,
+    paging: toPaging(result.byAgent),
   };
 }
 
@@ -78,18 +109,6 @@ export function useProjectSessions(projectId: string, client: ApiClient | null) 
     sessionPaging: sessionsQuery.data?.paging ?? EMPTY_SESSION_PAGING,
     loading: sessionsQuery.isPending,
     error: sessionsQuery.error,
-  };
-}
-
-export function useProjectCatalog(projectId: string, client: ApiClient | null) {
-  const agentsQuery = useProjectAgents(projectId, client);
-  const sessionsQuery = useProjectSessions(projectId, client);
-  return {
-    agents: agentsQuery.agents,
-    sessions: sessionsQuery.sessions,
-    sessionPaging: sessionsQuery.sessionPaging,
-    loading: agentsQuery.loading || sessionsQuery.loading,
-    error: agentsQuery.error ?? sessionsQuery.error,
   };
 }
 
@@ -144,10 +163,6 @@ export async function ensureProjectSession(
   });
 }
 
-export function getCachedAgents(projectId: string): AgentSummary[] {
-  return queryClient.getQueryData(projectQueryKeys.agents(projectId)) ?? EMPTY_AGENTS;
-}
-
 function getCachedSessions(projectId: string): SessionInfo[] {
   return queryClient.getQueryData<SessionCatalog>(projectQueryKeys.sessions(projectId))?.sessions ?? EMPTY_SESSIONS;
 }
@@ -155,17 +170,6 @@ function getCachedSessions(projectId: string): SessionInfo[] {
 export function getCachedSession(projectId: string, sessionId: string): SessionInfo | undefined {
   return queryClient.getQueryData<SessionInfo>(projectQueryKeys.session(projectId, sessionId))
     ?? getCachedSessions(projectId).find((session) => session.id === sessionId);
-}
-
-export async function ensureProjectAgents(projectId: string, client: ApiClient): Promise<AgentSummary[]> {
-  return queryClient.ensureQueryData({
-    queryKey: projectQueryKeys.agents(projectId),
-    queryFn: () => client.listAgents(),
-  });
-}
-
-export async function refreshProjectAgents(projectId: string): Promise<void> {
-  await queryClient.invalidateQueries({ queryKey: projectQueryKeys.agents(projectId) });
 }
 
 export async function refreshProjectSessions(projectId: string): Promise<void> {
@@ -186,43 +190,20 @@ export async function loadMoreProjectSessions(
   const paging = current?.paging[agentId];
   if (!current || !paging?.hasMore || paging.loadingMore) return;
 
-  queryClient.setQueryData<SessionCatalog>(key, {
-    ...current,
-    paging: { ...current.paging, [agentId]: { ...paging, loadingMore: true } },
-  });
+  queryClient.setQueryData<SessionCatalog>(key, (catalog) =>
+    catalog ? setPagingLoadingMore(catalog, agentId, true) : catalog);
   try {
     const page = await client.listSessionsPage(agentId, {
       limit: SESSION_PAGE_SIZE,
       offset: paging.offset,
     });
     if (!isCurrentProjectGeneration(projectId, generation)) return;
-    queryClient.setQueryData<SessionCatalog>(key, (catalog) => {
-      if (!catalog) return catalog;
-      const existingIds = new Set(catalog.sessions.map((session) => session.id));
-      return {
-        sessions: [
-          ...catalog.sessions,
-          ...page.items.filter((session) => !existingIds.has(session.id)),
-        ],
-        paging: {
-          ...catalog.paging,
-          [agentId]: {
-            hasMore: page.hasMore,
-            offset: paging.offset + page.items.length,
-            loadingMore: false,
-          },
-        },
-      };
-    });
+    queryClient.setQueryData<SessionCatalog>(key, (catalog) =>
+      catalog ? appendSessionPage(catalog, agentId, page, paging.offset) : catalog);
   } catch {
     if (!isCurrentProjectGeneration(projectId, generation)) return;
-    queryClient.setQueryData<SessionCatalog>(key, (catalog) => catalog ? {
-      ...catalog,
-      paging: {
-        ...catalog.paging,
-        [agentId]: { ...catalog.paging[agentId], loadingMore: false },
-      },
-    } : catalog);
+    queryClient.setQueryData<SessionCatalog>(key, (catalog) =>
+      catalog ? setPagingLoadingMore(catalog, agentId, false) : catalog);
   }
 }
 
@@ -245,10 +226,8 @@ export async function createProjectSession(
     status: "active",
   };
   if (!isCurrentProjectGeneration(projectId, generation)) return session;
-  queryClient.setQueryData<SessionCatalog>(projectQueryKeys.sessions(projectId), (catalog) => ({
-    sessions: [session, ...(catalog?.sessions ?? []).filter((item) => item.id !== session.id)],
-    paging: catalog?.paging ?? {},
-  }));
+  queryClient.setQueryData<SessionCatalog>(projectQueryKeys.sessions(projectId), (catalog) =>
+    upsertSessionStart(catalog, session));
   queryClient.setQueryData(projectQueryKeys.session(projectId, session.id), session);
   if (initialMessage) {
     useProjectDataStore.getState().setInitialMessage(projectId, session.id, initialMessage);
@@ -265,10 +244,8 @@ export async function renameProjectSession(
   const generation = getProjectGeneration(projectId);
   const updated = await client.renameSession(session.agentId, session.id, title);
   if (!isCurrentProjectGeneration(projectId, generation)) return updated;
-  queryClient.setQueryData<SessionCatalog>(projectQueryKeys.sessions(projectId), (catalog) => catalog ? {
-    ...catalog,
-    sessions: catalog.sessions.map((item) => item.id === session.id ? updated : item),
-  } : catalog);
+  queryClient.setQueryData<SessionCatalog>(projectQueryKeys.sessions(projectId), (catalog) =>
+    catalog ? replaceSession(catalog, session.id, updated) : catalog);
   queryClient.setQueryData(projectQueryKeys.session(projectId, session.id), updated);
   return updated;
 }
@@ -281,58 +258,8 @@ export async function deleteProjectSession(
   const generation = getProjectGeneration(projectId);
   await client.deleteSession(session.agentId, session.id);
   if (!isCurrentProjectGeneration(projectId, generation)) return;
-  queryClient.setQueryData<SessionCatalog>(projectQueryKeys.sessions(projectId), (catalog) => catalog ? {
-    ...catalog,
-    sessions: catalog.sessions.filter((item) => item.id !== session.id),
-    paging: {
-      ...catalog.paging,
-      [session.agentId]: catalog.paging[session.agentId]
-        ? {
-            ...catalog.paging[session.agentId],
-            offset: Math.max(0, catalog.paging[session.agentId].offset - 1),
-          }
-        : catalog.paging[session.agentId],
-    },
-  } : catalog);
+  queryClient.setQueryData<SessionCatalog>(projectQueryKeys.sessions(projectId), (catalog) =>
+    catalog ? removeSession(catalog, session) : catalog);
   queryClient.removeQueries({ queryKey: projectQueryKeys.session(projectId, session.id) });
   useProjectDataStore.getState().clearInitialMessage(projectId, session.id);
-}
-
-export async function createProjectAgent(
-  projectId: string,
-  client: ApiClient,
-  slug: string,
-  content: string,
-  themeContent?: string,
-): Promise<void> {
-  await client.createAgent(slug, content, themeContent);
-  await refreshProjectAgents(projectId);
-  await refreshProjectSessions(projectId);
-}
-
-export async function updateProjectAgent(
-  projectId: string,
-  client: ApiClient,
-  agentId: string,
-  content: string,
-  themeContent?: string,
-): Promise<void> {
-  await client.updateAgent(agentId, content, themeContent);
-  await refreshProjectAgents(projectId);
-}
-
-export async function deleteProjectAgent(
-  projectId: string,
-  client: ApiClient,
-  agentId: string,
-): Promise<void> {
-  await client.deleteAgent(agentId);
-  await refreshProjectAgents(projectId);
-  await refreshProjectSessions(projectId);
-}
-
-export function clearProjectQueries(projectId: string): void {
-  projectGenerations.set(projectId, getProjectGeneration(projectId) + 1);
-  void queryClient.cancelQueries({ queryKey: projectQueryKeys.all(projectId) });
-  queryClient.removeQueries({ queryKey: projectQueryKeys.all(projectId) });
 }

--- a/packages/app/src/queries/project/sessions.ts
+++ b/packages/app/src/queries/project/sessions.ts
@@ -12,13 +12,13 @@ const SESSION_PAGE_SIZE = 10;
 const EMPTY_SESSIONS: SessionInfo[] = [];
 const EMPTY_SESSION_PAGING: Record<string, SessionPaging> = {};
 
-export interface SessionPaging {
+interface SessionPaging {
   hasMore: boolean;
   offset: number;
   loadingMore: boolean;
 }
 
-export interface SessionCatalog {
+interface SessionCatalog {
   sessions: SessionInfo[];
   paging: Record<string, SessionPaging>;
 }


### PR DESCRIPTION
## 背景

回应 code review report 的两个问题：

1. **`useProjectCatalog()` 订阅过宽**：固定同时订阅 agents + sessions 两个 query，但 `McpDialog`、`TriggerDialog`、`ChatPage` 只消费 agents——session catalog 每次变更（create/rename/delete/loadMore/agent bus invalidate）都会触发这些组件无谓重渲染，且 `ChatPage` 同时还通过 `useProjectSession` 查单条详情，依赖关系失真。
2. **`queries/project.ts` 职责过宽**：约 320 行混合 agent query、session catalog、session detail、分页算法、mutations、手动 cache 同步、项目关闭 generation 守卫、React hook 与 ui-sdk 命令式 facade——变化原因过多，且 `SessionCatalog` 形状在 5 处手写 patch，cache policy 没有单一实现位置。

## 改动

### Commit 1：拆分 hook
- 新增 `useProjectAgents()` / `useProjectSessions()`，`useProjectCatalog` 保留为两者的组合（loading/error 语义与原先一致）
- `McpDialog` / `TriggerDialog` / `ChatPage` 改为 `useProjectAgents`；`agent-session-list` / `ContentBrowserPage` / `FloatingChatManager` 保持聚合订阅

### Commit 2：按域拆文件 + transition 收敛
- `queries/project.ts` → `queries/project/{agents,sessions,lifecycle,index}.ts`，14 处外部导入路径不变（目录 index）
- SessionCatalog 的 5 处 cache 写入收敛为纯 transition 函数：`upsertSessionStart` / `replaceSession` / `removeSession` / `setPagingLoadingMore` / `appendSessionPage`——session cache policy 只有 sessions.ts 一个实现位置
- generation 守卫（项目关闭竞态保护）独立为 lifecycle.ts

### Commit 3：review 反馈
- 移除无外部消费方的 `useProjectSessions` re-export 与 `SessionPaging`/`SessionCatalog` 类型 export（导出面最小化）
- 补 loadMore 失败路径 `loadingMore` 复位测试（顺带锁住比原实现更安全的 no-op 语义）

## 验证

- `npm run lint --workspace=packages/app`：0 error（仅存量 warning）
- `npm run typecheck --workspace=packages/app`：通过
- `npm test --workspace=packages/app`：117 文件 / 1041 测试全过（含 project.test.ts 13 个）

## 文档同步

- `docs/official/project-structure.md` 对 `queries/` 只到目录粒度，无需更新；frontend.md / app README 均无该文件级引用
- 无数据格式、契约、用户文案变更