### PR TITLE
docs: chat theme skill 补头像与气泡尖角对齐指引

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -2,9 +2,6 @@ name: PR Build
 
 on:
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,7 +11,29 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.filter.outputs.docs-only }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect docs-only change
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA"...HEAD | grep -qvE '^docs/|\.md$'; then
+            echo "docs-only=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs-only=true" >> "$GITHUB_OUTPUT"
+          fi
+
   verify:
+    needs: changes
+    if: needs.changes.outputs.docs-only == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ npm run build:landing   # 构建 landing page（含 @spherse/i18n 依赖构建�
 
 ## 一般开发流程
 
-0. **准备分支**：从最新 `origin/dev` checkout 一个随机名分支并 attach 到当前 worktree（`git fetch origin dev && git worktree attach` 或等价方式）；工作区不干净时停止并告知用户
+0. **准备分支**：在开始任何调研和分析之前，先从最新 `origin/dev` checkout 一个随机名分支并 attach 到当前 worktree（`git fetch origin dev && git worktree attach` 或等价方式）；工作区不干净时停止并告知用户
 1. **需求分析**：需求下发后先对照代码现状分析可行性与影响面，与用户讨论澄清歧义，商定方案；不明确不动手
 2. **design doc**：方案商定后写成 design doc，放 `docs/dev/{features,infra}/{yyyy-MM-dd-name}/`（结构参考同类目录的近期文档；放置规则见 **doc-sync** skill）；写完开 sub agent review，反馈按 critical / important / medium / minor 分级处理
 3. **实现**：复杂需求按 design doc 拆分任务并落盘 `plan.md`，逐项实现勾选；相对简单的任务直接实现。测试不强制 TDD、按场景选：不变量密集的纯逻辑（fold、access policy、错误分类等）先写测试再实现，UI / 集成路径实现后补

--- a/packages/presets/skills/spherse-create-agent-chat-theme/SKILL.md
+++ b/packages/presets/skills/spherse-create-agent-chat-theme/SKILL.md
@@ -83,6 +83,19 @@ Agent chat themes live in the agent directory as `theme.css` (`.spherse/agents/{
 >
 > 其它可主题化区域（项目面板 `data-project-panel`、内容浏览器 `data-content-browser`、文档视图容器 `data-content-doc`）在聊天窗口 DOM 之外，**不受 agent theme 影响**，请在项目级 `.spherse/theme.css` 中定制，详见 `spherse-create-ui-theme` skill。
 
+## 头像
+
+助手头像用 `[data-chat-message][data-role="assistant"]::before` 实现（`content` 占位 + `background` 画图）。注意：消息外层行 `[data-chat-message]` 是 **flex 布局**（`flex items-start`），`::before` 作为第一个 flex item 默认停在气泡**左上角**。
+
+尖角在左下角（如 `border-radius: 18px 18px 18px 4px`）时，给头像加 `align-self: flex-end` 与尖角对齐；在左上角则保持默认：
+
+```css
+[data-chat-message][data-role="assistant"]::before {
+  /* ...尺寸、圆角、背景... */
+  align-self: flex-end;
+}
+```
+
 ## 引用图片与字体
 
 主题以 `<link>` 从项目 preview 路由载入，CSS 中相对 `url()` 的解析基址为 agent 目录 `.spherse/agents/{agent-slug}/`。因此本地图片、字体等资源可以用相对路径正常引用。
@@ -139,6 +152,8 @@ Agent chat themes live in the agent directory as `theme.css` (`.spherse/agents/{
     height: 36px;
     margin-right: 8px;
     flex-shrink: 0;
+    /* 气泡尖角在左下角（border-radius: 18px 18px 18px 4px），头像沉底对齐尖角 */
+    align-self: flex-end;
     border-radius: 50%;
     background: radial-gradient(circle at 40% 35%, #e2c87a 0%, #c9a04a 40%, #8a6a2a 100%);
     box-shadow: 0 0 12px rgba(201, 160, 74, 0.3), inset 0 -2px 4px rgba(0, 0, 0, 0.3);
@@ -247,4 +262,5 @@ Agent chat themes live in the agent directory as `theme.css` (`.spherse/agents/{
 - 把根级变量 / 背景声明写到 `[data-chat-root] { ... }` 之外——它们不会作用于聊天窗口。所有规则都要嵌套在根块内。
 - 用位置选择器（如 `> div`、`> div:first-child`）选气泡或输入框——这些会随 DOM 结构变化失效。改用命名钩子 `[data-chat-bubble]` / `[data-chat-composer-input]`。
 - 在 agent theme 里改侧边栏变量。Agent theme 只影响聊天窗口，不影响项目侧边栏；侧边栏变量应写在项目级 `.spherse/theme.css`。
+- 头像停留在气泡左上角、与左下角的尖角错位——消息行是 flex 布局，头像默认在行顶；尖角在左下时需给头像加 `align-self: flex-end`（见「头像」一节）。
 - 重复定义同一 `::before` 头像规则。如非有意覆盖，每条规则只写一次。


### PR DESCRIPTION
## 变更内容

- `spherse-create-agent-chat-theme` skill 新增「头像」一节：说明消息行是 flex 布局、头像 `::before` 默认停在气泡左上角；尖角在左下角时需 `align-self: flex-end` 与尖角对齐
- skill 示例中的助手头像补上 `align-self: flex-end`，与其左下角尖角的气泡保持一致
- 「常见错误」新增头像与尖角错位条目
- AGENTS.md 开发流程步骤 0 明确「在开始任何调研和分析之前」先准备分支

## doc-sync 自查

- theme mechanism / themeable selectors → 本 PR 即对应 skill，已更新
- presets skill 源编辑 → 已触发 `npm run build --workspace=packages/presets` sync（生成物 gitignored）
- 其余（目录结构 / 架构 / 数据格式 / glossary / i18n / backlog）无影响：纯文档改动

## 验证

- `npm run lint` 通过（16 条 warning 均为无关存量文件）
- presets sync build 通过

## Review 反馈处理

- 用户指出「头像对齐」章节列表太长 → 已简化为单句（已修）
- 用户要求 AGENTS.md 步骤 0 补充时序说明 → 已加（已修）