### PR TITLE
feat: open .spherse/agents/*/assets/ for LLM read/write and server read

### DIFF
--- a/docs/official/architecture/security.md
+++ b/docs/official/architecture/security.md
@@ -28,7 +28,7 @@
 | agentsRoot | `M/agents` |
 | agentProfile / agentTheme / agentMcp | `M/agents/*/profile.md` / `theme.css` / `mcp.json` |
 | agentSessions | `M/agents/*/sessions.db*` |
-| agentSkills / agentTriggers / agentTriggerLogs | `M/agents/*/skills/**` / `triggers/index.yml` / `triggers/logs.jsonl` |
+| agentSkills / agentAssets / agentTriggers / agentTriggerLogs | `M/agents/*/skills/**` / `assets/**` / `triggers/index.yml` / `triggers/logs.jsonl` |
 | spherseMetaDir / spherseOther | `M` / `M/**`（兜底，最后） |
 
 - 匹配顺序：extraRules 逐条优先 → 内置模式按上表声明序 → 都不中归 `userFiles`
@@ -49,10 +49,10 @@
 
 ### 白名单
 
-- **LLM read**（16 类）：
+- **LLM read**（17 类）：
   - userFiles、rootIndex、changelog、projectConfig、projectTheme、generatedImages、attachments、skills
-  - agentsRoot、agentProfile、agentTheme、agentSkills、agentTriggers、agentTriggerLogs、spherseMetaDir、**spherseOther**
-- **LLM write**（5 类 + 规则授权）：userFiles、projectTheme、skills、agentTheme、agentSkills——AI 可直接创建/修改项目与 agent 级 skill
+  - agentsRoot、agentProfile、agentTheme、agentSkills、agentAssets、agentTriggers、agentTriggerLogs、spherseMetaDir、**spherseOther**
+- **LLM write**（6 类 + 规则授权）：userFiles、projectTheme、skills、agentTheme、agentSkills、agentAssets（agent 私有静态资源，如 theme 配图/字体）——AI 可直接创建/修改项目与 agent 级 skill 及 assets
 - **server read / write**：见 [server.md](server.md)「访问策略白名单」
 - **agentMcp 与 agentSessions 不在任何白名单**：mcp.json（含 headers/env 明文）与 sessions.db 对 LLM 和 server 通用路由均不可读写，只经专用门面（McpConfigStore / SessionStore）
 

--- a/docs/official/architecture/server.md
+++ b/docs/official/architecture/server.md
@@ -98,7 +98,7 @@
 
 ## 访问策略白名单（server 端）
 
-- **read**：userFiles / rootIndex / changelog / projectTheme / generatedImages / attachments / skills / agentTheme / agentSkills
+- **read**：userFiles / rootIndex / changelog / projectTheme / generatedImages / attachments / skills / agentTheme / agentSkills / agentAssets
 - **write**：userFiles / rootIndex / changelog / projectTheme / attachments / skills / agentSkills
 - 全部经 core `serverAccessPolicy`（见 [security.md](security.md)）；capability 私有路径（pathRules）对 server 不可写，开放需经 PM 门面
 

--- a/docs/official/data-conventions.md
+++ b/docs/official/data-conventions.md
@@ -24,8 +24,9 @@ project-root/
 │   │       ├── triggers/          # 惰性：首次保存触发器时创建
 │   │       │   ├── index.yml
 │   │       │   └── logs.jsonl
-│   │       └── skills/            # 可选：agent-level 私有 skill
-│   │           └── <skill-name>/SKILL.md
+  │   │       ├── skills/            # 可选：agent-level 私有 skill
+  │   │       │   └── <skill-name>/SKILL.md
+  │   │       └── assets/            # 可选：agent 私有静态资源（theme 配图、字体等），LLM 读写、server 只读
 │   ├── generated-images/          # generate_image 落盘（首次生图时创建）
 │   ├── attachments/               # 聊天图片上传落盘
 │   └── skills/                    # 新建项目时创建的空目录（用户自建 project skill）
@@ -66,7 +67,7 @@ aiAccess:
 
 - 解析为 YAML 后裸 cast，core 侧无 schema 校验；残留未知字段（如老项目的 `defaultModel`）静默忽略，随下次保存原样保留
 - 模型选择不在项目配置：由用户级 `AppSettings.models.text.defaultModel` 决定
-- 特殊文件路径归属由 `@spherse/core` 的 `access/path-category.ts` 中 `PATH_PATTERNS` 固定（17 类 + `userFiles` 兜底），不可配置；capability 可经 `pathRules` 声明优先裁决（memory capability 已在使用，见 `architecture/security.md`）
+- 特殊文件路径归属由 `@spherse/core` 的 `access/path-category.ts` 中 `PATH_PATTERNS` 固定（18 类 + `userFiles` 兜底），不可配置；capability 可经 `pathRules` 声明优先裁决（memory capability 已在使用，见 `architecture/security.md`）
 - `welcomePage.path` 校验：`/` 分隔、拒绝绝对路径与 `..`、扩展名白名单 html / htm / png / jpg / jpeg / gif / webp / svg、必须归类为 `userFiles`（即排除 `.spherse/**`、AGENTS.md、CHANGELOG.md）；保存时不要求文件存在；渲染时 settings 查询失败或资源加载失败回退占位态
 - `deniedPaths` 校验：拒绝绝对路径、`..` 与尾部斜杠并去重；保留路径（一切非 `userFiles` 类别）不可加入——它们由 access policy 白名单另行控制
 

--- a/docs/official/data-conventions.md
+++ b/docs/official/data-conventions.md
@@ -24,9 +24,9 @@ project-root/
 │   │       ├── triggers/          # 惰性：首次保存触发器时创建
 │   │       │   ├── index.yml
 │   │       │   └── logs.jsonl
-  │   │       ├── skills/            # 可选：agent-level 私有 skill
-  │   │       │   └── <skill-name>/SKILL.md
-  │   │       └── assets/            # 可选：agent 私有静态资源（theme 配图、字体等），LLM 读写、server 只读
+│   │       ├── skills/            # 可选：agent-level 私有 skill
+│   │       │   └── <skill-name>/SKILL.md
+│   │       └── assets/            # 可选：agent 私有静态资源（theme 配图、字体等），LLM 读写、server 只读
 │   ├── generated-images/          # generate_image 落盘（首次生图时创建）
 │   ├── attachments/               # 聊天图片上传落盘
 │   └── skills/                    # 新建项目时创建的空目录（用户自建 project skill）

--- a/docs/official/glossary.md
+++ b/docs/official/glossary.md
@@ -48,7 +48,7 @@
 | Tool（AgentTool） | agent 可调用的操作，工厂函数模式 `createXxxTool(projectRoot)` | [architecture/capabilities.md](architecture/capabilities.md) |
 | 审批门（ApprovalGate） | 危险工具 execute 前的人工确认（`withApproval` 包装） | [architecture/security.md](architecture/security.md) |
 | 问答门（askGate） | `ask_user` 工具向用户提问的同步等待机制 | [architecture/capabilities.md](architecture/capabilities.md) |
-| category（PATH_PATTERNS） | 路径语义分类（17 类 + `userFiles` 兜底），access policy 的裁决基础 | [architecture/security.md](architecture/security.md) |
+| category（PATH_PATTERNS） | 路径语义分类（18 类 + `userFiles` 兜底），access policy 的裁决基础 | [architecture/security.md](architecture/security.md) |
 | llmAccessPolicy / serverAccessPolicy | LLM 工具与 server 路由各自的白名单裁决器，基于 category | [architecture/security.md](architecture/security.md) |
 | FileWriteMutex | 装配点创建、全链路注入的共享文件写互斥（防并发写撕裂） | [architecture/core.md](architecture/core.md) |
 | ModelCatalog | 模型目录；所有权在 desktop main 组合根，注入链上不自建 | [architecture/desktop.md](architecture/desktop.md) |

--- a/packages/core/src/__tests__/access/access-policy.test.ts
+++ b/packages/core/src/__tests__/access/access-policy.test.ts
@@ -35,6 +35,8 @@ const MATRIX: MatrixRow[] = [
   { category: "agentSessions", path: ".spherse/agents/bot-abc123/sessions.db-shm", llmRead: false, llmWrite: false, srvRead: false, srvWrite: false },
   { category: "agentSkills", path: ".spherse/agents/bot-abc123/skills/my-skill/SKILL.md", llmRead: true, llmWrite: true, srvRead: true, srvWrite: true },
   { category: "agentAssets", path: ".spherse/agents/bot-abc123/assets/bg.png", llmRead: true, llmWrite: true, srvRead: true, srvWrite: false },
+  { category: "agentAssets", path: ".spherse/agents/bot-abc123/assets", llmRead: true, llmWrite: true, srvRead: true, srvWrite: false },
+  { category: "spherseOther", path: ".spherse/agents/bot-abc123/assetsy/bg.png", llmRead: true, llmWrite: false, srvRead: false, srvWrite: false },
   { category: "agentTriggers", path: ".spherse/agents/bot-abc123/triggers/index.yml", llmRead: true, llmWrite: false, srvRead: false, srvWrite: false },
   { category: "spherseMetaDir", path: ".spherse", llmRead: true, llmWrite: false, srvRead: false, srvWrite: false },
   { category: "agentsRoot", path: ".spherse/agents", llmRead: true, llmWrite: false, srvRead: false, srvWrite: false },

--- a/packages/core/src/__tests__/access/access-policy.test.ts
+++ b/packages/core/src/__tests__/access/access-policy.test.ts
@@ -34,6 +34,7 @@ const MATRIX: MatrixRow[] = [
   { category: "agentSessions", path: ".spherse/agents/bot-abc123/sessions.db-wal", llmRead: false, llmWrite: false, srvRead: false, srvWrite: false },
   { category: "agentSessions", path: ".spherse/agents/bot-abc123/sessions.db-shm", llmRead: false, llmWrite: false, srvRead: false, srvWrite: false },
   { category: "agentSkills", path: ".spherse/agents/bot-abc123/skills/my-skill/SKILL.md", llmRead: true, llmWrite: true, srvRead: true, srvWrite: true },
+  { category: "agentAssets", path: ".spherse/agents/bot-abc123/assets/bg.png", llmRead: true, llmWrite: true, srvRead: true, srvWrite: false },
   { category: "agentTriggers", path: ".spherse/agents/bot-abc123/triggers/index.yml", llmRead: true, llmWrite: false, srvRead: false, srvWrite: false },
   { category: "spherseMetaDir", path: ".spherse", llmRead: true, llmWrite: false, srvRead: false, srvWrite: false },
   { category: "agentsRoot", path: ".spherse/agents", llmRead: true, llmWrite: false, srvRead: false, srvWrite: false },

--- a/packages/core/src/__tests__/access/path-category.test.ts
+++ b/packages/core/src/__tests__/access/path-category.test.ts
@@ -75,6 +75,18 @@ describe("categorizePath", () => {
     ).toBe("agentSkills");
   });
 
+  it("classifies agent-level assets directory", () => {
+    expect(categorizePath(".spherse/agents/historian-abc123/assets")).toBe(
+      "agentAssets",
+    );
+    expect(
+      categorizePath(".spherse/agents/historian-abc123/assets/bg.png"),
+    ).toBe("agentAssets");
+    expect(
+      categorizePath(".spherse/agents/historian-abc123/assets/fonts/main.woff2"),
+    ).toBe("agentAssets");
+  });
+
   it("classifies .spherse directory itself as spherseMetaDir", () => {
     expect(categorizePath(".spherse")).toBe("spherseMetaDir");
   });

--- a/packages/core/src/access/access-policy.ts
+++ b/packages/core/src/access/access-policy.ts
@@ -27,6 +27,7 @@ const LLM_READ: ReadonlySet<PathCategory> = new Set<PathCategory>([
   "agentProfile",
   "agentTheme",
   "agentSkills",
+  "agentAssets",
   "agentTriggers",
   "agentTriggerLogs",
   "spherseMetaDir",
@@ -39,6 +40,7 @@ const LLM_WRITE: ReadonlySet<PathCategory> = new Set<PathCategory>([
   "skills",
   "agentTheme",
   "agentSkills",
+  "agentAssets",
 ]);
 
 const SRV_READ: ReadonlySet<PathCategory> = new Set<PathCategory>([
@@ -51,6 +53,7 @@ const SRV_READ: ReadonlySet<PathCategory> = new Set<PathCategory>([
   "skills",
   "agentTheme",
   "agentSkills",
+  "agentAssets",
 ]);
 
 const SRV_WRITE: ReadonlySet<PathCategory> = new Set<PathCategory>([

--- a/packages/core/src/access/path-category.ts
+++ b/packages/core/src/access/path-category.ts
@@ -22,6 +22,7 @@ export type PathCategory =
   | "agentMcp"
   | "agentSessions"
   | "agentSkills"
+  | "agentAssets"
   | "agentTriggers"
   | "agentTriggerLogs"
   | "spherseMetaDir"
@@ -42,6 +43,7 @@ const PATH_PATTERNS: Record<string, string> = {
   agentMcp: `${PROJECT_META_DIR}/agents/*/mcp.json`,
   agentSessions: `${PROJECT_META_DIR}/agents/*/sessions.db*`,
   agentSkills: `${PROJECT_META_DIR}/agents/*/skills/**`,
+  agentAssets: `${PROJECT_META_DIR}/agents/*/assets/**`,
   agentTriggers: `${PROJECT_META_DIR}/agents/*/triggers/index.yml`,
   agentTriggerLogs: `${PROJECT_META_DIR}/agents/*/triggers/logs.jsonl`,
   spherseMetaDir: PROJECT_META_DIR,

--- a/packages/presets/skills/spherse-create-agent-chat-theme/SKILL.md
+++ b/packages/presets/skills/spherse-create-agent-chat-theme/SKILL.md
@@ -100,12 +100,13 @@ Agent chat themes live in the agent directory as `theme.css` (`.spherse/agents/{
 
 主题以 `<link>` 从项目 preview 路由载入，CSS 中相对 `url()` 的解析基址为 agent 目录 `.spherse/agents/{agent-slug}/`。因此本地图片、字体等资源可以用相对路径正常引用。
 
-- **素材放在 agent 目录**：推荐把图片/字体放进 agent 目录，用相对路径引用：
+- **素材放在 agent 的 assets 目录**：推荐把图片/字体放进 `.spherse/agents/{agent-slug}/assets/`（该目录对你开放读写），theme.css 用相对路径引用：
   ```css
   [data-chat-root] {
-    background-image: url(./bg.png);
+    background-image: url(./assets/bg.png);
   }
   ```
+  注意 agent 目录根下的其它未归类文件（如直接放 `bg.png` 在 agent 目录）你无法写入；SVG 等文本素材可直接 `write_file` 创建，PNG/JPG 等二进制文件你无法直接生成，需要用户手动放入。
 - **引用项目内其它位置的文件**：用 `../` 跳出 agent 目录（`../` 到 `.spherse/`，再 `../` 到项目根）：
   ```css
   [data-chat-root] {

--- a/packages/presets/skills/spherse-create-agent-chat-theme/SKILL.md
+++ b/packages/presets/skills/spherse-create-agent-chat-theme/SKILL.md
@@ -107,10 +107,10 @@ Agent chat themes live in the agent directory as `theme.css` (`.spherse/agents/{
   }
   ```
   注意 agent 目录根下的其它未归类文件（如直接放 `bg.png` 在 agent 目录）你无法写入；SVG 等文本素材可直接 `write_file` 创建，PNG/JPG 等二进制文件你无法直接生成，需要用户手动放入。
-- **引用项目内其它位置的文件**：用 `../` 跳出 agent 目录（`../` 到 `.spherse/`，再 `../` 到项目根）：
+- **引用项目内其它位置的文件**：用 `../` 逐级跳出 agent 目录（`../` 到 `.spherse/agents/`，`../../` 到 `.spherse/`，`../../../` 到项目根）：
   ```css
   [data-chat-root] {
-    background-image: url(../assets/welcome.png);   /* 项目根 assets/ 下 */
+    background-image: url(../../../assets/welcome.png);   /* 项目根 assets/ 下 */
   }
   ```
 - **远程 URL**：`url(https://example.com/texture.png)` 照常工作，不受影响。


### PR DESCRIPTION
## 需求

为 `.spherse/agents/*/assets/` 开放 LLM 读写 + server 读权限，用于存放 agent 私有静态资源（theme.css 相对引用的图片/字体等）。改动小（一个内置类别 + 白名单），经确认跳过 design doc 直接实现。

## 方案

- `path-category.ts` 新增内置类别 `agentAssets`（`.spherse/agents/*/assets/**`），走内置类别而非 capability pathRule：pathRule 仅作用于 LLM 端，无法表达 SRV_READ（renderer 经 preview 路由加载素材必需）
- `access-policy.ts`：加入 LLM_READ / LLM_WRITE / SRV_READ；**不加 SRV_WRITE**（server 端无写入需求，PM 写门面对 assets 关闭，与「用户手动放入二进制素材」的指引一致）
- theme skill 素材推荐路径从 agent 目录根改为 `./assets/`（目录根未归类文件 LLM 仍不可写）
- 同步文档：data-conventions.md（目录树 + 18 类计数）、security.md（分类表 + 17/6 类白名单）、server.md（SRV read 清单）、glossary.md（计数）
- 测试：MATRIX 钉住四象限（文件 + 目录本身）、`assetsy` 负例

## 已知边界

- write_file 仅支持文本：SVG/字体可由 LLM 创建，PNG/JPG 等二进制需用户手动放入（skill 文案已说明）
- fs-watcher watched 集合不含 agentAssets（与 agentSkills 一致），素材变更不触发 renderer 热刷新，重进/刷新时生效（preview 有 ETag + no-cache）

## 验证

- core 1131 tests / server 257 tests / presets 5 tests 全过；lint + typecheck 干净