### PR TITLE
feat: 文件树改为目录 Query + expandedPaths（followup P1）

### DIFF
--- a/docs/dev/infra/2026-08-22-frontend-architecture-followup/followup.md
+++ b/docs/dev/infra/2026-08-22-frontend-architecture-followup/followup.md
@@ -31,7 +31,7 @@ PR #24 已完成第一阶段状态边界收敛：
 | P0 | 拆分 `useProjectCatalog` | 减少无关 session observer、请求和重渲染 | 下次修改 agent/session 查询 |
 | P0 | 统一 session detail cache | 消除列表/详情双份实体同步 | 下次修改深链或 UI SDK session lookup |
 | P1 | 拆分 `queries/project.ts` | 降低查询、mutation、生命周期混杂复杂度 | 文件超过可维护阈值或新增第三个 project query 域 |
-| P1 | 文件树改为目录 Query + expandedPaths | 删除递归服务端快照和复杂 merge | 下次大改文件树或 fs-watch |
+| P1 | 文件树改为目录 Query + expandedPaths（已实施，见 `2026-08-28-file-tree-directory-queries/design.md`） | 删除递归服务端快照和复杂 merge | 下次大改文件树或 fs-watch |
 | P1 | 移除 streaming/trigger 镜像 | 消除跨 store 手工同步 | 下次修改 SessionRow/AgentRow 状态来源 |
 | P1 | 标准化 React mutation hooks | 统一 pending/error/乐观更新 | 出现第二个需要 mutation 状态的消费方 |
 | P2 | 迁移 dialog 服务端状态 | 删除 load-on-open effect 模板 | 逐个 dialog 功能修改时顺带迁移 |

--- a/docs/dev/infra/2026-08-28-file-tree-directory-queries/design.md
+++ b/docs/dev/infra/2026-08-28-file-tree-directory-queries/design.md
@@ -1,0 +1,118 @@
+# [Infra] 文件树改为目录 Query + expandedPaths
+
+## 背景
+
+对应 `docs/dev/infra/2026-08-22-frontend-architecture-followup/followup.md` 的 P1 条目「文件树改为目录 Query + expandedPaths」。
+
+当前 `useFileTreeController` 在 TanStack Query 缓存（`directory(projectId, dirPath)`）之外又维护一棵包含服务端 children 的递归本地树（`TreeNode { expanded, loaded, children }`）。每次 invalidation 后通过 `refreshExpanded` 递归序贯重取所有已展开目录，再用 `mergeExpandedState` / `mergeRefreshedTree` 合并服务端数据与展开状态。问题：
+
+- 服务端 children 双份存储；子目录级 query 缓存"只写不读"
+- 刷新成本随展开目录数线性增长（`for...of + await` 串行请求），且 `refreshTree` 与被订阅根 query 的自动 refetch 造成双份遍历
+- `invalidateProjectFileQueries` 对任何单文件变更都无条件失效全部 directory keys，fs-watch / agent 写文件期间每个 300ms 批次触发全量串行重取
+- 双份状态带来展开/折叠竞态，两个 merge helper 即为补偿
+
+## 目标
+
+- 本地 state 只保存交互状态：`expandedPaths: Set<string>`、`creating`、`deleteTarget`；不再保存服务端 children 快照
+- 每个目录节点组件自持 `useProjectDirectory`（`enabled: expanded`），Query 负责请求、缓存、去重和竞态
+- 删除 `mergeExpandedState` / `mergeRefreshedTree` / `updateNode` / 递归 `refreshExpanded`
+- invalidation 按父目录 + 后代路径精准失效，fs-watch 单文件变更只重取受影响的已订阅目录
+
+## 非目标
+
+- 不改 server API（`GET /content/:path` 不变）
+- 不改 `FileTreeProps` 对外契约（`user-file-panel` / `skill-panel` 调用面零变化）
+- 不引入虚拟滚动 / 树扁平化渲染
+
+## 方案
+
+### 数据模型（tree-model.ts）
+
+```ts
+export interface TreeItem {
+  name: string;
+  path: string;      // 项目相对全路径
+  type: "file" | "directory";
+}
+export interface DeleteTarget {
+  name: string;
+  path: string;
+  type: "file" | "directory";
+}
+```
+
+`buildTreeItems(entries, parentPath)` 保留现有过滤（dotfiles）与排序（目录优先 + localeCompare），输出纯数据，不含 expanded/loaded/children。新增 `parentDirPath(path)`。保留导出 `INVALID_NAME_RE` / `CreateAction` / `CreatingState`（InlineNameInput、context 依赖）。删除 `TreeNode` / `buildNodes` / `updateNode` / `mergeExpandedState` / `mergeRefreshedTree`。
+
+### Query 层（queries/content.ts）
+
+- `useProjectDirectory(projectId, client, dirPath, options?: { enabled?: boolean })`：透传 `enabled`，目录未展开时不发起请求（disabled query 仍注册 observer，但不计入 active，invalidation 不会触发重取）
+- 新增 `directoryKeyMatchesChangedPath(queryKey, projectId, changedPath)` predicate，三种匹配均基于归一化（反斜杠 → 正斜杠）后的 `changedPath`（归一化在 `invalidateProjectFileQueries` 入口统一完成，content predicate 复用同一份归一化结果）：
+  - `dirPath === changedPath`（变更对象本身是目录）
+  - `dirPath` 以 `changedPath + "/"` 开头（后代目录，删除目录场景）
+  - `dirPath === parentDir(changedPath)`（直接父目录，listing 变化）
+- `invalidateProjectFileQueries(projectId, changedPath)` 将「全量失效 directories」改为上述 predicate；content keys 与 fileTree index 失效行为不变；无 `changedPath` 时仍全量失效（重连场景）
+
+### Controller（useFileTreeController.ts）
+
+不再持有 `rootNodes`，只管理：
+
+```ts
+expandedPaths: ReadonlySet<string>   // toggleDir / 展开清理
+creating: CreatingState | null
+deleteTarget: DeleteTarget | null
+```
+
+- `toggleDir(path)`：Set 增删
+- `requestCreate(item, action)`：目录 → 以目录为 parent 并展开；文件 → 以 `parentDirPath` 为 parent
+- `submitCreate`：mkdir / touchFile 成功后 `invalidateProjectFileQueries(projectId, targetPath)`（精准失效父目录）；失败仅 toast，保留 `creating`（输入框不消失，与现状一致）
+- `confirmDelete`：删除成功后失效变更路径；同时清理 `expandedPaths` 中被删路径及其后代（避免本地删除后重建同名目录时幽灵展开态）
+- 根 query（loading / 空态）上移到 `FileTree` 组件
+
+### 组件层
+
+- `FileTree`（index.tsx）：自持根 `useProjectDirectory(projectId, client, basePath)`，渲染根级 rows + 根级 InlineNameInput + DeleteConfirmDialog
+- `FileTreeNode.tsx` 导出 `FileTreeItem({ item, depth })`：
+  - 文件 → `TreeRow`（点击 `selectFile`），非 readOnly 时由 `FileTreeContextMenu` 包裹（new-file/new-folder 以文件父目录为 parent、copy-path、delete、float）
+  - 目录 → `DirectoryNode`：自持 `useProjectDirectory(..., { enabled: expanded })`，chevron 即时旋转（展开态来自 expandedPaths），首次展开 pending 时显示 loading 行；`query.data` 经 `buildTreeItems` 渲染子节点（递归组件，hook 合法）；非 readOnly 时 row 由 `FileTreeContextMenu` 包裹；readOnly 时文件与目录均渲染裸 row（无 menu、无 float）
+  - Base-UI Collapsible Panel 默认关闭即卸载：折叠后子树组件卸载、子目录 query 退订，invalidation 不再触发隐藏重取
+- `file-tree-context` 增加 `projectId` / `client` / `expandedPaths` / `selectFile`；`requestDelete(item: TreeItem)`、`requestCreate(item: TreeItem, action)`；`toggleNode` 拆为 `selectFile` + `toggleDir`
+- `FileTreeContextMenu` 的 `node`、`DeleteConfirmDialog` 的 `target` 换用新类型（字段用法不变）
+
+### 语义保证
+
+- 空目录 vs 未加载：`query.data === []` 为空目录；`enabled && query.isPending` 为加载中（Query pending ≠ collapsed）
+- 目录 query error：按空目录渲染（对齐现状 `loadChildren` catch → `[]` 的静默降级）；目录被外部删除后，父级 listing 刷新会使该节点整体卸载，孤儿 query 不再被渲染
+- `staleTime: Infinity` 下折叠不删缓存，重新展开命中缓存即渲染；若缓存已被精准失效则重新请求（E2E「re-expanding a collapsed folder shows fresh content」由 fs-watch → 精准失效 → 重新订阅重取保证）
+- 并发安全：展开状态是唯一本地写入方，children 一律来自 Query，无 merge 时序问题
+
+### 已知取舍
+
+- fs-watch 外部删除已展开目录且之后重建同名目录：`expandedPaths` 残留会使新目录自动展开（无数据正确性问题，children 来自新请求）；不为此外部删除场景引入额外的展开态清理机制
+- predicate 匹配区分大小写：大小写不敏感文件系统上 fs-watch 路径大小写与 key 不一致时会 miss（现状靠全量失效免疫）；记录为已知限制
+
+## 影响文件
+
+| 文件 | 变更 |
+|---|---|
+| `packages/app/src/queries/content.ts` | directory predicate + enabled 选项 + 精准失效 |
+| `packages/app/src/queries/content.test.ts` | 新增 directory 失效测试 |
+| `packages/app/src/components/file-tree/tree-model.ts` | 重写为纯数据模型 |
+| `packages/app/src/components/file-tree/tree-model.test.ts` | 重写 |
+| `packages/app/src/components/file-tree/hooks/useFileTreeController.ts` | 重写为交互状态 controller |
+| `packages/app/src/components/file-tree/file-tree-context.tsx` | context 值适配 |
+| `packages/app/src/components/file-tree/FileTreeNode.tsx` | FileTreeItem + DirectoryNode（自持 query） |
+| `packages/app/src/components/file-tree/index.tsx` | 根 query + 装配 |
+| `packages/app/src/components/file-tree/FileTreeContextMenu.tsx` | 类型替换 |
+| `packages/app/src/components/file-tree/DeleteConfirmDialog.tsx` | 类型替换 |
+
+## 测试计划
+
+- 单测：`tree-model.test.ts`（buildTreeItems 过滤/排序/路径、parentDirPath）；`content.test.ts`（directory predicate：父目录命中、后代命中、兄弟不命中；全量失效路径不变）
+- E2E：`npm run test:e2e --workspace=packages/desktop -- e2e/file-tree.spec.ts`（展开/折叠、重新展开取新、context menu 创建文件/文件夹、删除、取消）
+
+## 验收标准（对齐 followup doc）
+
+- 本地 state 不再保存服务端 children 快照
+- 删除 `mergeExpandedState` / `mergeRefreshedTree`
+- fs-watch 按父目录精准失效
+- 创建、删除、嵌套展开、重连和项目切换 E2E 覆盖保持通过

--- a/docs/dev/infra/2026-08-28-file-tree-directory-queries/design.md
+++ b/docs/dev/infra/2026-08-28-file-tree-directory-queries/design.md
@@ -65,7 +65,8 @@ deleteTarget: DeleteTarget | null
 - `toggleDir(path)`：Set 增删
 - `requestCreate(item, action)`：目录 → 以目录为 parent 并展开；文件 → 以 `parentDirPath` 为 parent
 - `submitCreate`：mkdir / touchFile 成功后 `invalidateProjectFileQueries(projectId, targetPath)`（精准失效父目录）；失败仅 toast，保留 `creating`（输入框不消失，与现状一致）
-- `confirmDelete`：删除成功后失效变更路径；同时清理 `expandedPaths` 中被删路径及其后代（避免本地删除后重建同名目录时幽灵展开态）
+- `confirmDelete`：删除成功后失效变更路径，并清理 `expandedPaths` 中被删路径及其后代（失败路径不清理，保留展开态）
+- controller 在 `projectId` 变化时重置交互状态（expandedPaths / creating / deleteTarget），避免项目切换残留
 - 根 query（loading / 空态）上移到 `FileTree` 组件
 
 ### 组件层
@@ -89,6 +90,8 @@ deleteTarget: DeleteTarget | null
 
 - fs-watch 外部删除已展开目录且之后重建同名目录：`expandedPaths` 残留会使新目录自动展开（无数据正确性问题，children 来自新请求）；不为此外部删除场景引入额外的展开态清理机制
 - predicate 匹配区分大小写：大小写不敏感文件系统上 fs-watch 路径大小写与 key 不一致时会 miss（现状靠全量失效免疫）；记录为已知限制
+- `parentDirOf`（queries/content.ts）与 `parentDirPath`（tree-model.ts）为两份同逻辑拷贝：为避免 queries → components 反向依赖，不共享 import；改动路径语义时需同步两处
+- 本变更前即无文件树「项目切换 / 重连」专属 E2E 用例；验收以既有 file-tree spec 全量通过 + 新增删除已展开目录用例为准
 
 ## 影响文件
 
@@ -107,12 +110,12 @@ deleteTarget: DeleteTarget | null
 
 ## 测试计划
 
-- 单测：`tree-model.test.ts`（buildTreeItems 过滤/排序/路径、parentDirPath）；`content.test.ts`（directory predicate：父目录命中、后代命中、兄弟不命中；全量失效路径不变）
-- E2E：`npm run test:e2e --workspace=packages/desktop -- e2e/file-tree.spec.ts`（展开/折叠、重新展开取新、context menu 创建文件/文件夹、删除、取消）
+- 单测：`tree-model.test.ts`（buildTreeItems 过滤/排序/路径、parentDirPath）；`content.test.ts`（directory predicate：父目录命中、后代命中、兄弟不命中、反斜杠归一化；全量失效路径不变）
+- E2E：`npm run test:e2e --workspace=packages/desktop -- e2e/file-tree.spec.ts`（展开/折叠、重新展开取新、context menu 创建文件/文件夹、删除文件、删除已展开目录、取消）
 
 ## 验收标准（对齐 followup doc）
 
 - 本地 state 不再保存服务端 children 快照
 - 删除 `mergeExpandedState` / `mergeRefreshedTree`
 - fs-watch 按父目录精准失效
-- 创建、删除、嵌套展开、重连和项目切换 E2E 覆盖保持通过
+- 创建、删除、嵌套展开、重新展开取新等 E2E 覆盖通过（`e2e/file-tree.spec.ts` 全量）

--- a/docs/dev/infra/2026-08-28-file-tree-directory-queries/plan.md
+++ b/docs/dev/infra/2026-08-28-file-tree-directory-queries/plan.md
@@ -1,0 +1,10 @@
+# Plan
+
+- [x] 1. `queries/content.ts`：`directoryKeyMatchesChangedPath` predicate、`useProjectDirectory` enabled 选项、`invalidateProjectFileQueries` 精准失效
+- [x] 2. `tree-model.ts` 重写 + `tree-model.test.ts` 重写
+- [x] 3. `useFileTreeController.ts` 重写（expandedPaths / creating / deleteTarget）
+- [x] 4. `file-tree-context.tsx` / `FileTreeNode.tsx` / `index.tsx` / `FileTreeContextMenu.tsx` / `DeleteConfirmDialog.tsx` 适配
+- [x] 5. `content.test.ts` 补 directory predicate 测试
+- [x] 6. lint + build + typecheck + `npm test --workspace=packages/app`（117 files / 1044 tests 通过）
+- [x] 7. E2E `e2e/file-tree.spec.ts`（10/10）+ `e2e/floating-content-browser.spec.ts`（7/7，覆盖 float 菜单）
+- [ ] 8. commit、code-review、doc-sync

--- a/docs/dev/infra/2026-08-28-file-tree-directory-queries/plan.md
+++ b/docs/dev/infra/2026-08-28-file-tree-directory-queries/plan.md
@@ -7,4 +7,5 @@
 - [x] 5. `content.test.ts` 补 directory predicate 测试
 - [x] 6. lint + build + typecheck + `npm test --workspace=packages/app`（117 files / 1044 tests 通过）
 - [x] 7. E2E `e2e/file-tree.spec.ts`（10/10）+ `e2e/floating-content-browser.spec.ts`（7/7，覆盖 float 菜单）
-- [ ] 8. commit、code-review、doc-sync
+- [x] 8. commit、code-review、doc-sync
+- [x] 9. review 反馈修复：删除成功后清理展开态、projectId 切换重置交互状态、TreeItemType 去 export、反斜杠归一化单测、删除已展开目录 E2E、design 已知取舍补记

--- a/docs/official/architecture/frontend.md
+++ b/docs/official/architecture/frontend.md
@@ -83,7 +83,7 @@ renderer 单份代码、宿主差异经此接口抽象的决策见 [ADR-0006](..
   - 应用级：settings、project-settings、onboarding、debug-tools
 - `layouts/` 仅 `ProjectScope`：项目生命周期编排 + 桥挂载；跨 feature 编排放 layout 或自治 bridge
 - `components/` 收 shadcn/ui 与跨 feature 复用组件；两个可复用子系统：
-  - `file-tree/`：`FileTree` 支持 rootPath / emptyLabel，user-file-panel 与 skill-panel 共用
+  - `file-tree/`：`FileTree` 支持 rootPath / emptyLabel，user-file-panel 与 skill-panel 共用；目录数据全走 directory query（每个目录节点组件自持 `useProjectDirectory`，`enabled: expanded`），controller 只保存交互状态（expandedPaths / creating / deleteTarget）
   - `floating-frame/`：拖拽 / resize chrome，`hookPrefix` 生成 `data-*-float-*` 主题钩子，三个浮窗 feature 复用
 - side-panel 双形态：桌面 pinned 常驻或 hover 展开（clickAway 收起）；移动端（768px 断点）浮动按钮 + transform 滑出面板 + backdrop，关闭态 `inert` 防焦点泄漏
 

--- a/packages/app/src/components/file-tree/DeleteConfirmDialog.tsx
+++ b/packages/app/src/components/file-tree/DeleteConfirmDialog.tsx
@@ -8,14 +8,14 @@ import {
   AlertDialogFooter,
   AlertDialogTitle,
 } from "../../components/ui/alert-dialog";
-import type { TreeNode } from "./tree-model";
+import type { DeleteTarget } from "./tree-model";
 
 export function DeleteConfirmDialog({
   target,
   onConfirm,
   onCancel,
 }: {
-  target: TreeNode | null;
+  target: DeleteTarget | null;
   onConfirm: () => void;
   onCancel: () => void;
 }) {

--- a/packages/app/src/components/file-tree/FileTreeContextMenu.tsx
+++ b/packages/app/src/components/file-tree/FileTreeContextMenu.tsx
@@ -7,7 +7,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "../../components/ui/context-menu";
-import type { CreateAction, TreeNode } from "./tree-model";
+import type { CreateAction, TreeItem } from "./tree-model";
 
 export function FileTreeContextMenu({
   node,
@@ -17,7 +17,7 @@ export function FileTreeContextMenu({
   onFloatFile,
   floatedFilePaths,
 }: {
-  node: TreeNode;
+  node: TreeItem;
   children: React.ReactNode;
   onCreate: (action: CreateAction) => void;
   onDelete: () => void;

--- a/packages/app/src/components/file-tree/FileTreeNode.tsx
+++ b/packages/app/src/components/file-tree/FileTreeNode.tsx
@@ -1,128 +1,141 @@
+import { useMemo } from "react";
 import { ChevronRightIcon, FileIcon, FolderIcon } from "lucide-react";
+import { useI18n } from "@spherse/i18n/react";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "../../components/ui/collapsible";
 import { TreeRow } from "../../components/ui/tree-row";
-import type { TreeNode } from "./tree-model";
+import { useProjectDirectory } from "../../queries/content";
+import { buildTreeItems, type TreeItem } from "./tree-model";
 import { FileTreeContextMenu } from "./FileTreeContextMenu";
 import { InlineNameInput } from "./InlineNameInput";
 import { useFileTreeCtx } from "./file-tree-context";
 
-export function FileTreeNode({ node, depth }: { node: TreeNode; depth: number }) {
+export function FileTreeItem({ item, depth }: { item: TreeItem; depth: number }) {
+  if (item.type === "directory") {
+    return <DirectoryNode item={item} depth={depth} />;
+  }
+  return <FileRow item={item} depth={depth} />;
+}
+
+function FileRow({ item, depth }: { item: TreeItem; depth: number }) {
   const {
     selectedFilePath,
-    creating,
-    toggleNode,
+    selectFile,
     requestCreate,
-    submitCreate,
-    cancelCreate,
     requestDelete,
     onFloatFile,
     floatedFilePaths,
     readOnly,
   } = useFileTreeCtx();
 
-  const isCreatingInThisDir =
-    creating && node.type === "directory" && creating.parentPath === node.path;
-
-  const isSelected = node.type === "file" && node.path === selectedFilePath;
+  const isSelected = item.path === selectedFilePath;
 
   const row = (
-    <TreeRow
-      depth={depth}
-      selected={isSelected}
-      className={node.type === "directory" ? "group" : undefined}
-      onClick={() => toggleNode(node)}
-    >
-      {node.type === "directory" && (
-        <ChevronRightIcon className="size-4 shrink-0 text-sidebar-foreground/70 transition-transform group-data-[panel-open]:rotate-90" />
-      )}
-      {node.type === "directory" ? (
-        <FolderIcon className="size-4 shrink-0 text-sidebar-foreground/70" />
-      ) : (
-        <FileIcon className="size-4 shrink-0 text-sidebar-foreground/70" />
-      )}
+    <TreeRow depth={depth} selected={isSelected} onClick={() => selectFile(item.path)}>
+      <FileIcon className="size-4 shrink-0 text-sidebar-foreground/70" />
       <span className="overflow-hidden text-ellipsis whitespace-nowrap">
-        {node.name}
+        {item.name}
       </span>
     </TreeRow>
   );
 
-  const menuTrigger =
-    node.type === "directory" ? (
-      <CollapsibleTrigger
-        render={
-          <TreeRow depth={depth} className="group" />
-        }
-      >
-        <ChevronRightIcon className="size-4 shrink-0 text-sidebar-foreground/70 transition-transform group-data-[panel-open]:rotate-90" />
-        <FolderIcon className="size-4 shrink-0 text-sidebar-foreground/70" />
-        <span className="overflow-hidden text-ellipsis whitespace-nowrap">
-          {node.name}
-        </span>
-      </CollapsibleTrigger>
-    ) : (
-      row
-    );
+  if (readOnly) {
+    return row;
+  }
+
+  return (
+    <FileTreeContextMenu
+      node={item}
+      onCreate={(action) => requestCreate(item, action)}
+      onDelete={() => requestDelete(item)}
+      onFloatFile={onFloatFile}
+      floatedFilePaths={floatedFilePaths}
+    >
+      {row}
+    </FileTreeContextMenu>
+  );
+}
+
+function DirectoryNode({ item, depth }: { item: TreeItem; depth: number }) {
+  const { t } = useI18n();
+  const {
+    projectId,
+    client,
+    expandedPaths,
+    creating,
+    toggleDir,
+    requestCreate,
+    submitCreate,
+    cancelCreate,
+    requestDelete,
+    readOnly,
+  } = useFileTreeCtx();
+
+  const expanded = expandedPaths.has(item.path);
+  const query = useProjectDirectory(projectId, client, item.path, { enabled: expanded });
+  const items = useMemo(
+    () => (query.data ? buildTreeItems(query.data, item.path) : []),
+    [query.data, item.path],
+  );
+  const isCreatingInThisDir = creating && creating.parentPath === item.path;
+
+  const trigger = (
+    <CollapsibleTrigger render={<TreeRow depth={depth} className="group" />}>
+      <ChevronRightIcon className="size-4 shrink-0 text-sidebar-foreground/70 transition-transform group-data-[panel-open]:rotate-90" />
+      <FolderIcon className="size-4 shrink-0 text-sidebar-foreground/70" />
+      <span className="overflow-hidden text-ellipsis whitespace-nowrap">
+        {item.name}
+      </span>
+    </CollapsibleTrigger>
+  );
+
+  const content = (
+    <CollapsibleContent className="ml-2">
+      <div className="flex flex-col gap-px">
+        {isCreatingInThisDir && creating && (
+          <InlineNameInput
+            depth={depth + 1}
+            onSubmit={(name) => submitCreate(creating.parentPath, creating.action, name)}
+            onCancel={cancelCreate}
+          />
+        )}
+        {expanded && query.isPending && (
+          <p
+            style={{ paddingLeft: (depth + 1) * 16 + 8 }}
+            className="text-xs text-sidebar-foreground/70"
+          >
+            {t("common.loading")}
+          </p>
+        )}
+        {items.map((child) => (
+          <FileTreeItem key={child.path} item={child} depth={depth + 1} />
+        ))}
+      </div>
+    </CollapsibleContent>
+  );
 
   if (readOnly) {
-    return node.type === "file" ? (
-      menuTrigger
-    ) : (
-      <Collapsible open={node.expanded} onOpenChange={() => toggleNode(node)}>
-        {menuTrigger}
-        <CollapsibleContent className="ml-2">
-          <div className="flex flex-col gap-px">
-            {node.children.map((child) => (
-              <FileTreeNode key={child.path} node={child} depth={depth + 1} />
-            ))}
-          </div>
-        </CollapsibleContent>
+    return (
+      <Collapsible open={expanded} onOpenChange={() => toggleDir(item.path)}>
+        {trigger}
+        {content}
       </Collapsible>
     );
   }
 
-  if (node.type === "file") {
-    return (
-      <FileTreeContextMenu
-        node={node}
-        onCreate={(action) => requestCreate(node, action)}
-        onDelete={() => requestDelete(node)}
-        onFloatFile={onFloatFile}
-        floatedFilePaths={floatedFilePaths}
-      >
-        {menuTrigger}
-      </FileTreeContextMenu>
-    );
-  }
-
   return (
-    <Collapsible open={node.expanded} onOpenChange={() => toggleNode(node)}>
+    <Collapsible open={expanded} onOpenChange={() => toggleDir(item.path)}>
       <FileTreeContextMenu
-        node={node}
-        onCreate={(action) => requestCreate(node, action)}
-        onDelete={() => requestDelete(node)}
+        node={item}
+        onCreate={(action) => requestCreate(item, action)}
+        onDelete={() => requestDelete(item)}
       >
-        {menuTrigger}
+        {trigger}
       </FileTreeContextMenu>
-      <CollapsibleContent className="ml-2">
-        <div className="flex flex-col gap-px">
-          {isCreatingInThisDir && creating && (
-            <InlineNameInput
-              depth={depth + 1}
-              onSubmit={(name) =>
-                submitCreate(creating.parentPath, creating.action, name)
-              }
-              onCancel={cancelCreate}
-            />
-          )}
-          {node.children.map((child) => (
-            <FileTreeNode key={child.path} node={child} depth={depth + 1} />
-          ))}
-        </div>
-      </CollapsibleContent>
+      {content}
     </Collapsible>
   );
 }

--- a/packages/app/src/components/file-tree/file-tree-context.tsx
+++ b/packages/app/src/components/file-tree/file-tree-context.tsx
@@ -1,15 +1,20 @@
 import { createContext, useContext } from "react";
 import type { ReactNode } from "react";
-import type { CreatingState, CreateAction, TreeNode } from "./tree-model";
+import type { ApiClient } from "../../lib/api";
+import type { CreatingState, CreateAction, TreeItem } from "./tree-model";
 
 export interface FileTreeContextValue {
+  projectId: string;
+  client: ApiClient;
   selectedFilePath?: string;
+  expandedPaths: ReadonlySet<string>;
   creating: CreatingState | null;
-  toggleNode: (node: TreeNode) => void;
-  requestCreate: (node: TreeNode, action: CreateAction) => void;
+  selectFile: (filePath: string) => void;
+  toggleDir: (path: string) => void;
+  requestCreate: (item: TreeItem, action: CreateAction) => void;
   submitCreate: (parentPath: string, action: CreateAction, name: string) => void;
   cancelCreate: () => void;
-  requestDelete: (node: TreeNode) => void;
+  requestDelete: (item: TreeItem) => void;
   onFloatFile?: (filePath: string) => void;
   floatedFilePaths?: Set<string>;
   readOnly?: boolean;

--- a/packages/app/src/components/file-tree/hooks/useFileTreeController.ts
+++ b/packages/app/src/components/file-tree/hooks/useFileTreeController.ts
@@ -1,146 +1,77 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useCallback } from "react";
 import { toast } from "sonner";
 import { useI18n } from "@spherse/i18n/react";
 import type { ApiClient } from "../../../lib/api";
 import {
-  type TreeNode,
+  type TreeItem,
   type CreatingState,
+  type DeleteTarget,
   type CreateAction,
   INVALID_NAME_RE,
-  buildNodes,
-  updateNode,
-  mergeExpandedState,
-  mergeRefreshedTree,
+  parentDirPath,
+  childPath,
 } from "../tree-model";
-import { fetchProjectDirectory, invalidateProjectFileQueries, useProjectDirectory } from "../../../queries/content";
+import { invalidateProjectFileQueries } from "../../../queries/content";
 
 export interface FileTreeController {
-  rootNodes: TreeNode[];
-  loading: boolean;
+  expandedPaths: ReadonlySet<string>;
   creating: CreatingState | null;
-  deleteTarget: TreeNode | null;
-  toggleNode: (node: TreeNode) => void;
-  requestCreate: (node: TreeNode, action: CreateAction) => void;
+  deleteTarget: DeleteTarget | null;
+  toggleDir: (path: string) => void;
+  requestCreate: (item: TreeItem, action: CreateAction) => void;
   submitCreate: (parentPath: string, action: CreateAction, name: string) => void;
   cancelCreate: () => void;
-  requestDelete: (node: TreeNode) => void;
+  requestDelete: (item: TreeItem) => void;
   confirmDelete: () => void;
   cancelDelete: () => void;
 }
 
 export function useFileTreeController(
   client: ApiClient,
-  onSelectFile: (filePath: string) => void,
   onDeleted: ((path: string) => void) | undefined,
   projectId: string,
-  rootPath: string,
 ): FileTreeController {
   const { t } = useI18n();
-  const [rootNodes, setRootNodes] = useState<TreeNode[]>([]);
-  const rootQuery = useProjectDirectory(projectId, client, rootPath);
+  const [expandedPaths, setExpandedPaths] = useState<ReadonlySet<string>>(() => new Set());
   const [creating, setCreating] = useState<CreatingState | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<TreeNode | null>(null);
-  const nodesRef = useRef<TreeNode[]>([]);
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
 
-  useEffect(() => {
-    nodesRef.current = rootNodes;
-  }, [rootNodes]);
-
-  const loadChildren = useCallback(
-    async (parentPath: string) => {
-      try {
-        return await fetchProjectDirectory(projectId, client, parentPath);
-      } catch {
-        return [];
+  const toggleDir = useCallback((path: string) => {
+    setExpandedPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
       }
-    },
-    [client, projectId],
-  );
-
-  const refreshExpanded = useCallback(
-    async (nodes: TreeNode[]): Promise<TreeNode[]> => {
-      const result: TreeNode[] = [];
-      for (const node of nodes) {
-        if (node.type === "directory" && node.expanded && node.loaded) {
-          const entries = await loadChildren(node.path);
-          const children = buildNodes(entries, node.path);
-          const merged = mergeExpandedState(children, node.children);
-          const recursed = await refreshExpanded(merged);
-          result.push({ ...node, children: recursed });
-        } else {
-          result.push(node);
-        }
-      }
-      return result;
-    },
-    [loadChildren],
-  );
-
-  const buildRefreshedRoot = useCallback(async (entries: Awaited<ReturnType<ApiClient["listContent"]>>) => {
-    const root = buildNodes(entries, rootPath);
-    const merged = mergeExpandedState(root, nodesRef.current);
-    return refreshExpanded(merged);
-  }, [refreshExpanded, rootPath]);
-
-  const refreshTree = useCallback(async (changedPath: string) => {
-    await invalidateProjectFileQueries(projectId, changedPath);
-    const entries = await fetchProjectDirectory(projectId, client, rootPath);
-    const refreshed = await buildRefreshedRoot(entries);
-    setRootNodes((current) => mergeRefreshedTree(refreshed, current));
-  }, [buildRefreshedRoot, client, projectId, rootPath]);
-
-  useEffect(() => {
-    if (!rootQuery.data) return;
-    let cancelled = false;
-    void buildRefreshedRoot(rootQuery.data).then((refreshed) => {
-      if (cancelled) return;
-      setRootNodes((current) => mergeRefreshedTree(refreshed, current));
+      return next;
     });
-    return () => {
-      cancelled = true;
-    };
-  }, [buildRefreshedRoot, rootQuery.data, rootQuery.dataUpdatedAt]);
+  }, []);
 
-  const toggleNode = useCallback(
-    async (node: TreeNode) => {
-      if (node.type === "file") {
-        onSelectFile(node.path);
-        return;
-      }
-
-      const children = node.expanded
-        ? node.children
-        : buildNodes(await loadChildren(node.path), node.path);
-      setRootNodes((prev) =>
-        updateNode(prev, node.path, (current) => ({
-          ...current,
-          children,
-          loaded: true,
-          expanded: !current.expanded,
-        })),
-      );
-    },
-    [onSelectFile, loadChildren],
-  );
+  const expandDir = useCallback((path: string) => {
+    setExpandedPaths((prev) => {
+      if (prev.has(path)) return prev;
+      const next = new Set(prev);
+      next.add(path);
+      return next;
+    });
+  }, []);
 
   const requestCreate = useCallback(
-    (node: TreeNode, action: CreateAction) => {
-      const dirPath =
-        node.type === "directory"
-          ? node.path
-          : node.path.split("/").slice(0, -1).join("/");
-      if (node.type === "directory" && !node.expanded) {
-        toggleNode(node);
+    (item: TreeItem, action: CreateAction) => {
+      const parentPath = item.type === "directory" ? item.path : parentDirPath(item.path);
+      if (item.type === "directory") {
+        expandDir(item.path);
       }
-      setCreating({ parentPath: dirPath, action });
+      setCreating({ parentPath, action });
     },
-    [toggleNode],
+    [expandDir],
   );
 
   const submitCreate = useCallback(
     async (parentPath: string, action: CreateAction, name: string) => {
       if (!name || INVALID_NAME_RE.test(name)) return;
-      const targetPath = parentPath ? `${parentPath}/${name}` : name;
+      const targetPath = childPath(parentPath, name);
       try {
         if (action === "new-folder") {
           await client.mkdir(targetPath);
@@ -148,41 +79,55 @@ export function useFileTreeController(
           await client.touchFile(targetPath);
         }
         setCreating(null);
-        await refreshTree(targetPath);
+        await invalidateProjectFileQueries(projectId, targetPath);
       } catch (err) {
         toast.error(t("file-tree.createFailed", { message: (err as Error).message }));
       }
     },
-    [client, refreshTree, t],
+    [client, projectId, t],
   );
 
   const cancelCreate = useCallback(() => setCreating(null), []);
 
-  const requestDelete = useCallback((node: TreeNode) => setDeleteTarget(node), []);
+  const requestDelete = useCallback(
+    (item: TreeItem) => setDeleteTarget({ name: item.name, path: item.path, type: item.type }),
+    [],
+  );
 
   const confirmDelete = useCallback(() => {
     if (!deleteTarget) return;
-    const node = deleteTarget;
+    const target = deleteTarget;
     setDeleteTarget(null);
+    setExpandedPaths((prev) => {
+      const next = new Set<string>();
+      let changed = false;
+      for (const path of prev) {
+        if (path === target.path || path.startsWith(`${target.path}/`)) {
+          changed = true;
+          continue;
+        }
+        next.add(path);
+      }
+      return changed ? next : prev;
+    });
     void client
-      .deleteContent(node.path)
+      .deleteContent(target.path)
       .then(async () => {
-        onDeleted?.(node.path);
-        await refreshTree(node.path);
+        onDeleted?.(target.path);
+        await invalidateProjectFileQueries(projectId, target.path);
       })
       .catch((err: unknown) => {
         toast.error(t("file-tree.deleteFailed", { message: (err as Error).message }));
       });
-  }, [deleteTarget, client, onDeleted, refreshTree, t]);
+  }, [deleteTarget, client, onDeleted, projectId, t]);
 
   const cancelDelete = useCallback(() => setDeleteTarget(null), []);
 
   return {
-    rootNodes,
-    loading: rootQuery.isPending,
+    expandedPaths,
     creating,
     deleteTarget,
-    toggleNode,
+    toggleDir,
     requestCreate,
     submitCreate,
     cancelCreate,

--- a/packages/app/src/components/file-tree/hooks/useFileTreeController.ts
+++ b/packages/app/src/components/file-tree/hooks/useFileTreeController.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { toast } from "sonner";
 import { useI18n } from "@spherse/i18n/react";
 import type { ApiClient } from "../../../lib/api";
@@ -35,6 +35,12 @@ export function useFileTreeController(
   const [expandedPaths, setExpandedPaths] = useState<ReadonlySet<string>>(() => new Set());
   const [creating, setCreating] = useState<CreatingState | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+
+  useEffect(() => {
+    setExpandedPaths(new Set());
+    setCreating(null);
+    setDeleteTarget(null);
+  }, [projectId]);
 
   const toggleDir = useCallback((path: string) => {
     setExpandedPaths((prev) => {
@@ -98,22 +104,22 @@ export function useFileTreeController(
     if (!deleteTarget) return;
     const target = deleteTarget;
     setDeleteTarget(null);
-    setExpandedPaths((prev) => {
-      const next = new Set<string>();
-      let changed = false;
-      for (const path of prev) {
-        if (path === target.path || path.startsWith(`${target.path}/`)) {
-          changed = true;
-          continue;
-        }
-        next.add(path);
-      }
-      return changed ? next : prev;
-    });
     void client
       .deleteContent(target.path)
       .then(async () => {
         onDeleted?.(target.path);
+        setExpandedPaths((prev) => {
+          const next = new Set<string>();
+          let changed = false;
+          for (const path of prev) {
+            if (path === target.path || path.startsWith(`${target.path}/`)) {
+              changed = true;
+              continue;
+            }
+            next.add(path);
+          }
+          return changed ? next : prev;
+        });
         await invalidateProjectFileQueries(projectId, target.path);
       })
       .catch((err: unknown) => {

--- a/packages/app/src/components/file-tree/index.tsx
+++ b/packages/app/src/components/file-tree/index.tsx
@@ -1,8 +1,11 @@
+import { useMemo } from "react";
 import { useI18n } from "@spherse/i18n/react";
 import { useProjectCtx } from "../../context/project-context";
 import { useApiClient } from "../../lib/use-connection";
+import { useProjectDirectory } from "../../queries/content";
 import { useFileTreeController } from "./hooks/useFileTreeController";
-import { FileTreeNode } from "./FileTreeNode";
+import { buildTreeItems } from "./tree-model";
+import { FileTreeItem } from "./FileTreeNode";
 import { FileTreeProvider } from "./file-tree-context";
 import { InlineNameInput } from "./InlineNameInput";
 import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
@@ -23,12 +26,21 @@ export function FileTree({ selectedFilePath, onSelectFile, onDeleted, onFloatFil
   const { projectId } = useProjectCtx();
   const client = useApiClient(projectId);
   const basePath = rootPath ?? "";
-  const ctrl = useFileTreeController(client, onSelectFile, onDeleted, projectId, basePath);
+  const ctrl = useFileTreeController(client, onDeleted, projectId);
+  const rootQuery = useProjectDirectory(projectId, client, basePath);
+  const items = useMemo(
+    () => (rootQuery.data ? buildTreeItems(rootQuery.data, basePath) : []),
+    [rootQuery.data, basePath],
+  );
 
   const ctxValue = {
+    projectId,
+    client,
     selectedFilePath,
+    expandedPaths: ctrl.expandedPaths,
     creating: ctrl.creating,
-    toggleNode: ctrl.toggleNode,
+    selectFile: onSelectFile,
+    toggleDir: ctrl.toggleDir,
     requestCreate: ctrl.requestCreate,
     submitCreate: ctrl.submitCreate,
     cancelCreate: ctrl.cancelCreate,
@@ -40,14 +52,14 @@ export function FileTree({ selectedFilePath, onSelectFile, onDeleted, onFloatFil
 
   return (
     <div className="flex flex-col gap-px text-xs">
-      {ctrl.loading ? (
+      {rootQuery.isPending ? (
         <p className="px-2 text-xs text-sidebar-foreground/70">{t("common.loading")}</p>
-      ) : ctrl.rootNodes.length === 0 ? (
+      ) : items.length === 0 ? (
         <p className="px-2 text-xs text-sidebar-foreground/70">{emptyLabel ?? t("file-tree.empty")}</p>
       ) : (
         <FileTreeProvider value={ctxValue}>
-          {ctrl.rootNodes.map((node) => (
-            <FileTreeNode key={node.path} node={node} depth={0} />
+          {items.map((item) => (
+            <FileTreeItem key={item.path} item={item} depth={0} />
           ))}
         </FileTreeProvider>
       )}

--- a/packages/app/src/components/file-tree/tree-model.test.ts
+++ b/packages/app/src/components/file-tree/tree-model.test.ts
@@ -1,47 +1,17 @@
 import { describe, expect, it } from "vitest";
-import {
-  buildNodes,
-  mergeExpandedState,
-  mergeRefreshedTree,
-  updateNode,
-  type TreeNode,
-} from "./tree-model";
+import { buildTreeItems, childPath, parentDirPath } from "./tree-model";
 import type { FileEntry } from "../../lib/types";
 
-describe("mergeRefreshedTree", () => {
-  it("keeps current expansion while accepting refreshed children", () => {
-    const current = buildNodes([{ name: "docs", type: "directory" }], "");
-    current[0] = {
-      ...current[0],
-      expanded: true,
-      loaded: true,
-      children: buildNodes([{ name: "old.md", type: "file" }], "docs"),
-    };
-    const refreshed = buildNodes([{ name: "docs", type: "directory" }], "");
-    refreshed[0] = {
-      ...refreshed[0],
-      expanded: true,
-      loaded: true,
-      children: buildNodes([{ name: "new.md", type: "file" }], "docs"),
-    };
-
-    const merged = mergeRefreshedTree(refreshed, current);
-
-    expect(merged[0].expanded).toBe(true);
-    expect(merged[0].children.map((node) => node.name)).toEqual(["new.md"]);
-  });
-});
-
-describe("buildNodes", () => {
+describe("buildTreeItems", () => {
   it("filters dotfiles and dotdirs", () => {
     const entries: FileEntry[] = [
       { name: ".hidden", type: "file" },
       { name: ".config", type: "directory" },
       { name: "README.md", type: "file" },
     ];
-    const nodes = buildNodes(entries, "");
-    expect(nodes).toHaveLength(1);
-    expect(nodes[0].name).toBe("README.md");
+    const items = buildTreeItems(entries, "");
+    expect(items).toHaveLength(1);
+    expect(items[0].name).toBe("README.md");
   });
 
   it("sorts directories before files, then alphabetically", () => {
@@ -51,8 +21,8 @@ describe("buildNodes", () => {
       { name: "beta.txt", type: "file" },
       { name: "gamma", type: "directory" },
     ];
-    const nodes = buildNodes(entries, "");
-    expect(nodes.map((n) => n.name)).toEqual(["alpha", "gamma", "beta.txt", "zebra.md"]);
+    const items = buildTreeItems(entries, "");
+    expect(items.map((item) => item.name)).toEqual(["alpha", "gamma", "beta.txt", "zebra.md"]);
   });
 
   it("builds paths with parent prefix", () => {
@@ -60,9 +30,9 @@ describe("buildNodes", () => {
       { name: "src", type: "directory" },
       { name: "index.ts", type: "file" },
     ];
-    const nodes = buildNodes(entries, "project");
-    expect(nodes[0].path).toBe("project/src");
-    expect(nodes[1].path).toBe("project/index.ts");
+    const items = buildTreeItems(entries, "project");
+    expect(items[0].path).toBe("project/src");
+    expect(items[1].path).toBe("project/index.ts");
   });
 
   it("builds full project-relative paths when rooted at a nested rootPath", () => {
@@ -70,147 +40,33 @@ describe("buildNodes", () => {
       { name: "foo", type: "directory" },
       { name: "SKILL.md", type: "file" },
     ];
-    const nodes = buildNodes(entries, ".spherse/skills");
-    expect(nodes[0].path).toBe(".spherse/skills/foo");
-    expect(nodes[1].path).toBe(".spherse/skills/SKILL.md");
+    const items = buildTreeItems(entries, ".spherse/skills");
+    expect(items[0].path).toBe(".spherse/skills/foo");
+    expect(items[1].path).toBe(".spherse/skills/SKILL.md");
   });
 
   it("returns empty array for empty input", () => {
-    expect(buildNodes([], "")).toEqual([]);
+    expect(buildTreeItems([], "")).toEqual([]);
   });
 });
 
-describe("updateNode", () => {
-  const tree: TreeNode[] = [
-    {
-      name: "src",
-      path: "src",
-      type: "directory",
-      expanded: false,
-      loaded: true,
-      children: [
-        {
-          name: "index.ts",
-          path: "src/index.ts",
-          type: "file",
-          expanded: false,
-          loaded: false,
-          children: [],
-        },
-      ],
-    },
-    {
-      name: "README.md",
-      path: "README.md",
-      type: "file",
-      expanded: false,
-      loaded: false,
-      children: [],
-    },
-  ];
-
-  it("updates a top-level node", () => {
-    const result = updateNode(tree, "README.md", (n) => ({ ...n, expanded: true }));
-    expect(result[1].expanded).toBe(true);
-    expect(result[0].expanded).toBe(false);
+describe("parentDirPath", () => {
+  it("returns empty string for top-level paths", () => {
+    expect(parentDirPath("docs")).toBe("");
   });
 
-  it("updates a nested node", () => {
-    const result = updateNode(tree, "src/index.ts", (n) => ({ ...n, expanded: true }));
-    expect(result[0].children[0].expanded).toBe(true);
-  });
-
-  it("returns same reference for leaf nodes with no children", () => {
-    const result = updateNode(tree, "README.md", (n) => ({ ...n, expanded: true }));
-    expect(result[0].children[0]).toBe(tree[0].children[0]);
+  it("returns the direct parent for nested paths", () => {
+    expect(parentDirPath("src/components/ui")).toBe("src/components");
+    expect(parentDirPath(".spherse/skills/demo/SKILL.md")).toBe(".spherse/skills/demo");
   });
 });
 
-describe("mergeExpandedState", () => {
-  it("preserves expanded, loaded and children from old nodes", () => {
-    const newNodes: TreeNode[] = [
-      {
-        name: "src",
-        path: "src",
-        type: "directory",
-        expanded: false,
-        loaded: false,
-        children: [],
-      },
-    ];
-    const oldNodes: TreeNode[] = [
-      {
-        name: "src",
-        path: "src",
-        type: "directory",
-        expanded: true,
-        loaded: true,
-        children: [
-          {
-            name: "index.ts",
-            path: "src/index.ts",
-            type: "file",
-            expanded: false,
-            loaded: false,
-            children: [],
-          },
-        ],
-      },
-    ];
-    const result = mergeExpandedState(newNodes, oldNodes);
-    expect(result[0].expanded).toBe(true);
-    expect(result[0].loaded).toBe(true);
-    expect(result[0].children).toBe(oldNodes[0].children);
+describe("childPath", () => {
+  it("concatenates with separator under a parent", () => {
+    expect(childPath("docs", "a.md")).toBe("docs/a.md");
   });
 
-  it("returns new node as-is when no matching old node", () => {
-    const newNodes: TreeNode[] = [
-      {
-        name: "new-dir",
-        path: "new-dir",
-        type: "directory",
-        expanded: false,
-        loaded: false,
-        children: [],
-      },
-    ];
-    const result = mergeExpandedState(newNodes, []);
-    expect(result[0]).toBe(newNodes[0]);
-  });
-
-  it("preserves entire old subtree when old node is loaded", () => {
-    const newNodes: TreeNode[] = [
-      {
-        name: "src",
-        path: "src",
-        type: "directory",
-        expanded: false,
-        loaded: false,
-        children: [],
-      },
-    ];
-    const oldNodes: TreeNode[] = [
-      {
-        name: "src",
-        path: "src",
-        type: "directory",
-        expanded: true,
-        loaded: true,
-        children: [
-          {
-            name: "sub",
-            path: "src/sub",
-            type: "directory",
-            expanded: true,
-            loaded: true,
-            children: [],
-          },
-        ],
-      },
-    ];
-    const result = mergeExpandedState(newNodes, oldNodes);
-    expect(result[0].children[0].expanded).toBe(true);
-    expect(result[0].children[0].loaded).toBe(true);
-    expect(result[0].children).toBe(oldNodes[0].children);
+  it("returns the bare name at the project root", () => {
+    expect(childPath("", "docs")).toBe("docs");
   });
 });

--- a/packages/app/src/components/file-tree/tree-model.ts
+++ b/packages/app/src/components/file-tree/tree-model.ts
@@ -1,6 +1,6 @@
 import type { FileEntry } from "../../lib/types";
 
-export type TreeItemType = "file" | "directory";
+type TreeItemType = "file" | "directory";
 
 export interface TreeItem {
   name: string;

--- a/packages/app/src/components/file-tree/tree-model.ts
+++ b/packages/app/src/components/file-tree/tree-model.ts
@@ -1,12 +1,11 @@
 import type { FileEntry } from "../../lib/types";
 
-export interface TreeNode {
+export type TreeItemType = "file" | "directory";
+
+export interface TreeItem {
   name: string;
   path: string;
-  type: "file" | "directory";
-  expanded: boolean;
-  children: TreeNode[];
-  loaded: boolean;
+  type: TreeItemType;
 }
 
 export type CreateAction = "new-file" | "new-folder";
@@ -16,9 +15,24 @@ export interface CreatingState {
   action: CreateAction;
 }
 
+export interface DeleteTarget {
+  name: string;
+  path: string;
+  type: TreeItemType;
+}
+
 export const INVALID_NAME_RE = /[/\\:]/;
 
-export function buildNodes(entries: FileEntry[], parentPath: string): TreeNode[] {
+export function childPath(parentPath: string, name: string): string {
+  return parentPath ? `${parentPath}/${name}` : name;
+}
+
+export function parentDirPath(path: string): string {
+  const idx = path.lastIndexOf("/");
+  return idx === -1 ? "" : path.slice(0, idx);
+}
+
+export function buildTreeItems(entries: FileEntry[], parentPath: string): TreeItem[] {
   return entries
     .filter((e) => !e.name.startsWith("."))
     .sort((a, b) => {
@@ -27,56 +41,7 @@ export function buildNodes(entries: FileEntry[], parentPath: string): TreeNode[]
     })
     .map((entry) => ({
       name: entry.name,
-      path: parentPath ? `${parentPath}/${entry.name}` : entry.name,
+      path: childPath(parentPath, entry.name),
       type: entry.type,
-      expanded: false,
-      children: [],
-      loaded: false,
     }));
-}
-
-export function updateNode(
-  nodes: TreeNode[],
-  path: string,
-  update: (node: TreeNode) => TreeNode,
-): TreeNode[] {
-  return nodes.map((node) => {
-    if (node.path === path) return update(node);
-    if (node.children.length === 0) return node;
-    return { ...node, children: updateNode(node.children, path, update) };
-  });
-}
-
-export function mergeExpandedState(
-  newNodes: TreeNode[],
-  oldNodes: TreeNode[],
-): TreeNode[] {
-  return newNodes.map((node) => {
-    const old = oldNodes.find((o) => o.path === node.path);
-    if (!old) return node;
-    return {
-      ...node,
-      expanded: old.expanded,
-      loaded: old.loaded,
-      children: old.children,
-    };
-  });
-}
-
-export function mergeRefreshedTree(
-  refreshedNodes: TreeNode[],
-  currentNodes: TreeNode[],
-): TreeNode[] {
-  return refreshedNodes.map((node) => {
-    const current = currentNodes.find((item) => item.path === node.path);
-    if (!current) return node;
-    return {
-      ...node,
-      expanded: current.expanded,
-      loaded: current.loaded,
-      children: node.loaded
-        ? mergeRefreshedTree(node.children, current.children)
-        : current.children,
-    };
-  });
 }

--- a/packages/app/src/queries/content.test.ts
+++ b/packages/app/src/queries/content.test.ts
@@ -81,12 +81,23 @@ describe("directoryKeyMatchesChangedPath", () => {
 });
 
 describe("invalidateProjectFileQueries with a directory path", () => {
+  const projectId = "p1";
+
   beforeEach(() => {
     queryClient.clear();
   });
 
+  it("normalizes windows separators before matching directory keys", async () => {
+    queryClient.setQueryData(projectQueryKeys.directory(projectId, "docs"), []);
+    queryClient.setQueryData(projectQueryKeys.directory(projectId, "other"), []);
+
+    await invalidateProjectFileQueries(projectId, "docs\\a.md");
+
+    expect(queryClient.getQueryState(projectQueryKeys.directory(projectId, "docs"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(projectQueryKeys.directory(projectId, "other"))?.isInvalidated).toBe(false);
+  });
+
   it("invalidates open file content queries under the replaced directory", async () => {
-    const projectId = "p1";
     const staleData = { path: ".spherse/skills/demo/SKILL.md", content: "version: 0.1.0", binary: false };
     queryClient.setQueryData(projectQueryKeys.content(projectId, ".spherse/skills/demo/SKILL.md"), staleData);
     queryClient.setQueryData(projectQueryKeys.content(projectId, "notes/other.md"), {

--- a/packages/app/src/queries/content.test.ts
+++ b/packages/app/src/queries/content.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { contentKeyMatchesChangedPath, invalidateProjectFileQueries } from "./content";
+import {
+  contentKeyMatchesChangedPath,
+  directoryKeyMatchesChangedPath,
+  invalidateProjectFileQueries,
+} from "./content";
 import { queryClient } from "./client";
 import { projectQueryKeys } from "./keys";
 
@@ -30,6 +34,52 @@ describe("contentKeyMatchesChangedPath", () => {
   });
 });
 
+describe("directoryKeyMatchesChangedPath", () => {
+  const projectId = "p1";
+
+  it("matches the changed directory itself", () => {
+    const key = projectQueryKeys.directory(projectId, "docs");
+    expect(directoryKeyMatchesChangedPath(key, projectId, "docs")).toBe(true);
+  });
+
+  it("matches the direct parent of the changed path", () => {
+    const key = projectQueryKeys.directory(projectId, "src/components");
+    expect(directoryKeyMatchesChangedPath(key, projectId, "src/components/Button.tsx")).toBe(true);
+  });
+
+  it("matches the project root as parent of a top-level path", () => {
+    const key = projectQueryKeys.directory(projectId, "");
+    expect(directoryKeyMatchesChangedPath(key, projectId, "README.md")).toBe(true);
+  });
+
+  it("matches descendant directories of a removed directory", () => {
+    const key = projectQueryKeys.directory(projectId, "docs/guide/assets");
+    expect(directoryKeyMatchesChangedPath(key, projectId, "docs/guide")).toBe(true);
+  });
+
+  it("does not match sibling directories sharing a string prefix", () => {
+    const key = projectQueryKeys.directory(projectId, "docs-extra");
+    expect(directoryKeyMatchesChangedPath(key, projectId, "docs")).toBe(false);
+  });
+
+  it("does not match deeper ancestors than the direct parent", () => {
+    const key = projectQueryKeys.directory(projectId, "src");
+    expect(directoryKeyMatchesChangedPath(key, projectId, "src/components/ui")).toBe(false);
+  });
+
+  it("ignores keys of other projects or other query domains", () => {
+    expect(
+      directoryKeyMatchesChangedPath(["projects", "p2", "directories", "docs"], projectId, "docs"),
+    ).toBe(false);
+    expect(
+      directoryKeyMatchesChangedPath(["projects", projectId, "content", "docs"], projectId, "docs"),
+    ).toBe(false);
+    expect(
+      directoryKeyMatchesChangedPath(["projects", projectId, "directories", 7], projectId, "docs"),
+    ).toBe(false);
+  });
+});
+
 describe("invalidateProjectFileQueries with a directory path", () => {
   beforeEach(() => {
     queryClient.clear();
@@ -45,11 +95,17 @@ describe("invalidateProjectFileQueries with a directory path", () => {
       binary: false,
     });
     queryClient.setQueryData(projectQueryKeys.fileTree(projectId), { entries: [] });
+    queryClient.setQueryData(projectQueryKeys.directory(projectId, ".spherse/skills"), [{ name: "demo", type: "directory" }]);
+    queryClient.setQueryData(projectQueryKeys.directory(projectId, ".spherse/skills/demo"), [{ name: "SKILL.md", type: "file" }]);
+    queryClient.setQueryData(projectQueryKeys.directory(projectId, ".spherse/skills/other"), []);
 
     await invalidateProjectFileQueries(projectId, ".spherse/skills/demo");
 
     expect(queryClient.getQueryState(projectQueryKeys.content(projectId, ".spherse/skills/demo/SKILL.md"))?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(projectQueryKeys.content(projectId, "notes/other.md"))?.isInvalidated).toBe(false);
     expect(queryClient.getQueryState(projectQueryKeys.fileTree(projectId))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(projectQueryKeys.directory(projectId, ".spherse/skills"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(projectQueryKeys.directory(projectId, ".spherse/skills/demo"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(projectQueryKeys.directory(projectId, ".spherse/skills/other"))?.isInvalidated).toBe(false);
   });
 });

--- a/packages/app/src/queries/content.ts
+++ b/packages/app/src/queries/content.ts
@@ -10,12 +10,16 @@ function directoryQueryOptions(projectId: string, client: ApiClient, dirPath: st
   };
 }
 
-export function useProjectDirectory(projectId: string, client: ApiClient, dirPath: string) {
-  return useQuery(directoryQueryOptions(projectId, client, dirPath));
-}
-
-export function fetchProjectDirectory(projectId: string, client: ApiClient, dirPath: string) {
-  return queryClient.fetchQuery(directoryQueryOptions(projectId, client, dirPath));
+export function useProjectDirectory(
+  projectId: string,
+  client: ApiClient,
+  dirPath: string,
+  options?: { enabled?: boolean },
+) {
+  return useQuery({
+    ...directoryQueryOptions(projectId, client, dirPath),
+    enabled: options?.enabled,
+  });
 }
 
 export function useProjectFileTree(projectId: string, client: ApiClient) {
@@ -38,22 +42,44 @@ export function contentKeyMatchesChangedPath(
   return filePath === changedPath || filePath.startsWith(`${changedPath}/`);
 }
 
+function parentDirOf(path: string): string {
+  const idx = path.lastIndexOf("/");
+  return idx === -1 ? "" : path.slice(0, idx);
+}
+
+export function directoryKeyMatchesChangedPath(
+  queryKey: readonly unknown[],
+  projectId: string,
+  changedPath: string,
+): boolean {
+  if (queryKey[0] !== "projects" || queryKey[1] !== projectId || queryKey[2] !== "directories") {
+    return false;
+  }
+  const dirPath = queryKey[3];
+  if (typeof dirPath !== "string") return false;
+  if (dirPath === changedPath || dirPath.startsWith(`${changedPath}/`)) return true;
+  return dirPath === parentDirOf(changedPath);
+}
+
 export async function invalidateProjectFileQueries(projectId: string, changedPath?: string): Promise<void> {
   const invalidations: Promise<void>[] = [];
   if (changedPath) {
     const normalizedPath = changedPath.replace(/\\/g, "/");
     invalidations.push(
       queryClient.invalidateQueries({
-        predicate: (query) => contentKeyMatchesChangedPath(query.queryKey, projectId, normalizedPath),
+        predicate: (query) =>
+          contentKeyMatchesChangedPath(query.queryKey, projectId, normalizedPath) ||
+          directoryKeyMatchesChangedPath(query.queryKey, projectId, normalizedPath),
       }),
     );
   } else {
     invalidations.push(queryClient.invalidateQueries({
       queryKey: ["projects", projectId, "content"],
+    }), queryClient.invalidateQueries({
+      queryKey: projectQueryKeys.directories(projectId),
     }));
   }
   invalidations.push(
-    queryClient.invalidateQueries({ queryKey: projectQueryKeys.directories(projectId) }),
     queryClient.invalidateQueries({ queryKey: projectQueryKeys.fileTree(projectId) }),
   );
   await Promise.all(invalidations);

--- a/packages/desktop/e2e/file-tree.spec.ts
+++ b/packages/desktop/e2e/file-tree.spec.ts
@@ -205,6 +205,32 @@ test("delete a file via context menu and confirm", async () => {
   }
 });
 
+test("delete an expanded directory removes it with its subtree", async () => {
+  const project = await createFileTreeProject();
+  const { app, page } = await launchFileTreeApp(project);
+
+  try {
+    await treeButton(page, "src").click();
+    await treeButton(page, "components").click();
+    await expect(treeButton(page, "ui")).toBeVisible();
+
+    await treeButton(page, "src").click({ button: "right" });
+    await page.getByRole("menuitem", { name: "删除" }).click();
+
+    const dialog = page.locator('[role="alertdialog"]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("src");
+
+    await dialog.getByRole("button", { name: "删除" }).click();
+    await expect(dialog).not.toBeVisible();
+
+    await expect(treeButton(page, "src")).not.toBeVisible({ timeout: 5000 });
+    await expect(treeButton(page, "components")).not.toBeVisible();
+  } finally {
+    await app.close();
+  }
+});
+
 test("cancel deletion via alert dialog", async () => {
   const project = await createFileTreeProject();
   const { app, page } = await launchFileTreeApp(project);


### PR DESCRIPTION
## 概要

实施 `docs/dev/infra/2026-08-22-frontend-architecture-followup/followup.md` 的 P1 条目「文件树改为目录 Query + expandedPaths」：删除文件树的递归本地状态树与 merge helpers，目录数据全走 TanStack Query，本地只保存交互状态。

- **Query 层**：`invalidateProjectFileQueries` 对 directory keys 从全量失效改为 predicate 精准失效（变更对象本身 + 后代 + 直接父目录）；`useProjectDirectory` 支持 `enabled`。fs-watch / agent 写文件期间不再触发所有已展开目录的串行全量重取
- **模型层**：`tree-model.ts` 重写为纯数据（`TreeItem` / `DeleteTarget` / `buildTreeItems` / `parentDirPath`），删除 `TreeNode` / `buildNodes` / `updateNode` / `mergeExpandedState` / `mergeRefreshedTree`
- **Controller**：`useFileTreeController` 只保存 `expandedPaths` Set + `creating` + `deleteTarget`，删除递归 `refreshExpanded` 与双份遍历；projectId 切换时重置交互状态；删除成功后才清理展开态
- **组件层**：每个目录节点组件自持 `useProjectDirectory({ enabled: expanded })`，折叠即卸载退订；首次展开显示 loading；`FileTreeProps` 对外契约零变化（user-file-panel / skill-panel 无需改动）

Design doc：`docs/dev/infra/2026-08-28-file-tree-directory-queries/design.md`

## 测试

- 单测：`tree-model.test.ts` 重写；`content.test.ts` 补 directory predicate 7 用例（父目录/后代/兄弟前缀/跨项目/反斜杠归一化）与精准失效集成断言；app 全量 1046 用例通过
- E2E：`e2e/file-tree.spec.ts` 11/11（新增「删除已展开目录」复合用例）；`e2e/floating-content-browser.spec.ts` 7/7（覆盖文件树 float 菜单）
- lint / build / typecheck 全过；已 rebase 到最新 origin/dev（#48 / #49）后复验
