### PR TITLE
infra: 项目生命周期编排收敛——closeProjectCascade + ProjectRuntimeBridges + streaming 关闭断开

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -13,6 +13,7 @@
 - [ ] **`data-chat-root` 伪元素偏移防御**：`[data-chat-root]`（`features/chat/index.tsx`）同样是 `flex flex-col` 容器，用户在 agent theme 写 `::before/::after` 漏 `position` 时会同样挤压聊天列导致偏移。但 chat-root 默认非定位上下文，不能直接照搬 `data-app-root` 的 `position: absolute` 默认值（否则伪元素会逃逸到最近的定位祖先 `data-app-root`）。需先把 chat-root 设为定位上下文（如加 `position: relative`），再在 base styles 给 `[data-chat-root]::before/::after` 加同款 `position: absolute; pointer-events: none` 默认值，并同步 `spherse-create-agent-chat-theme` skill 文档。
 - [ ] **chat 错误分类兜底 TRANSIENT 的收敛**：服务端 `classify-run-error.ts` 与 renderer `classify-error.ts` 对未知错误都兜底 TRANSIENT——程序性错误（TypeError、内部 bug）也被标为可重试类。前端自动重试已移除（bd58e1e），误分类现仅影响错误展示，但手动 retry-last 会重新执行副作用工具，误分类仍会诱导用户重试。方向：不可重试类（ValidationError 文案等）前置排除，双端规则保持一致。
 - [ ] **恢复 Windows 自动更新 feed（latest.yml，双 arch）**：CI 自 OSS 镜像改造（ba8c049）起统一 `--publish never` + `gh release upload`，release 上不再有 `latest.yml`，Windows 客户端 electron-updater 检查更新因 404 报 `update-error`。恢复需研究多 arch 语义：一个 `latest.yml` 只指向一个安装包，x64 与 arm64 需按 electron-updater 的 channel 文件约定（如 `latest.yml` / `latest-arm64.yml`）分别生成并上传，避免 arm64 设备被推 x64 包（或反向）。可考虑在 `publish-oss` 或 build job 中集中生成。
+- [ ] **refreshProjects 路径不回收 streaming runtime**：外部关闭/多窗口场景下项目从快照消失时，`app-store.refreshProjects` 只改 projects map，不走 `closeProjectCascade`，该项目 chat streaming runtime（WS + 重连定时器）仍存活。受「全局 store 不得依赖 feature-local store」约束，修复需 streaming runtime 生命周期整体重构，宜与 followup P1「移除 streaming/trigger 镜像」合并考虑。参见 `docs/dev/infra/2026-08-28-project-lifecycle-orchestration/design.md` 已知缺口
 
 ## 技术债（重构与收敛）
 
@@ -31,6 +32,7 @@
 - [ ] **server 契约缺口修复（4 处）**：① `POST /attachments` 响应无 schema——renderer 在 `api.ts` 本地另定义 `attachmentUploadResponse` 手工校验，契约应上收到 contracts；② `DELETE /attachments` body 无 schema 无 parseContract；③ `images/export` body schema 内联手写，未进 contracts；④ agent 级 `GET .../agents/:agentId/sessions` 整路由无 schema（无 limit 分支返回裸 `listSessions()`）。四处均违反 server README「所有 JSON route 绑定机制 1（Fastify schema option）」规则；修复时补 contract 或在 README 豁免清单显式登记取舍。
 - [ ] **安全语义对齐（三项决策 + 落地）**：① `.spherse` 未分类文件（`spherseOther`）LLM 可读——`LLM_READ` 白名单包含该类别且有测试钉住（`access-policy.test.ts`），与「避免内部数据泄漏」的最初意图相悖，需决策收紧为不可读或接受现状并改测试意图注释；② `memory_save`/`memory_recall` 直连 MemoryStore 完全不经 access policy——用户 deny `.spherse` 后 memory 持久化照常工作，与文档曾声称的「安全优先语义」不符，需决策是否让 memory 工具走 policy 或显式豁免；③ `manage_project_config` 的 `update_welcome_page` 是写操作且 UI 归入高级工具组，但 core 层未包 `withApproval`（与 run_command/manage_agent/manage_trigger 的「高级写操作经审批」模式不一致），yolo 警示文案也未提及它——需决策补审批或在文档/文案中显式声明豁免取舍。
 - [ ] **跨层接缝契约清单对账**：SessionPort 5 方法（create/restore/sendMessage/abortSession/sessionExists）在 server/desktop 包的契约覆盖缺口逐条对账（trigger 路径、ws-chat 路径），按 AGENTS.md 契约规矩补齐。
+- [ ] **项目关闭路径 E2E 缺口**：无 spec 覆盖 activity-bar 关闭项目 → `closeProjectCascade` 级联清理（streaming 断开、query cache 清除、再打开同名项目状态干净）。级联清理现仅由单测锁住；补 E2E 时可用 mock agent 制造 streaming 中关闭场景。
 
 ## 条件触发（设计决策）
 

--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -32,7 +32,6 @@
 - [ ] **server 契约缺口修复（4 处）**：① `POST /attachments` 响应无 schema——renderer 在 `api.ts` 本地另定义 `attachmentUploadResponse` 手工校验，契约应上收到 contracts；② `DELETE /attachments` body 无 schema 无 parseContract；③ `images/export` body schema 内联手写，未进 contracts；④ agent 级 `GET .../agents/:agentId/sessions` 整路由无 schema（无 limit 分支返回裸 `listSessions()`）。四处均违反 server README「所有 JSON route 绑定机制 1（Fastify schema option）」规则；修复时补 contract 或在 README 豁免清单显式登记取舍。
 - [ ] **安全语义对齐（三项决策 + 落地）**：① `.spherse` 未分类文件（`spherseOther`）LLM 可读——`LLM_READ` 白名单包含该类别且有测试钉住（`access-policy.test.ts`），与「避免内部数据泄漏」的最初意图相悖，需决策收紧为不可读或接受现状并改测试意图注释；② `memory_save`/`memory_recall` 直连 MemoryStore 完全不经 access policy——用户 deny `.spherse` 后 memory 持久化照常工作，与文档曾声称的「安全优先语义」不符，需决策是否让 memory 工具走 policy 或显式豁免；③ `manage_project_config` 的 `update_welcome_page` 是写操作且 UI 归入高级工具组，但 core 层未包 `withApproval`（与 run_command/manage_agent/manage_trigger 的「高级写操作经审批」模式不一致），yolo 警示文案也未提及它——需决策补审批或在文档/文案中显式声明豁免取舍。
 - [ ] **跨层接缝契约清单对账**：SessionPort 5 方法（create/restore/sendMessage/abortSession/sessionExists）在 server/desktop 包的契约覆盖缺口逐条对账（trigger 路径、ws-chat 路径），按 AGENTS.md 契约规矩补齐。
-- [ ] **项目关闭路径 E2E 缺口**：无 spec 覆盖 activity-bar 关闭项目 → `closeProjectCascade` 级联清理（streaming 断开、query cache 清除、再打开同名项目状态干净）。级联清理现仅由单测锁住；补 E2E 时可用 mock agent 制造 streaming 中关闭场景。
 
 ## 条件触发（设计决策）
 

--- a/docs/dev/infra/2026-08-22-frontend-architecture-followup/followup.md
+++ b/docs/dev/infra/2026-08-22-frontend-architecture-followup/followup.md
@@ -35,7 +35,7 @@ PR #24 已完成第一阶段状态边界收敛：
 | P1 | 移除 streaming/trigger 镜像 | 消除跨 store 手工同步 | 下次修改 SessionRow/AgentRow 状态来源 |
 | P1 | 标准化 React mutation hooks | 统一 pending/error/乐观更新 | 出现第二个需要 mutation 状态的消费方 |
 | P2 | 迁移 dialog 服务端状态 | 删除 load-on-open effect 模板 | 逐个 dialog 功能修改时顺带迁移 |
-| P2 | 收敛项目级 bridge | 控制 ProjectScope 基础设施膨胀 | bridge 数量继续增长时 |
+| P2 | 收敛项目级 bridge（已实施，见 `2026-08-28-project-lifecycle-orchestration/design.md`，同 PR 一并修复关闭项目不断开 streaming runtime 的泄漏并收敛关闭级联清理） | 控制 ProjectScope 基础设施膨胀 | bridge 数量继续增长时 |
 | P2 | 建立组件测试基础设施 | 提升交互与 Query 边界测试质量 | 开始批量补组件测试时 |
 
 ## P0：拆分聚合查询
@@ -286,6 +286,8 @@ useCreateAgentMutation()
 ```
 
 该组件仅负责挂载自治 bridge，不成为新事件总线或 service locator。
+
+> 已实施（2026-08-28）：见 `2026-08-28-project-lifecycle-orchestration/design.md`。触发条件由 ThemeQueryBridge + WelcomePageQueryBridge 满足；同 PR 补齐 `closeProjectCascade` 级联清理与 streaming runtime 关闭断开。
 
 ## P2：组件测试基础设施
 

--- a/docs/dev/infra/2026-08-28-project-lifecycle-orchestration/design.md
+++ b/docs/dev/infra/2026-08-28-project-lifecycle-orchestration/design.md
@@ -109,7 +109,7 @@ export async function closeProjectCascade(
 
 - 单测：streaming-store `disconnectProject`（断开目标项目全部 runtime、不影响其他项目、streaming 中的 session 也被断开且不再重连）；structure tests（清理面扫描、bridge 组件纯挂载）；cascade 行为测试（成功清理全表面、host close 失败时本地状态不动）；app-store `closeProject`（setLastActiveProject 失败仍完成本地删除）
 - 既有测试回归：`npm test --workspace=packages/app`
-- E2E：当前无直接覆盖项目关闭的 spec；按变更影响面运行 `app-launch`（layout 挂载/项目恢复）、`chat-streaming-resilience`（streaming store）、`floating-chat`（经 ProjectRuntimeBridges 挂载）。项目关闭路径的 E2E 缺口记录到 backlog
+- E2E：`project-close.spec.ts`——streaming 中经 activity bar 关闭项目断开 chat runtime（WS mock 计数断言无重连）、关闭后 reload 不再恢复项目且 lastRoute 已清、重开项目落到欢迎页；另按变更影响面运行 `app-launch`、`chat-streaming-resilience`、`floating-chat`
 
 ## 验收标准（对齐 followup doc）
 

--- a/docs/dev/infra/2026-08-28-project-lifecycle-orchestration/design.md
+++ b/docs/dev/infra/2026-08-28-project-lifecycle-orchestration/design.md
@@ -1,0 +1,119 @@
+# [Infra] 项目级生命周期编排收敛
+
+## 背景
+
+`docs/dev/infra/2026-08-22-frontend-architecture-followup/followup.md` P2「收敛项目级 Bridge」的触发条件（新增两个以上项目级 bridge）已满足：`ProjectScope` 现挂载 5 个 bridge（UiSdk / TriggerEvent / ContentQuery / ThemeQuery / WelcomePage）+ 3 个 FeatureGate manager（FloatingChat / FloatingContentBrowser / Browser）+ 3 个项目级 hook 与 2 个 useEffect。
+
+同时项目关闭清理链落在 `features/activity-bar/use-project-actions.ts` 的 `handleCloseProject` 中，手工编排 8 个清理调用。`packages/app/README.md` 写明「关闭项目时，由编排层显式清理所有 per-project store 和 query cache」，但该编排层实际不存在：每新增一个 per-project store 都必须记得修改 activity-bar 的 hook，且该 hook 是 feature 层代码承担 app 级编排职责。此外 `lib/use-project-navigation.ts` 的模块级 `projectNavStacks` Map 属于 per-project 状态但不在任何清理面中，关闭后永不释放。
+
+清理链还存在一个正确性缺陷：**关闭项目不断开该项目的 streaming runtime**。`cleanupExpired` 的守卫 `!session.streaming` 使仍在 streaming 的 session 永不清理，其 WebSocket 与重连定时器持续存活；且后续事件回写 `setStreaming` 会在 `project-data-store` 中重建已清除的项目条目（`updateProjectData` 对不存在的项目会创建）。
+
+## 目标
+
+- 项目关闭的全部级联清理收敛为单一入口 `closeProjectCascade`，调用方（当前仅 activity-bar）只保留导航与 toast 等 UI 关注点
+- 关闭项目时同步断开该项目全部 streaming runtime（WebSocket、重连/心跳/探测定时器）
+- `ProjectScope` 回归纯布局：bridge 与 manager 挂载收敛到 `<ProjectRuntimeBridges />`（followup P2 原方案）
+- 新增 per-project store 时，structure test 强制其在 cascade 清理面中出现，消除「记得来加一行」的隐式契约
+
+## 非目标
+
+- 不改 server API 与 host bridge 契约
+- 不做 session detail cache 统一、streaming/trigger 镜像移除（followup P0/P1 独立推进）
+- 不引入 store 注册表、事件总线或 service locator：cascade 使用显式清理清单（followup 红线「不把多个 bridge 合成新的全局事件总线」）
+- 不改 streaming TTL 缓存策略（未关闭项目仍保留 5 分钟空闲缓存）
+- 不处理「关闭项目时正在 streaming 的会话的服务端侧终止」——服务端随项目关闭自会回收，本变更只保证客户端不再持有连接
+
+## 方案
+
+### 1. streaming 泄漏修复（先行，独立可交付）
+
+`useStreamingStore` 新增 action：
+
+```ts
+disconnectProject(projectId: string): void
+```
+
+遍历 `state.sessions` 中 `session.projectId === projectId` 的条目，逐个调用现有 `disconnect(sessionId)`（含 runtime dispose、eventQueue 清理、空闲定时器回收；跨项目仍有 session 时全局清理定时器按现状保留）。
+
+顺序安全性依据：`ChatSessionRuntime.dispose()` 先置 `manuallyClosed = true`、清空全部定时器、将 `this.ws` 置 null 再 `close()`；`ws.onclose` / `ws.onmessage` / `reconcileHistory` 异步回溯均有 `this.ws !== ws` 或 `!getSession()` 守卫早退——**dispose 之后无任何回调写入 store**，因此 cascade 中 disconnect 之后的清理不会出现迟到写入。
+
+### 2. `closeProjectCascade`
+
+新文件 `packages/app/src/layouts/project-lifecycle.ts`（README 已规定 layouts 承担「项目生命周期编排」，依赖方向 layouts → stores/queries 合法）：
+
+```ts
+export async function closeProjectCascade(
+  bridge: HostBridge,
+  projectId: string,
+): Promise<string | null>
+```
+
+清理顺序：
+
+1. `useAppStore.getState().closeProject(bridge, projectId)` —— host 侧关闭 + projects map 删除 + 计算 nextProjectId（不变）。**置于最前**：失败直接抛出，本地状态完全不动（与现状一致）；若先做本地清理而 host 关闭失败，会出现「项目仍打开但 chat session 已全部从 store 删除且 attach effect 不重跑」的部分态
+2. `useStreamingStore.getState().disconnectProject(projectId)` —— host 关闭成功后立即断开事件源，后续清理期间无写入方
+3. `clearProjectQueries(projectId)` —— generation +1、cancel、remove（不变）
+4. 逐个 per-project store 清理：`useAgentSessionListUiStore` / `useTriggerStore` / `useFloatingChatStore` / `useFloatingContentBrowserStore` / `useBrowserStore` 的 `clearProject`
+5. `useProjectDataStore.getState().clearProjectData(projectId)`
+6. `clearProjectNavHistory(projectId)`（`lib/use-project-navigation.ts` 新导出；模块级 `projectNavStacks` Map 当前永不清理）
+7. `clearLastRoute(projectId)`
+
+返回值与现有 `app-store.closeProject` 一致（nextProjectId），导航留在调用方。
+
+`use-project-actions.ts` 的 `handleCloseProject` 改为调用 cascade + 导航；删除对逐个清理函数的直接依赖。
+
+### 3. `<ProjectRuntimeBridges />`
+
+新文件 `packages/app/src/layouts/ProjectRuntimeBridges.tsx`，仅负责挂载（无 state、无 effect、无 props），**返回 fragment 不引入包装元素**（当前 8 个挂载点是 ProjectScope flex 容器的直接子节点，包 div 会改变布局树）：
+
+- 3 个 FeatureGate manager：FloatingChatManager / FloatingContentBrowserManager / BrowserManager
+- 5 个 bridge：UiSdkBridge / TriggerEventBridge / ContentQueryBridge / ThemeQueryBridge / WelcomePageQueryBridge
+
+`ProjectScope` 渲染 `<ProjectRuntimeBridges />` 替代上述 8 个挂载点与对应 import。
+
+### 4. structure test 防漏
+
+`layouts/project-lifecycle.structure.test.ts`：
+
+- fs 递归遍历 `packages/app/src` 全部 `.ts` 源文件（跳过 `.test.ts`），按 `create<...Store>(` 定义识别 store 文件——不依赖「store 必须在特定路径」的命名约定，未来 `stores/sub/` 或 feature 内多级目录均可覆盖；凡 store 文件内定义了 `clearProject` / `clearProjectData` action 的，其导出的 `useXxxStore` 标识符必须出现在 `project-lifecycle.ts` 源码中
+- 断言 cascade 源码包含 `disconnectProject`、`clearProjectQueries`、`clearProjectNavHistory`、`clearLastRoute`（streaming / query / nav 栈 / localStorage 四个非 store action 清理面）
+- 同步更新 `ProjectScope.structure.test.ts`：`<UiSdkBridge />` 断言迁移为 `<ProjectRuntimeBridges />`
+
+新增 `ProjectRuntimeBridges.structure.test.ts`：断言组件源码不含 `useState` / `useEffect`（仅挂载，不成为逻辑汇聚点），且返回 fragment（不含 JSX 包装元素）。
+
+### 已知取舍
+
+- structure test 基于源码文本扫描而非 AST：对「一个文件定义多个 store」等特殊形态覆盖不足；当前仓库所有 per-project store 均为一文件一 store，文本断言足够，误报优于漏报
+- 显式清单仍是手工维护：test 保证「定义了 clearProject 的 store 不被遗漏」，但不强制新 store 必须提供 clearProject；由 README 既有规范与 review 保证
+- 迟到写入的保护机制按层区分：session mutations 由 generation 拦截（`queries/project/sessions.ts`）；agent mutations 无 generation，靠 invalidate-no-op 兜底；bridge 事件（如 trigger）由 unmount 截断。`clearProjectQueries` 与 navigate 之间 TriggerEventBridge 仍挂载的极小窗口内，trigger 事件可为已清项目重建 byProject 条目并残留到下次打开——可接受，随 followup P1 镜像移除整体消除
+- `app-store.refreshProjects`（外部关闭/多窗口导致项目从快照消失）不走 cascade，该路径下 streaming runtime 仍可能泄漏：受「全局 store 不得依赖 feature-local store」红线约束，修复需 streaming runtime 生命周期整体重构（与 followup P1 镜像移除合并考虑），本设计记为已知缺口
+- Composer 草稿 localStorage key `spherse:draft:{sessionId}` 为 per-session key，无法由 projectId 枚举清理，项目关闭后残留——已知缺口，无正确性影响
+- cascade 内错误直接抛出与 `app-store.closeProject` 现行为一致；host 关闭成功后的本地清理均为同步纯内存操作，无中间失败态
+
+## 影响文件
+
+| 文件 | 变更 |
+|---|---|
+| `packages/app/src/features/chat/runtime/streaming-store.ts` | 新增 `disconnectProject` |
+| `packages/app/src/features/chat/runtime/streaming-store.test.ts` | 新增 disconnectProject 用例 |
+| `packages/app/src/layouts/project-lifecycle.ts` | 新增 cascade |
+| `packages/app/src/layouts/project-lifecycle.structure.test.ts` | 新增清理面扫描测试 |
+| `packages/app/src/layouts/ProjectRuntimeBridges.tsx` | 新增 bridge 收敛组件 |
+| `packages/app/src/layouts/ProjectRuntimeBridges.structure.test.ts` | 新增挂载结构测试 |
+| `packages/app/src/layouts/ProjectScope.tsx` | 移除 8 个挂载点，渲染 ProjectRuntimeBridges |
+| `packages/app/src/layouts/ProjectScope.structure.test.ts` | 断言更新 |
+| `packages/app/src/lib/use-project-navigation.ts` | 新增 `clearProjectNavHistory` 导出 |
+| `packages/app/src/features/activity-bar/use-project-actions.ts` | handleCloseProject 改用 cascade |
+
+## 测试计划
+
+- 单测：streaming-store `disconnectProject`（断开目标项目全部 runtime、不影响其他项目、空闲定时器回收）；structure tests（清理面扫描、bridge 组件纯挂载）
+- 既有测试回归：`npm test --workspace=packages/app`
+- E2E：项目关闭路径相关 spec（`npm run test:e2e --workspace=packages/desktop -- -g "project"`），重点验证关闭含正在 streaming 会话的项目后无残留连接、再打开同名项目状态干净
+
+## 验收标准（对齐 followup doc）
+
+- `ProjectScope` 不再直接挂载任何 bridge / manager
+- 项目关闭的级联清理只有一个入口；activity-bar 不再 import 任何 store 清理函数
+- 关闭项目后该项目无存活 streaming runtime；`project-data-store` 不再被关闭后的项目重建条目
+- 所有定义 `clearProject` 的 store 被 structure test 覆盖

--- a/docs/dev/infra/2026-08-28-project-lifecycle-orchestration/design.md
+++ b/docs/dev/infra/2026-08-28-project-lifecycle-orchestration/design.md
@@ -88,7 +88,7 @@ export async function closeProjectCascade(
 - 迟到写入的保护机制按层区分：session mutations 由 generation 拦截（`queries/project/sessions.ts`）；agent mutations 无 generation，靠 invalidate-no-op 兜底；bridge 事件（如 trigger）由 unmount 截断。`clearProjectQueries` 与 navigate 之间 TriggerEventBridge 仍挂载的极小窗口内，trigger 事件可为已清项目重建 byProject 条目并残留到下次打开——可接受，随 followup P1 镜像移除整体消除
 - `app-store.refreshProjects`（外部关闭/多窗口导致项目从快照消失）不走 cascade，该路径下 streaming runtime 仍可能泄漏：受「全局 store 不得依赖 feature-local store」红线约束，修复需 streaming runtime 生命周期整体重构（与 followup P1 镜像移除合并考虑），本设计记为已知缺口
 - Composer 草稿 localStorage key `spherse:draft:{sessionId}` 为 per-session key，无法由 projectId 枚举清理，项目关闭后残留——已知缺口，无正确性影响
-- cascade 内错误直接抛出与 `app-store.closeProject` 现行为一致；host 关闭成功后的本地清理均为同步纯内存操作，无中间失败态
+- cascade 内错误直接抛出与 `app-store.closeProject` 现行为一致；`closeProject` 中的 `setLastActiveProject` 为 hint 性持久化，失败时仅 warn 不中断（否则该 host await 点失败会使本地清理全跳过、泄漏以新路径复发），「host 关闭成功后的本地清理均为同步纯内存操作，无中间失败态」由此成立
 
 ## 影响文件
 
@@ -107,9 +107,9 @@ export async function closeProjectCascade(
 
 ## 测试计划
 
-- 单测：streaming-store `disconnectProject`（断开目标项目全部 runtime、不影响其他项目、空闲定时器回收）；structure tests（清理面扫描、bridge 组件纯挂载）
+- 单测：streaming-store `disconnectProject`（断开目标项目全部 runtime、不影响其他项目、streaming 中的 session 也被断开且不再重连）；structure tests（清理面扫描、bridge 组件纯挂载）；cascade 行为测试（成功清理全表面、host close 失败时本地状态不动）；app-store `closeProject`（setLastActiveProject 失败仍完成本地删除）
 - 既有测试回归：`npm test --workspace=packages/app`
-- E2E：项目关闭路径相关 spec（`npm run test:e2e --workspace=packages/desktop -- -g "project"`），重点验证关闭含正在 streaming 会话的项目后无残留连接、再打开同名项目状态干净
+- E2E：当前无直接覆盖项目关闭的 spec；按变更影响面运行 `app-launch`（layout 挂载/项目恢复）、`chat-streaming-resilience`（streaming store）、`floating-chat`（经 ProjectRuntimeBridges 挂载）。项目关闭路径的 E2E 缺口记录到 backlog
 
 ## 验收标准（对齐 followup doc）
 

--- a/docs/dev/infra/2026-08-28-project-lifecycle-orchestration/plan.md
+++ b/docs/dev/infra/2026-08-28-project-lifecycle-orchestration/plan.md
@@ -1,11 +1,12 @@
 # Plan
 
-- [ ] 1. `streaming-store` 新增 `disconnectProject(projectId)` + 单测
-- [ ] 2. `lib/use-project-navigation.ts` 新增 `clearProjectNavHistory(projectId)`
-- [ ] 3. 新增 `layouts/project-lifecycle.ts`：`closeProjectCascade`（app-store close，失败即抛不动本地 → disconnectProject → clearProjectQueries → 5 个 feature store clearProject → clearProjectData → clearProjectNavHistory → clearLastRoute）
-- [ ] 4. `use-project-actions.ts` 的 `handleCloseProject` 改调 cascade，移除直接清理依赖
-- [ ] 5. 新增 `layouts/ProjectRuntimeBridges.tsx`（fragment：3 manager + 5 bridge），`ProjectScope` 改为渲染该组件
-- [ ] 6. 新增 `project-lifecycle.structure.test.ts`（递归扫描 `create<...Store>(` 定义的 store 文件，定义 `clearProject`/`clearProjectData` 的必须出现在 cascade 源码；断言四个非 store 清理面）与 `ProjectRuntimeBridges.structure.test.ts`；更新 `ProjectScope.structure.test.ts`
-- [ ] 7. 回归：`npm test --workspace=packages/app`、lint、typecheck、项目关闭相关 E2E
+- [x] 1. `streaming-store` 新增 `disconnectProject(projectId)` + 单测
+- [x] 2. `lib/use-project-navigation.ts` 新增 `clearProjectNavHistory(projectId)`
+- [x] 3. 新增 `layouts/project-lifecycle.ts`：`closeProjectCascade`（app-store close，失败即抛不动本地 → disconnectProject → clearProjectQueries → 5 个 feature store clearProject → clearProjectData → clearProjectNavHistory → clearLastRoute）
+- [x] 4. `use-project-actions.ts` 的 `handleCloseProject` 改调 cascade，移除直接清理依赖
+- [x] 5. 新增 `layouts/ProjectRuntimeBridges.tsx`（fragment：3 manager + 5 bridge），`ProjectScope` 改为渲染该组件
+- [x] 6. 新增 `project-lifecycle.structure.test.ts`（递归扫描 `create<...Store>(` 定义的 store 文件，定义 `clearProject`/`clearProjectData` 的必须出现在 cascade 源码；断言四个非 store 清理面）与 `ProjectRuntimeBridges.structure.test.ts`；更新 `ProjectScope.structure.test.ts`
+- [x] 7. 回归：`npm test --workspace=packages/app`、lint、typecheck、项目关闭相关 E2E
 - [ ] 8. doc-sync：`packages/app/README.md` 编排层现状、followup P2 状态、`docs/official/project-structure.md`、backlog
+
 

--- a/docs/dev/infra/2026-08-28-project-lifecycle-orchestration/plan.md
+++ b/docs/dev/infra/2026-08-28-project-lifecycle-orchestration/plan.md
@@ -7,6 +7,6 @@
 - [x] 5. 新增 `layouts/ProjectRuntimeBridges.tsx`（fragment：3 manager + 5 bridge），`ProjectScope` 改为渲染该组件
 - [x] 6. 新增 `project-lifecycle.structure.test.ts`（递归扫描 `create<...Store>(` 定义的 store 文件，定义 `clearProject`/`clearProjectData` 的必须出现在 cascade 源码；断言四个非 store 清理面）与 `ProjectRuntimeBridges.structure.test.ts`；更新 `ProjectScope.structure.test.ts`
 - [x] 7. 回归：`npm test --workspace=packages/app`、lint、typecheck、项目关闭相关 E2E
-- [ ] 8. doc-sync：`packages/app/README.md` 编排层现状、followup P2 状态、`docs/official/project-structure.md`、backlog
+- [x] 8. doc-sync：`packages/app/README.md` 编排层现状、followup P2 状态、`docs/official/project-structure.md`、backlog
 
 

--- a/docs/dev/infra/2026-08-28-project-lifecycle-orchestration/plan.md
+++ b/docs/dev/infra/2026-08-28-project-lifecycle-orchestration/plan.md
@@ -1,0 +1,11 @@
+# Plan
+
+- [ ] 1. `streaming-store` 新增 `disconnectProject(projectId)` + 单测
+- [ ] 2. `lib/use-project-navigation.ts` 新增 `clearProjectNavHistory(projectId)`
+- [ ] 3. 新增 `layouts/project-lifecycle.ts`：`closeProjectCascade`（app-store close，失败即抛不动本地 → disconnectProject → clearProjectQueries → 5 个 feature store clearProject → clearProjectData → clearProjectNavHistory → clearLastRoute）
+- [ ] 4. `use-project-actions.ts` 的 `handleCloseProject` 改调 cascade，移除直接清理依赖
+- [ ] 5. 新增 `layouts/ProjectRuntimeBridges.tsx`（fragment：3 manager + 5 bridge），`ProjectScope` 改为渲染该组件
+- [ ] 6. 新增 `project-lifecycle.structure.test.ts`（递归扫描 `create<...Store>(` 定义的 store 文件，定义 `clearProject`/`clearProjectData` 的必须出现在 cascade 源码；断言四个非 store 清理面）与 `ProjectRuntimeBridges.structure.test.ts`；更新 `ProjectScope.structure.test.ts`
+- [ ] 7. 回归：`npm test --workspace=packages/app`、lint、typecheck、项目关闭相关 E2E
+- [ ] 8. doc-sync：`packages/app/README.md` 编排层现状、followup P2 状态、`docs/official/project-structure.md`、backlog
+

--- a/docs/official/architecture/frontend.md
+++ b/docs/official/architecture/frontend.md
@@ -64,13 +64,14 @@ renderer 单份代码、宿主差异经此接口抽象的决策见 [ADR-0006](..
 | useAgentBusRefresh（hook） | agent | agent_updated 刷 agents；created / deleted 加刷 sessions |
 | UiSdkBridge（event 桥） | fs-watch | 变更事件 debounce 后定向转发给订阅的 iframe（见 [ui-sdk.md](ui-sdk.md)） |
 
-- 纯失效桥挂 ProjectScope；带运行态的域（trigger）用专属桥；跨会话 toast（ApprovalNoticeBridge，订阅 streaming-store）与自动更新 toast（UpdateNoticeBridge，订阅 host-bridge updater 事件）挂 App 级
+- 项目级桥统一挂 `ProjectRuntimeBridges`（ProjectScope 内的纯挂载 fragment：3 个 FeatureGate manager + 5 个 bridge）；带运行态的域（trigger）用专属桥；跨会话 toast（ApprovalNoticeBridge，订阅 streaming-store）与自动更新 toast（UpdateNoticeBridge，订阅 host-bridge updater 事件）挂 App 级
 - **重连补偿**：bus 重连置 `resumedAt`，各桥经 `useReconnectedSync` 批量失效缓存——错过的事件不重放，靠失效重拉对齐
 - App 级补偿：重连后 refreshProjects；路由指向已消失项目时重定向
 
 ## 项目生命周期
 
-- closeProject 编排链（`use-project-actions.ts`）：clearProjectData → clearProjectQueries → 各 feature store `clearProject` → clearLastRoute——per-project 状态全部显式清理
+- 项目关闭级联清理单一入口 `closeProjectCascade`（`layouts/project-lifecycle.ts`，调用方 `use-project-actions.ts` 只保留导航/toast）：app-store `closeProject`（host 侧关闭，失败即抛、本地不动）→ streaming `disconnectProject`（断开该项目全部 chat runtime）→ `clearProjectQueries` → 各 feature store `clearProject` → `clearProjectData` → `clearProjectNavHistory` → `clearLastRoute`
+- 清理面为显式清单，`project-lifecycle.structure.test.ts` 递归扫描全部定义 `clearProject` action 的 store 强制其出现在 cascade 中——新增 per-project store 必须定义 `clearProject` 并纳入清单；不做注册表/事件总线
 - projectId 全链路一致：URL param → ProjectContext（`useProjectCtx`）→ query key → localStorage key 后缀 → bus 订阅 key
 - 依赖注入：`ProjectContext` 注入稳定只读的 projectId / projectRoot；`useConnection()` 返回 connection 本体，`useApiClient(projectId)` 从 connection 派生 ApiClient
 
@@ -81,7 +82,7 @@ renderer 单份代码、宿主差异经此接口抽象的决策见 [ADR-0006](..
   - 内容与浏览：content-browser、browser、welcome-page、text-selection-session
   - 会话：chat、floating-chat、floating-content-browser
   - 应用级：settings、project-settings、onboarding、debug-tools
-- `layouts/` 仅 `ProjectScope`：项目生命周期编排 + 桥挂载；跨 feature 编排放 layout 或自治 bridge
+- `layouts/`：`ProjectScope`（项目工作区 layout route）+ `ProjectRuntimeBridges`（项目级桥挂载）+ `project-lifecycle.ts`（项目关闭级联清理）；跨 feature 编排放 layout 或自治 bridge
 - `components/` 收 shadcn/ui 与跨 feature 复用组件；两个可复用子系统：
   - `file-tree/`：`FileTree` 支持 rootPath / emptyLabel，user-file-panel 与 skill-panel 共用；目录数据全走 directory query（每个目录节点组件自持 `useProjectDirectory`，`enabled: expanded`），controller 只保存交互状态（expandedPaths / creating / deleteTarget）
   - `floating-frame/`：拖拽 / resize chrome，`hookPrefix` 生成 `data-*-float-*` 主题钩子，三个浮窗 feature 复用

--- a/docs/official/architecture/ui-sdk.md
+++ b/docs/official/architecture/ui-sdk.md
@@ -9,7 +9,7 @@
 SDK 由两半组成，仅以 postMessage 协议耦合：
 
 - **`@spherse/sdk`**（`packages/sdk/`）：被注入 iframe 的客户端运行时，暴露 `window.spherse.*`
-- **`src/ui-sdk/`**（app 内）：host 桥——接收 action、定向分发事件；`UiSdkBridge` 挂 ProjectScope，自治获取 projectId 与 client
+- **`src/ui-sdk/`**（app 内）：host 桥——接收 action、定向分发事件；`UiSdkBridge` 挂 ProjectRuntimeBridges（ProjectScope 内），自治获取 projectId 与 client
 
 ## @spherse/sdk
 

--- a/docs/official/project-structure.md
+++ b/docs/official/project-structure.md
@@ -214,7 +214,9 @@ spherse/
 │   │       │   ├── side-panel-store.ts   # side panel pinned/hover 折叠机制（全局 UI 状态，localStorage 持久化）+ 移动端 mobileOpen 滑出态（与桌面解耦）
 │   │       │   └── bus-store.ts          # 全局多路复用 WebSocket 连接 store
 │   │       ├── layouts/
-│   │       │   └── ProjectScope.tsx      # 项目工作区 layout route（真嵌套路由），挂 ProjectProvider + Outlet 与自治基础设施 bridge，承载项目级生命周期
+│   │       │   ├── ProjectScope.tsx      # 项目工作区 layout route（真嵌套路由），挂 ProjectProvider + Outlet 与项目级 hook
+│   │       │   ├── ProjectRuntimeBridges.tsx # 项目级桥纯挂载 fragment（FeatureGate manager + 各自治 bridge）
+│   │       │   └── project-lifecycle.ts  # closeProjectCascade：项目关闭级联清理单一入口（structure test 强制清理面完整）
 │   │       ├── hooks/
 │   │       │   ├── useSidePanel.ts       # side panel pinned/hover/mobileOpen 状态合并派生 + clickAway props
 │   │       │   ├── useCustomTheme.ts
@@ -263,10 +265,10 @@ spherse/
 │   │       │   ├── user-file-panel/      # Files section（SidebarGroup + AI 读取限制 dialog），复用 base components/file-tree
 │   │       │   ├── skill-panel/          # Skills section（三点菜单：技能市场/创建/安装技能 + CreateSkillDialog + MarketplaceDialog + marketplace-state 卡片状态推导），复用 base components/file-tree（rootPath=".spherse/skills"）
 │   │       │   ├── settings/             # 设置弹窗（文本/图片/通用/关于 tab，文本 tab 支持自定义 OpenAI 兼容供应商：CustomProviderDialog 创建/编辑、ModelProviderItem 行渲染、custom-provider-id id 生成）、更新检查 hook（useUpdateChecker reducer + 挂载恢复归位）与 UpdateChecker 组件、UpdateNoticeBridge（自动检测发现新版 → 全局右下角 toast，App 根挂载）、设置 store、类型与测试
-│   │       │   ├── welcome-page/         # 项目欢迎页渲染（HTML iframe / 图片）+ WelcomePageQueryBridge（project.yaml fs-watch/reconnect → welcome-page 查询失效，ProjectScope 挂载）
+│   │       │   ├── welcome-page/         # 项目欢迎页渲染（HTML iframe / 图片）+ WelcomePageQueryBridge（project.yaml fs-watch/reconnect → welcome-page 查询失效，ProjectRuntimeBridges 挂载）
 │   │       │   ├── project-settings/     # 项目设置弹窗集合
 │   │       │   │   ├── welcome-page-settings/ # 项目欢迎页路径设置弹窗
-│   │       │   │   └── theme-settings/        # 项目主题 CSS 编辑弹窗 + ThemeQueryBridge（fs-watch/reconnect → theme-settings 查询失效，ProjectScope 挂载）
+│   │       │   │   └── theme-settings/        # 项目主题 CSS 编辑弹窗 + ThemeQueryBridge（fs-watch/reconnect → theme-settings 查询失效，ProjectRuntimeBridges 挂载）
 │   │       │   └── text-selection-session/ # 划选文本后发起会话
 │   │       ├── pages/
 │   │       │   ├── ChatPage.tsx          # Chat 路由 page，从 URL :sessionId 解析 session/agent 后渲染 Chat

--- a/docs/official/project-structure.md
+++ b/docs/official/project-structure.md
@@ -314,10 +314,12 @@ spherse/
 │   │   └── e2e/                      # Playwright E2E 测试
 │   │       ├── helpers/
 │   │       │   ├── electron.ts       # Electron 应用启动辅助（测试项目创建、app launch）
-│   │       │   └── file-tree.ts      # 文件树 E2E 测试辅助（项目创建、app launch）
+│   │       │   ├── file-tree.ts      # 文件树 E2E 测试辅助（项目创建、app launch）
+│   │       │   └── chat.ts           # Chat E2E 测试辅助（mock agent 项目、WS mock、会话 API）
 │   │       ├── agent-dialog.spec.ts  # Agent 对话框搜索文件 E2E 测试
 │   │       ├── app-launch.spec.ts    # App 启动验证 smoke test
 │   │       ├── chat-streaming-resilience.spec.ts # Chat streaming 切换 session/后台流式/E2E WebSocket mock
+│   │       ├── project-close.spec.ts # 项目关闭 E2E 测试（streaming 中关闭断连 runtime、重启后干净重开）
 │   │       ├── file-tree.spec.ts     # 文件树 E2E 测试（展开折叠、创建删除、溢出截断）
 │   │       ├── agent-list.spec.ts              # Agent 列表展开折叠与会话重命名 E2E 测试
 │   │       ├── floating-chat.spec.ts            # 浮窗聊天 E2E 测试（浮窗/关闭/拖动/调整大小/项目切换）

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -21,7 +21,7 @@ flowchart TB
   Router --> App["App shell"]
   App --> ProjectScope["ProjectScope layout"]
   ProjectScope --> ProjectProvider["ProjectProvider"]
-  ProjectScope --> Bridges["Bus / Query / UI SDK bridges"]
+  ProjectScope --> Bridges["ProjectRuntimeBridges: bus / query / UI SDK bridges"]
   ProjectProvider --> Pages["pages: route adapters"]
   Pages --> Features["features: business UI"]
   Features --> Components["components: shared UI"]
@@ -93,7 +93,7 @@ src/
 - 只被单个 feature 使用的状态放 `features/<name>/store.ts`。feature-local store 不应被其他 feature 或全局 store import。
 - 全局 store 不得依赖 feature-local store。
 - store 呿名为 `use{SemanticName}Store`，作用域由文件位置表达。
-- 关闭项目时，由编排层显式清理所有 per-project store 和 query cache。
+- 关闭项目时由 `layouts/project-lifecycle.ts` 的 `closeProjectCascade` 显式清理所有 per-project store 和 query cache：新增 per-project store 必须定义 `clearProject` action 并加入该清单，`project-lifecycle.structure.test.ts` 会强制检查。
 
 ## 组件与 Feature
 

--- a/packages/app/src/features/activity-bar/use-project-actions.ts
+++ b/packages/app/src/features/activity-bar/use-project-actions.ts
@@ -2,15 +2,8 @@ import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { useI18n } from "@spherse/i18n/react";
 import { useAppStore } from "../../stores/app-store";
-import { useProjectDataStore } from "../../stores/project-data-store";
-import { clearLastRoute } from "../../lib/localstorage/last-route";
 import { useHostBridge } from "../../context/host-bridge-context";
-import { useAgentSessionListUiStore } from "../agent-session-list/store";
-import { useTriggerStore } from "../agent-trigger/store";
-import { useFloatingChatStore } from "../floating-chat/store";
-import { useFloatingContentBrowserStore } from "../floating-content-browser/store";
-import { useBrowserStore } from "../browser/store";
-import { clearProjectQueries } from "../../queries/project";
+import { closeProjectCascade } from "../../layouts/project-lifecycle";
 
 export function buildProjectRoute(projectId: string, lastRoute?: string): string {
   const suffix = lastRoute?.startsWith("/") ? lastRoute : "";
@@ -22,15 +15,8 @@ export function useProjectActions() {
   const { t } = useI18n();
   const bridge = useHostBridge();
   const openProject = useAppStore((s) => s.openProject);
-  const closeProject = useAppStore((s) => s.closeProject);
   const openProjectFolder = useAppStore((s) => s.openProjectFolder);
   const setActiveProject = useAppStore((s) => s.setActiveProject);
-  const clearProjectData = useProjectDataStore((s) => s.clearProjectData);
-  const clearAgentSessionListUi = useAgentSessionListUiStore((s) => s.clearProject);
-  const clearTriggerData = useTriggerStore((s) => s.clearProject);
-  const clearFloatingChat = useFloatingChatStore((s) => s.clearProject);
-  const clearFloatingContentBrowser = useFloatingContentBrowserStore((s) => s.clearProject);
-  const clearBrowser = useBrowserStore((s) => s.clearProject);
 
   const handleAddProject = async () => {
     try {
@@ -52,15 +38,7 @@ export function useProjectActions() {
   };
 
   const handleCloseProject = async (projectId: string) => {
-    const nextProjectId = await closeProject(bridge, projectId);
-    clearProjectData(projectId);
-    clearProjectQueries(projectId);
-    clearAgentSessionListUi(projectId);
-    clearTriggerData(projectId);
-    clearFloatingChat(projectId);
-    clearFloatingContentBrowser(projectId);
-    clearBrowser(projectId);
-    clearLastRoute(projectId);
+    const nextProjectId = await closeProjectCascade(bridge, projectId);
     if (nextProjectId) {
       const project = useAppStore.getState().projects.get(nextProjectId);
       navigate(buildProjectRoute(nextProjectId, project?.lastRoute));

--- a/packages/app/src/features/chat/runtime/streaming-store.test.ts
+++ b/packages/app/src/features/chat/runtime/streaming-store.test.ts
@@ -245,6 +245,59 @@ describe("streaming-store resilience", () => {
     expect(socket.closeSpy).toHaveBeenCalled();
   });
 
+  it("disconnectProject drops all sessions of the project and keeps other projects", async () => {
+    const client = createMockClient();
+    useStreamingStore.getState().attach(client, "target-1", BASE_URL, "closing", "a1");
+    const targetSocket = mock.instances[mock.instances.length - 1];
+    targetSocket.readyState = OPEN;
+    targetSocket.onopen?.({} as Event);
+    useStreamingStore.getState().attach(client, "target-2", BASE_URL, "closing", "a1");
+    const targetSocket2 = mock.instances[mock.instances.length - 1];
+    targetSocket2.readyState = OPEN;
+    targetSocket2.onopen?.({} as Event);
+    useStreamingStore.getState().attach(client, "other-1", BASE_URL, "staying", "a1");
+    const otherSocket = mock.instances[mock.instances.length - 1];
+    otherSocket.readyState = OPEN;
+    otherSocket.onopen?.({} as Event);
+    await vi.advanceTimersByTimeAsync(0);
+
+    useStreamingStore.getState().disconnectProject("closing");
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(useStreamingStore.getState().sessions["target-1"]).toBeUndefined();
+    expect(useStreamingStore.getState().sessions["target-2"]).toBeUndefined();
+    expect(useStreamingStore.getState().sessions["other-1"]).toBeDefined();
+    expect(targetSocket.closeSpy).toHaveBeenCalled();
+    expect(targetSocket2.closeSpy).toHaveBeenCalled();
+    expect(otherSocket.closeSpy).not.toHaveBeenCalled();
+    expect(mock.instances.filter((s) => s.readyState !== CLOSED)).toHaveLength(1);
+  });
+
+  it("disconnectProject disconnects a streaming session that cleanupExpired would keep", async () => {
+    const client = createMockClient();
+    useStreamingStore.getState().attach(client, "leak", BASE_URL, "closing", "a1");
+    const socket = mock.instances[mock.instances.length - 1];
+    socket.readyState = OPEN;
+    socket.onopen?.({} as Event);
+
+    useStreamingStore.getState().sendMessage("leak", "hi");
+    socket.onmessage?.({
+      data: JSON.stringify({ type: "message_start", message: { role: "assistant" } }),
+    } as MessageEvent);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(useStreamingStore.getState().sessions.leak.streaming).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(useStreamingStore.getState().sessions.leak).toBeDefined();
+
+    const instancesBeforeDisconnect = mock.instances.length;
+    useStreamingStore.getState().disconnectProject("closing");
+    expect(useStreamingStore.getState().sessions.leak).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mock.instances).toHaveLength(instancesBeforeDisconnect);
+  });
+
   it("keeps the active run streaming across an unexpected close", async () => {
     const client = createMockClient();
     useStreamingStore.getState().attach(client, "s2", BASE_URL, "p1", "a1");

--- a/packages/app/src/features/chat/runtime/streaming-store.ts
+++ b/packages/app/src/features/chat/runtime/streaming-store.ts
@@ -42,6 +42,7 @@ interface StreamingStoreActions {
   attach: (client: ApiClient, sessionId: string, baseUrl: string, projectId: string, agentId: string, initialMessage?: string, accessToken?: string | null) => void;
   detach: (sessionId: string) => void;
   disconnect: (sessionId: string) => void;
+  disconnectProject: (projectId: string) => void;
   touch: (sessionId: string) => void;
   sendMessage: (sessionId: string, text: string, image?: SendableImage) => boolean;
   retry: (sessionId: string) => void;
@@ -341,6 +342,15 @@ export const useStreamingStore = create<StreamingStoreState & StreamingStoreActi
       if (Object.keys(get().sessions).length === 0 && cleanupTimer) {
         clearInterval(cleanupTimer);
         cleanupTimer = undefined;
+      }
+    },
+
+    disconnectProject(projectId) {
+      const sessionIds = Object.entries(get().sessions)
+        .filter(([, session]) => session.projectId === projectId)
+        .map(([sessionId]) => sessionId);
+      for (const sessionId of sessionIds) {
+        get().disconnect(sessionId);
       }
     },
 

--- a/packages/app/src/layouts/ProjectRuntimeBridges.structure.test.ts
+++ b/packages/app/src/layouts/ProjectRuntimeBridges.structure.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+describe("ProjectRuntimeBridges structure", () => {
+  it("only mounts bridges and managers without logic", () => {
+    const source = readFileSync(join(currentDir, "ProjectRuntimeBridges.tsx"), "utf8");
+
+    expect(source).not.toContain("useState");
+    expect(source).not.toContain("useEffect");
+    expect(source).not.toContain("useRef");
+    expect(source).not.toContain("useBus");
+  });
+
+  it("returns a fragment without wrapper elements", () => {
+    const source = readFileSync(join(currentDir, "ProjectRuntimeBridges.tsx"), "utf8");
+
+    expect(source).toContain("<>");
+    expect(source).toContain("</>");
+    expect(source).not.toMatch(/<div/);
+    expect(source).not.toMatch(/<span/);
+  });
+
+  it("mounts the full project runtime surface", () => {
+    const source = readFileSync(join(currentDir, "ProjectRuntimeBridges.tsx"), "utf8");
+
+    for (const mount of [
+      "FloatingChatManager",
+      "FloatingContentBrowserManager",
+      "BrowserManager",
+      "UiSdkBridge",
+      "TriggerEventBridge",
+      "ContentQueryBridge",
+      "ThemeQueryBridge",
+      "WelcomePageQueryBridge",
+    ]) {
+      expect(source).toContain(`<${mount} />`);
+    }
+  });
+});

--- a/packages/app/src/layouts/ProjectRuntimeBridges.tsx
+++ b/packages/app/src/layouts/ProjectRuntimeBridges.tsx
@@ -1,0 +1,30 @@
+import { FloatingChatManager } from "../features/floating-chat";
+import { FloatingContentBrowserManager } from "../features/floating-content-browser";
+import { BrowserManager } from "../features/browser";
+import { TriggerEventBridge } from "../features/agent-trigger";
+import { FeatureGate } from "../components/FeatureGate";
+import { UiSdkBridge } from "../ui-sdk";
+import { ContentQueryBridge } from "../features/content-browser/ContentQueryBridge";
+import { ThemeQueryBridge } from "../features/project-settings/theme-settings/ThemeQueryBridge";
+import { WelcomePageQueryBridge } from "../features/welcome-page/WelcomePageQueryBridge";
+
+export function ProjectRuntimeBridges() {
+  return (
+    <>
+      <FeatureGate feature="floating-chat">
+        <FloatingChatManager />
+      </FeatureGate>
+      <FeatureGate feature="floating-content-browser">
+        <FloatingContentBrowserManager />
+      </FeatureGate>
+      <FeatureGate feature="browser">
+        <BrowserManager />
+      </FeatureGate>
+      <UiSdkBridge />
+      <TriggerEventBridge />
+      <ContentQueryBridge />
+      <ThemeQueryBridge />
+      <WelcomePageQueryBridge />
+    </>
+  );
+}

--- a/packages/app/src/layouts/ProjectScope.structure.test.ts
+++ b/packages/app/src/layouts/ProjectScope.structure.test.ts
@@ -26,6 +26,7 @@ describe("ProjectScope structure", () => {
     expect(source).not.toContain("ThemeQueryBridge");
     expect(source).not.toContain("WelcomePageQueryBridge");
     expect(source).not.toContain("FloatingChatManager");
+    expect(source).not.toContain("FloatingContentBrowserManager");
     expect(source).not.toContain("BrowserManager");
   });
 });

--- a/packages/app/src/layouts/ProjectScope.structure.test.ts
+++ b/packages/app/src/layouts/ProjectScope.structure.test.ts
@@ -13,7 +13,19 @@ describe("ProjectScope structure", () => {
     expect(source).not.toContain("useSpherseMessageListener");
     expect(source).not.toContain("useEventBridge");
     expect(source).toContain("useSidePanel");
-    expect(source).toContain("<UiSdkBridge />");
+    expect(source).toContain("<ProjectRuntimeBridges />");
     expect(source).toContain("Outlet");
+  });
+
+  it("delegates bridge and manager mounting to ProjectRuntimeBridges", () => {
+    const source = readFileSync(join(currentDir, "ProjectScope.tsx"), "utf8");
+
+    expect(source).not.toContain("UiSdkBridge");
+    expect(source).not.toContain("TriggerEventBridge");
+    expect(source).not.toContain("ContentQueryBridge");
+    expect(source).not.toContain("ThemeQueryBridge");
+    expect(source).not.toContain("WelcomePageQueryBridge");
+    expect(source).not.toContain("FloatingChatManager");
+    expect(source).not.toContain("BrowserManager");
   });
 });

--- a/packages/app/src/layouts/ProjectScope.tsx
+++ b/packages/app/src/layouts/ProjectScope.tsx
@@ -2,24 +2,16 @@ import { useEffect } from "react";
 import { Outlet, useLocation, useParams } from "react-router";
 import { useI18n } from "@spherse/i18n/react";
 import { SidePanel } from "../features/side-panel";
-import { FloatingChatManager } from "../features/floating-chat";
-import { FloatingContentBrowserManager } from "../features/floating-content-browser";
-import { BrowserManager } from "../features/browser";
-import { TriggerEventBridge } from "../features/agent-trigger";
-import { FeatureGate } from "../components/FeatureGate";
 import { useCustomTheme } from "../hooks/useCustomTheme";
 import { useAgentBusRefresh } from "../hooks/useAgentBusRefresh";
 import { useSidePanel } from "../hooks/use-side-panel";
-import { UiSdkBridge } from "../ui-sdk";
 import { useAppStore } from "../stores/app-store";
 import { useProjectNavHistory } from "../lib/use-project-navigation";
 import { ProjectProvider } from "../context/project-context";
 import { useHostBridge } from "../context/host-bridge-context";
 import { useApiClient } from "../lib/use-connection";
 import { useConnection } from "../lib/use-connection";
-import { ContentQueryBridge } from "../features/content-browser/ContentQueryBridge";
-import { ThemeQueryBridge } from "../features/project-settings/theme-settings/ThemeQueryBridge";
-import { WelcomePageQueryBridge } from "../features/welcome-page/WelcomePageQueryBridge";
+import { ProjectRuntimeBridges } from "./ProjectRuntimeBridges";
 
 export function ProjectScope() {
   const { projectId } = useParams();
@@ -71,20 +63,7 @@ export function ProjectScope() {
         >
           <Outlet />
         </main>
-        <FeatureGate feature="floating-chat">
-          <FloatingChatManager />
-        </FeatureGate>
-        <FeatureGate feature="floating-content-browser">
-          <FloatingContentBrowserManager />
-        </FeatureGate>
-        <FeatureGate feature="browser">
-          <BrowserManager />
-        </FeatureGate>
-        <UiSdkBridge />
-          <TriggerEventBridge />
-          <ContentQueryBridge />
-          <ThemeQueryBridge />
-          <WelcomePageQueryBridge />
+        <ProjectRuntimeBridges />
       </div>
     </ProjectProvider>
   );

--- a/packages/app/src/layouts/project-lifecycle.structure.test.ts
+++ b/packages/app/src/layouts/project-lifecycle.structure.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const srcRoot = join(currentDir, "..");
+const cascadeSource = readFileSync(join(currentDir, "project-lifecycle.ts"), "utf8");
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stats = statSync(full);
+    if (stats.isDirectory()) {
+      files.push(...collectSourceFiles(full));
+      continue;
+    }
+    if (entry.endsWith(".test.ts") || entry.endsWith(".test.tsx") || entry.endsWith(".d.ts")) continue;
+    if (entry.endsWith(".ts") || entry.endsWith(".tsx")) files.push(full);
+  }
+  return files;
+}
+
+function findProjectScopedStores(): string[] {
+  const stores: string[] = [];
+  for (const file of collectSourceFiles(srcRoot)) {
+    const source = readFileSync(file, "utf8");
+    const match = source.match(/export const (use\w+Store)\s*=\s*create</);
+    if (!match) continue;
+    if (!/(^|\W)clearProject(Data)?\s*[:(]/.test(source)) continue;
+    stores.push(match[1]);
+  }
+  return stores;
+}
+
+describe("closeProjectCascade structure", () => {
+  it("clears every store that defines a clearProject action", () => {
+    const stores = findProjectScopedStores();
+
+    expect(stores).toEqual(expect.arrayContaining([
+      "useProjectDataStore",
+      "useAgentSessionListUiStore",
+      "useTriggerStore",
+      "useFloatingChatStore",
+      "useFloatingContentBrowserStore",
+      "useBrowserStore",
+    ]));
+
+    for (const store of stores) {
+      expect(cascadeSource).toContain(store);
+    }
+  });
+
+  it("covers non-store cleanup surfaces", () => {
+    expect(cascadeSource).toContain("disconnectProject");
+    expect(cascadeSource).toContain("clearProjectQueries");
+    expect(cascadeSource).toContain("clearProjectNavHistory");
+    expect(cascadeSource).toContain("clearLastRoute");
+  });
+});

--- a/packages/app/src/layouts/project-lifecycle.test.ts
+++ b/packages/app/src/layouts/project-lifecycle.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { closeProjectCascade } from "./project-lifecycle";
+import { useAppStore, type ProjectState } from "../stores/app-store";
+import { useProjectDataStore } from "../stores/project-data-store";
+import { useStreamingStore } from "../features/chat/runtime/streaming-store";
+import { useAgentSessionListUiStore } from "../features/agent-session-list/store";
+import { queryClient } from "../queries/client";
+import { projectQueryKeys } from "../queries/keys";
+import { getLastRoute, setLastRoute } from "../lib/localstorage/last-route";
+import { clearProjectNavHistory } from "../lib/use-project-navigation";
+import type { HostBridge } from "../lib/host-bridge";
+
+vi.mock("../lib/use-project-navigation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/use-project-navigation")>();
+  return { ...actual, clearProjectNavHistory: vi.fn() };
+});
+
+function project(id: string): ProjectState {
+  return { id, path: `/tmp/${id}`, name: id, lastOpened: new Date().toISOString() };
+}
+
+function createBridge(closeProjectImpl?: ReturnType<typeof vi.fn>): HostBridge {
+  return {
+    project: {
+      closeProject: closeProjectImpl ?? vi.fn().mockResolvedValue(undefined),
+      setLastActiveProject: vi.fn().mockResolvedValue(undefined),
+    },
+  } as unknown as HostBridge;
+}
+
+function seedStreamingSession(sessionId: string, projectId: string): void {
+  useStreamingStore.setState((state) => ({
+    sessions: {
+      ...state.sessions,
+      [sessionId]: {
+        messages: [],
+        streaming: false,
+        lastActivityAt: Date.now(),
+        scrollPosition: 0,
+        attachedCount: 1,
+        initialMessageSent: false,
+        projectId,
+        hasMore: false,
+        oldestLoadedId: null,
+        loadingMore: false,
+        historyStatus: "ready",
+        connectionStatus: "open",
+        historyError: false,
+        reconnectFailed: false,
+        pendingWithdraw: false,
+      },
+    },
+  }));
+}
+
+function seedClosedProject(): void {
+  const projects = new Map<string, ProjectState>([
+    ["p1", project("p1")],
+    ["p2", project("p2")],
+  ]);
+  useAppStore.setState({ projects, activeProjectId: "p1", initializing: false });
+  seedStreamingSession("s1", "p1");
+  seedStreamingSession("s2", "p2");
+  queryClient.setQueryData(projectQueryKeys.sessions("p1"), { sessions: [], paging: {} });
+  useAgentSessionListUiStore.getState().setCollapsedAgentIds("p1", ["a1"]);
+  useProjectDataStore.getState().setInitialMessage("p1", "s1", "hello");
+  setLastRoute("p1", "/chat");
+}
+
+describe("closeProjectCascade", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient.clear();
+    localStorage.clear();
+    useAppStore.setState({
+      connection: { baseUrl: "http://localhost", accessToken: null },
+      projects: new Map(),
+      activeProjectId: null,
+      initializing: false,
+    });
+    useStreamingStore.setState({ sessions: {} });
+    useProjectDataStore.setState({ projects: {} });
+    useAgentSessionListUiStore.setState({ collapsedAgentIdsByProject: {} });
+  });
+
+  it("clears every per-project surface and returns the next project id", async () => {
+    seedClosedProject();
+    const bridge = createBridge();
+
+    const nextProjectId = await closeProjectCascade(bridge, "p1");
+
+    expect(nextProjectId).toBe("p2");
+    expect(useAppStore.getState().projects.has("p1")).toBe(false);
+    expect(useAppStore.getState().activeProjectId).toBe("p2");
+    expect(bridge.project?.setLastActiveProject).toHaveBeenCalledWith("p2");
+    expect(useStreamingStore.getState().sessions.s1).toBeUndefined();
+    expect(useStreamingStore.getState().sessions.s2).toBeDefined();
+    expect(queryClient.getQueryData(projectQueryKeys.sessions("p1"))).toBeUndefined();
+    expect(useAgentSessionListUiStore.getState().collapsedAgentIdsByProject.p1).toBeUndefined();
+    expect(useProjectDataStore.getState().projects.p1).toBeUndefined();
+    expect(getLastRoute("p1")).toBeNull();
+    expect(clearProjectNavHistory).toHaveBeenCalledWith("p1");
+  });
+
+  it("leaves local state untouched when the host close fails", async () => {
+    seedClosedProject();
+    const bridge = createBridge(vi.fn().mockRejectedValue(new Error("host close failed")));
+
+    await expect(closeProjectCascade(bridge, "p1")).rejects.toThrow("host close failed");
+
+    expect(useAppStore.getState().projects.has("p1")).toBe(true);
+    expect(useAppStore.getState().activeProjectId).toBe("p1");
+    expect(useStreamingStore.getState().sessions.s1).toBeDefined();
+    expect(queryClient.getQueryData(projectQueryKeys.sessions("p1"))).toBeDefined();
+    expect(useAgentSessionListUiStore.getState().collapsedAgentIdsByProject.p1).toBeDefined();
+    expect(useProjectDataStore.getState().projects.p1).toBeDefined();
+    expect(getLastRoute("p1")).toBe("/chat");
+    expect(clearProjectNavHistory).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/layouts/project-lifecycle.ts
+++ b/packages/app/src/layouts/project-lifecycle.ts
@@ -1,0 +1,30 @@
+import type { HostBridge } from "../lib/host-bridge";
+import { useAppStore } from "../stores/app-store";
+import { useProjectDataStore } from "../stores/project-data-store";
+import { clearProjectQueries } from "../queries/project";
+import { clearLastRoute } from "../lib/localstorage/last-route";
+import { clearProjectNavHistory } from "../lib/use-project-navigation";
+import { useStreamingStore } from "../features/chat/runtime/streaming-store";
+import { useAgentSessionListUiStore } from "../features/agent-session-list/store";
+import { useTriggerStore } from "../features/agent-trigger/store";
+import { useFloatingChatStore } from "../features/floating-chat/store";
+import { useFloatingContentBrowserStore } from "../features/floating-content-browser/store";
+import { useBrowserStore } from "../features/browser/store";
+
+export async function closeProjectCascade(
+  bridge: HostBridge,
+  projectId: string,
+): Promise<string | null> {
+  const nextProjectId = await useAppStore.getState().closeProject(bridge, projectId);
+  useStreamingStore.getState().disconnectProject(projectId);
+  clearProjectQueries(projectId);
+  useAgentSessionListUiStore.getState().clearProject(projectId);
+  useTriggerStore.getState().clearProject(projectId);
+  useFloatingChatStore.getState().clearProject(projectId);
+  useFloatingContentBrowserStore.getState().clearProject(projectId);
+  useBrowserStore.getState().clearProject(projectId);
+  useProjectDataStore.getState().clearProjectData(projectId);
+  clearProjectNavHistory(projectId);
+  clearLastRoute(projectId);
+  return nextProjectId;
+}

--- a/packages/app/src/lib/use-project-navigation.ts
+++ b/packages/app/src/lib/use-project-navigation.ts
@@ -31,6 +31,10 @@ export function useProjectNavHistory(projectId: string): void {
   }, [location.pathname, location.search, projectId]);
 }
 
+export function clearProjectNavHistory(projectId: string): void {
+  projectNavStacks.delete(projectId);
+}
+
 export function useProjectNavigation(): { back: () => void } {
   const navigate = useNavigate();
   const { projectId } = useProjectCtx();

--- a/packages/app/src/stores/app-store.test.ts
+++ b/packages/app/src/stores/app-store.test.ts
@@ -286,6 +286,32 @@ describe("useAppStore openSampleProject", () => {
   });
 });
 
+describe("useAppStore closeProject", () => {
+  beforeEach(() => {
+    setupStoreTest(false);
+  });
+
+  it("still removes the project when persisting the next active id fails", async () => {
+    useAppStore.setState({
+      projects: new Map<string, ProjectState>([
+        ["project-a", projectState()],
+        ["project-b", projectState({ id: "project-b", path: "/tmp/project-b", name: "project-b" })],
+      ]),
+      activeProjectId: "project-a",
+    });
+    const bridge = createMockHostBridge();
+    (bridge.project?.setLastActiveProject as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("persist failed"),
+    );
+
+    const nextActiveId = await useAppStore.getState().closeProject(bridge, "project-a");
+
+    expect(nextActiveId).toBe("project-b");
+    expect(useAppStore.getState().projects.has("project-a")).toBe(false);
+    expect(useAppStore.getState().activeProjectId).toBe("project-b");
+  });
+});
+
 describe("useAppStore refreshProjects", () => {
   beforeEach(() => {
     setupStoreTest(false);

--- a/packages/app/src/stores/app-store.ts
+++ b/packages/app/src/stores/app-store.ts
@@ -219,7 +219,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
     });
 
     if (nextActiveId) {
-      await bridge.project?.setLastActiveProject(nextActiveId);
+      try {
+        await bridge.project?.setLastActiveProject(nextActiveId);
+      } catch (err) {
+        console.warn("[app-store] failed to persist last active project:", err);
+      }
     }
 
     return nextActiveId;

--- a/packages/desktop/e2e/helpers/chat.ts
+++ b/packages/desktop/e2e/helpers/chat.ts
@@ -63,11 +63,7 @@ export async function launchChatApp(project: ChatProject): Promise<{ app: Electr
   const page = await app.firstWindow();
   await page.setViewportSize({ width: 1200, height: 800 });
   await page.waitForLoadState("domcontentloaded");
-  await page.evaluate(async ({ id, projectRoot }) => {
-    await window.electronAPI.openProject(projectRoot);
-    await window.electronAPI.addOpenProject(id, projectRoot);
-    await window.electronAPI.setLastActiveProject(id);
-  }, { id: project.projectId, projectRoot: project.root });
+  await openProjectInApp(page, project);
   return { app, page };
 }
 
@@ -89,6 +85,18 @@ export async function createSessionViaApi(page: Page, projectId: string, agentId
 export async function navigateToSession(page: Page, projectId: string, sessionId: string): Promise<void> {
   const projectUrl = `/project/${projectId}/chat/${sessionId}`;
   await page.goto(`file://${rendererEntry}?e2e=${navToken}#${projectUrl}`);
+}
+
+export async function navigateToProjectRoot(page: Page, projectId: string): Promise<void> {
+  await page.goto(`file://${rendererEntry}?e2e=${Date.now()}#/project/${projectId}`);
+}
+
+export async function openProjectInApp(page: Page, project: ChatProject): Promise<void> {
+  await page.evaluate(async ({ id, projectRoot }) => {
+    await window.electronAPI.openProject(projectRoot);
+    await window.electronAPI.addOpenProject(id, projectRoot);
+    await window.electronAPI.setLastActiveProject(id);
+  }, { id: project.projectId, projectRoot: project.root });
 }
 
 export function assistantTextMessage(text: string): MockEvent[] {

--- a/packages/desktop/e2e/project-close.spec.ts
+++ b/packages/desktop/e2e/project-close.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import {
+  createChatProject,
+  launchChatApp,
+  getServerPort,
+  createSessionViaApi,
+  navigateToSession,
+  navigateToProjectRoot,
+  openProjectInApp,
+  createStreamingSequence,
+  type MockEvent,
+} from "./helpers/chat";
+
+interface SocketTracking {
+  opened: number;
+  closed: number;
+}
+
+async function routeStreamingWithTracking(
+  page: Page,
+  port: number,
+  events: MockEvent[],
+): Promise<SocketTracking> {
+  const tracking: SocketTracking = { opened: 0, closed: 0 };
+  await page.routeWebSocket(`ws://localhost:${port}/ws/projects/**/chat/**`, (ws) => {
+    tracking.opened += 1;
+    ws.onClose(() => {
+      tracking.closed += 1;
+    });
+    ws.onMessage((message) => {
+      const parsed = JSON.parse(message as string);
+      if (parsed.type === "ping") {
+        ws.send(JSON.stringify({ type: "pong" }));
+      } else if (parsed.type === "message") {
+        for (const event of events) {
+          ws.send(JSON.stringify(event));
+        }
+      } else if (parsed.type === "abort") {
+        ws.send(JSON.stringify({ type: "agent_end", messages: [] }));
+      }
+    });
+  });
+  return tracking;
+}
+
+async function goOnboarding(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.location.hash = "#/";
+  });
+}
+
+async function closeProjectViaActivityBar(page: Page): Promise<void> {
+  const avatar = page.locator("[data-project-avatar]").first();
+  await expect(avatar).toBeVisible();
+  await avatar.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "关闭项目", exact: true }).click();
+}
+
+test("closing a streaming project disconnects its chat runtime", async () => {
+  const project = await createChatProject();
+  const { app, page } = await launchChatApp(project);
+
+  try {
+    const port = await getServerPort(page);
+    const sessionId = await createSessionViaApi(page, project.projectId, "assistant-1");
+
+    const eventsBeforeEnd = createStreamingSequence().filter((e) => e.type !== "agent_end");
+    const sockets = await routeStreamingWithTracking(page, port, eventsBeforeEnd);
+
+    await navigateToSession(page, project.projectId, sessionId);
+    await page.waitForSelector("[data-chat-composer]");
+
+    const textarea = page.locator("[data-chat-composer] textarea");
+    await textarea.fill("test message");
+    await textarea.press("Enter");
+
+    await page.waitForSelector("[data-chat-composer] button svg.lucide-square", { timeout: 5000 });
+
+    await goOnboarding(page);
+    await closeProjectViaActivityBar(page);
+
+    await expect(page.getByText("搭建属于你自己的世界")).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("[data-project-avatar]")).toHaveCount(0);
+
+    await expect.poll(() => sockets.closed, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+    await page.waitForTimeout(2000);
+    expect(sockets.opened).toBe(1);
+  } finally {
+    await app.close();
+  }
+});
+
+test("reopening a closed project after restart starts clean", async () => {
+  const project = await createChatProject();
+  const { app, page } = await launchChatApp(project);
+
+  try {
+    const sessionId = await createSessionViaApi(page, project.projectId, "assistant-1");
+    await navigateToSession(page, project.projectId, sessionId);
+    await page.waitForSelector("[data-chat-composer]");
+
+    await goOnboarding(page);
+    await closeProjectViaActivityBar(page);
+    await expect(page.getByText("搭建属于你自己的世界")).toBeVisible({ timeout: 10_000 });
+
+    await page.reload();
+    await page.waitForLoadState("domcontentloaded");
+    await page.waitForSelector("text=搭建属于你自己的世界", { timeout: 30_000 });
+    await expect(page.locator("[data-project-avatar]")).toHaveCount(0);
+
+    const lastRoute = await page.evaluate(
+      (id: string) => localStorage.getItem(`spherse:last-route:${id}`),
+      project.projectId,
+    );
+    expect(lastRoute).toBeNull();
+
+    await openProjectInApp(page, project);
+    await navigateToProjectRoot(page, project.projectId);
+
+    await expect(page.getByText("项目不存在")).toHaveCount(0);
+    await expect(page.locator("[data-chat-composer]")).toHaveCount(0);
+    await expect(page.getByText("Spherse", { exact: true }).first()).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
## 概要

对应 followup P2「收敛项目级 Bridge」（触发条件已被 ThemeQueryBridge + WelcomePageQueryBridge 满足），同时修复一个 streaming 泄漏正确性缺陷。Design doc：`docs/dev/infra/2026-08-28-project-lifecycle-orchestration/design.md`

- **fix**：关闭项目不断开该项目 streaming runtime——`cleanupExpired` 的 `!streaming` 守卫使活跃会话永不清理（WS + 重连定时器持续存活），且回写 `setStreaming` 会在 `project-data-store` 重建已清条目。新增 `streaming-store.disconnectProject(projectId)`，由 dispose 守卫链保证断开后无迟到写入
- **feat**：`layouts/project-lifecycle.ts` 新增 `closeProjectCascade` 单一入口收敛项目关闭级联清理（原散落在 activity-bar feature hook 的 8 个手工调用）；顺序：app-store close（失败即抛、本地不动）→ disconnectProject → clearProjectQueries → 5 个 feature store → clearProjectData → clearProjectNavHistory（新导出，原永不清理）→ clearLastRoute；`project-lifecycle.structure.test.ts` 递归扫描所有定义 `clearProject` 的 store 强制纳入清单，防新增遗漏
- **refactor**：ProjectScope 挂载的 3 manager + 5 bridge 收敛为 `ProjectRuntimeBridges`（fragment 纯挂载），ProjectScope 回归布局职责

## Review Report（code-review skill，对照 design doc 与代码逐条验证）

### 已修
- **medium**：`setLastActiveProject` 是 cascade 内第二个 host await 点，失败会使本地清理全跳过、泄漏以新路径复发 → `app-store.closeProject` 对该 hint 性持久化 catch 容错 + 单测（22e7a3a）
- **minor**：ProjectScope structure test 排除名单漏 `FloatingContentBrowserManager`（靠 `BrowserManager` 子串巧合覆盖）→ 补显式断言（22e7a3a）
- **minor**：plan.md 未勾选 → 已勾选（22e7a3a）

### 未修（记录理由）
- `handleCloseProject` 无 catch/toast 与 `handleAddProject` 风格不一致：与旧版行为一致非回归；补错误提示需新增 i18n 文案，避免本 PR 扩面，留待后续
- refreshProjects 路径 streaming 泄漏：受「全局 store 不得依赖 feature-local store」红线约束，宜与 followup P1 镜像移除合并重构 → 已记 backlog + design doc 已知缺口

### 已验证无问题的方面
cascade 顺序与 design 一致（design review 修正后）、dispose 守卫链、disconnectProject 遍历安全、依赖方向（layouts → stores/queries 合法）、use-project-actions 无行为丢失（清理面为严格超集）、structure test 正则无现实误报/漏报（全仓 12 个 store 形态核对）

## 验证

- `npm test --workspace=packages/app`：1057 通过（新增 12 例：disconnectProject 2、cascade 行为 2、closeProject 容错 1、structure test 3 文件）
- lint / typecheck（app）通过；E2E 按影响面：app-launch + chat-streaming-resilience + floating-chat 15/15 通过（首跑 2 例超时经干净 dev 对照与复跑判定为并行环境抖动）

## 遗留（已入 backlog）

- refreshProjects 路径不回收 streaming runtime（Bug 节）
- 项目关闭路径无 E2E 覆盖（技术债节）