### PR TITLE
fix: 文档划选后支持 Ctrl/Cmd+C 键盘复制

### DIFF
--- a/docs/dev/bugfix/2026-08-29-text-selection-keyboard-copy/design.md
+++ b/docs/dev/bugfix/2026-08-29-text-selection-keyboard-copy/design.md
@@ -1,0 +1,25 @@
+# 文档浏览划选后支持 Ctrl/Cmd+C 复制
+
+- 日期：2026-08-29
+- 状态：已实施（lint、typecheck、E2E 通过）
+- 类型：bugfix（交互行为）
+- 影响范围：`packages/app`（`text-selection-session` feature，仅 Electron 生效）
+
+## 1. 问题
+
+用户反馈：在 content browser 浏览文档时划选文本后，习惯性按 Ctrl/Cmd+C 无法复制，只能点浮动工具栏的复制按钮，反直觉。
+
+## 2. 根因分析
+
+没有任何快捷键拦截。`useTextSelection.ts` 在 `mouseup` 时把选区快照进 React state 后调用 `selection.removeAllRanges()` 主动销毁原生选区（2026-06-02 bugfix 引入：为让「发起会话」弹窗打开、焦点进入输入框后高亮不消失，用 `SelectionHighlightOverlay` 替代原生高亮）。副作用是按键时原生复制已无可复制内容，Ctrl/Cmd+C 变成 no-op，浮动按钮成了唯一复制路径。
+
+## 3. 方案
+
+保留既有「快照 + 自绘高亮」设计，在快照存活期间补回键盘复制路径：
+
+- `useTextSelection` 新增 keydown effect：`selectionState` 存在时监听 Ctrl/Cmd+C（排除 Alt 组合），`preventDefault()` 后 `navigator.clipboard.writeText(selectionState.text)`，成功后清除选区状态，与工具栏复制按钮行为一致
+- 焦点在可编辑元素内（input/textarea/contentEditable，如弹窗补充说明输入框）时不拦截，保证编辑场景的原生复制不受影响
+
+## 4. 测试
+
+- `packages/desktop/e2e/text-selection-session.spec.ts` 新增用例：划选后原生选区已 collapse 的前提下按 Ctrl/Cmd+C，通过主进程 `clipboard.readText()` 断言剪贴板内容为选中文本，且工具栏与高亮 overlay 随之清除

--- a/docs/dev/bugfix/2026-08-29-text-selection-keyboard-copy/design.md
+++ b/docs/dev/bugfix/2026-08-29-text-selection-keyboard-copy/design.md
@@ -18,8 +18,14 @@
 保留既有「快照 + 自绘高亮」设计，在快照存活期间补回键盘复制路径：
 
 - `useTextSelection` 新增 keydown effect：`selectionState` 存在时监听 Ctrl/Cmd+C（排除 Alt 组合），`preventDefault()` 后 `navigator.clipboard.writeText(selectionState.text)`，成功后清除选区状态，与工具栏复制按钮行为一致
-- 焦点在可编辑元素内（input/textarea/contentEditable，如弹窗补充说明输入框）时不拦截，保证编辑场景的原生复制不受影响
+- 拦截前两个放行守卫：
+  - 焦点在可编辑元素内（input/textarea/contentEditable，如弹窗补充说明输入框）不拦截，保证编辑场景的原生复制不受影响
+  - 存在非空原生选区时不拦截（如 Ctrl+A 全选、或划选了 content 区域外的文本——该路径 mouseup 不清除旧快照），避免旧快照覆盖用户新选区
+- 已知取舍：keydown 监听不受 `disabled` 门控，「发起会话」弹窗打开期间（快照存活）焦点在非编辑区按 Ctrl/Cmd+C 仍会复制快照并连带关闭弹窗——视为任务完成路径，与 Escape/点击外部关闭一致
+- 快捷键匹配用 `event.key === "c"`（非拉丁布局下失效），与仓库既有 Cmd/Ctrl+F、Cmd/Ctrl+S 写法保持一致，不单独特殊化
 
 ## 4. 测试
 
-- `packages/desktop/e2e/text-selection-session.spec.ts` 新增用例：划选后原生选区已 collapse 的前提下按 Ctrl/Cmd+C，通过主进程 `clipboard.readText()` 断言剪贴板内容为选中文本，且工具栏与高亮 overlay 随之清除
+- `packages/desktop/e2e/text-selection-session.spec.ts` 新增用例：
+  - 划选后原生选区已 collapse 的前提下按 Ctrl/Cmd+C，通过主进程 `clipboard.readText()` 断言剪贴板内容为选中文本，且工具栏与高亮 overlay 随之清除（按键前 `clipboard.clear()` 作哨兵，排除本机剪贴板残留假阳性）
+  - 打开「发起会话」弹窗后在补充说明 textarea 内选中文本按 Ctrl/Cmd+C，断言剪贴板内容为所输文本（可编辑排除守卫生效）且弹窗不关闭

--- a/packages/app/src/features/text-selection-session/hooks/useTextSelection.ts
+++ b/packages/app/src/features/text-selection-session/hooks/useTextSelection.ts
@@ -40,6 +40,12 @@ function getHighlightRects(range: Range): HighlightRect[] {
   return fallback ? [fallback] : [];
 }
 
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  return target.closest("input, textarea") !== null;
+}
+
 function getButtonPosition(event: MouseEvent) {
   const minX = VIEWPORT_PADDING + BUTTON_ESTIMATED_WIDTH / 2;
   const maxX = window.innerWidth - VIEWPORT_PADDING - BUTTON_ESTIMATED_WIDTH / 2;
@@ -94,6 +100,23 @@ export function useTextSelection({
     document.addEventListener("mouseup", handleMouseUp);
     return () => document.removeEventListener("mouseup", handleMouseUp);
   }, [disabled]);
+
+  useEffect(() => {
+    if (!selectionState) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.key.toLowerCase() !== "c") return;
+      if (isEditableTarget(event.target)) return;
+      event.preventDefault();
+      navigator.clipboard
+        .writeText(selectionState.text)
+        .then(() => setSelectionState(null))
+        .catch(() => {});
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [selectionState]);
 
   useEffect(() => {
     if (!selectionState) return;

--- a/packages/app/src/features/text-selection-session/hooks/useTextSelection.ts
+++ b/packages/app/src/features/text-selection-session/hooks/useTextSelection.ts
@@ -104,9 +104,18 @@ export function useTextSelection({
   useEffect(() => {
     if (!selectionState) return;
 
+    // handleMouseUp snapshots the selection and destroys the native one
+    // (removeAllRanges), so Ctrl/Cmd+C alone has nothing to copy. While the
+    // snapshot is alive, serve the shortcut from the snapshot, mirroring the
+    // toolbar copy button.
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!(event.metaKey || event.ctrlKey) || event.altKey || event.key.toLowerCase() !== "c") return;
+      // Native copy inside editable targets (e.g. the start-session popover
+      // comment box) must keep working untouched.
       if (isEditableTarget(event.target)) return;
+      // A fresh native selection can coexist with the snapshot (Ctrl+A, or
+      // dragging outside the content area, which skips the mouseup clear) —
+      // let the native copy win instead of stale snapshot text.
       const nativeSelection = window.getSelection();
       if (nativeSelection && !nativeSelection.isCollapsed && nativeSelection.toString().trim()) return;
       event.preventDefault();

--- a/packages/app/src/features/text-selection-session/hooks/useTextSelection.ts
+++ b/packages/app/src/features/text-selection-session/hooks/useTextSelection.ts
@@ -107,6 +107,8 @@ export function useTextSelection({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!(event.metaKey || event.ctrlKey) || event.altKey || event.key.toLowerCase() !== "c") return;
       if (isEditableTarget(event.target)) return;
+      const nativeSelection = window.getSelection();
+      if (nativeSelection && !nativeSelection.isCollapsed && nativeSelection.toString().trim()) return;
       event.preventDefault();
       navigator.clipboard
         .writeText(selectionState.text)

--- a/packages/desktop/e2e/text-selection-session.spec.ts
+++ b/packages/desktop/e2e/text-selection-session.spec.ts
@@ -125,6 +125,45 @@ test("text selection session shows stable button, fixed popover, and highlight o
   }
 });
 
+test("text selection copies via Ctrl/Cmd+C after native selection is released", async () => {
+  const project = await createTextSelectionProject();
+  const { app, page } = await launchAppWithProject(project);
+
+  try {
+    await page.waitForSelector("text=The obsidian tower stands beside the northern sea.");
+    const mouseUp = { x: 720, y: 400 };
+    await page.evaluate(() => {
+      const textNode = [...document.querySelectorAll("p")]
+        .flatMap((node) => [...node.childNodes])
+        .find((node) => node.textContent?.includes("obsidian tower"));
+      if (!textNode) throw new Error("target text node not found");
+      const start = textNode.textContent!.indexOf("obsidian tower");
+      const end = start + "obsidian tower".length;
+      const range = document.createRange();
+      range.setStart(textNode, start);
+      range.setEnd(textNode, end);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+    await page.evaluate(({ x, y }) => {
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: x, clientY: y }));
+    }, mouseUp);
+
+    const toolbar = page.getByTestId("text-selection-toolbar");
+    await expect(toolbar).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.getSelection()?.isCollapsed ?? true)).toBe(true);
+
+    await page.keyboard.press("ControlOrMeta+c");
+
+    await expect.poll(() => app.evaluate(({ clipboard }) => clipboard.readText())).toBe("obsidian tower");
+    await expect(toolbar).toBeHidden();
+    await expect(page.getByTestId("text-selection-highlight")).toBeHidden();
+  } finally {
+    await app.close();
+  }
+});
+
 test("text selection session keeps long agent list scrollable in a compact viewport", async () => {
   const project = await createTextSelectionProject();
   const { app, page } = await launchAppWithProject(project);

--- a/packages/desktop/e2e/text-selection-session.spec.ts
+++ b/packages/desktop/e2e/text-selection-session.spec.ts
@@ -154,11 +154,61 @@ test("text selection copies via Ctrl/Cmd+C after native selection is released", 
     await expect(toolbar).toBeVisible();
     await expect.poll(() => page.evaluate(() => window.getSelection()?.isCollapsed ?? true)).toBe(true);
 
+    await app.evaluate(({ clipboard }) => clipboard.clear());
     await page.keyboard.press("ControlOrMeta+c");
 
     await expect.poll(() => app.evaluate(({ clipboard }) => clipboard.readText())).toBe("obsidian tower");
     await expect(toolbar).toBeHidden();
     await expect(page.getByTestId("text-selection-highlight")).toBeHidden();
+  } finally {
+    await app.close();
+  }
+});
+
+test("text selection keyboard copy does not hijack editable targets inside popover", async () => {
+  const project = await createTextSelectionProject();
+  const { app, page } = await launchAppWithProject(project);
+
+  try {
+    await page.waitForSelector("text=The obsidian tower stands beside the northern sea.");
+    const mouseUp = { x: 720, y: 400 };
+    await page.evaluate(() => {
+      const textNode = [...document.querySelectorAll("p")]
+        .flatMap((node) => [...node.childNodes])
+        .find((node) => node.textContent?.includes("obsidian tower"));
+      if (!textNode) throw new Error("target text node not found");
+      const start = textNode.textContent!.indexOf("obsidian tower");
+      const end = start + "obsidian tower".length;
+      const range = document.createRange();
+      range.setStart(textNode, start);
+      range.setEnd(textNode, end);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+    await page.evaluate(({ x, y }) => {
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: x, clientY: y }));
+    }, mouseUp);
+
+    const toolbar = page.getByTestId("text-selection-toolbar");
+    await expect(toolbar).toBeVisible();
+    await toolbar.getByRole("button", { name: "发起会话" }).click();
+    const popover = page.getByTestId("text-selection-popover");
+    await expect(popover).toBeVisible();
+
+    const commentText = "editable comment copy";
+    const commentInput = page.getByPlaceholder("添加补充说明（可选）...");
+    await commentInput.fill(commentText);
+    await commentInput.evaluate((el) => {
+      el.focus();
+      el.setSelectionRange(0, el.value.length);
+    });
+
+    await app.evaluate(({ clipboard }) => clipboard.clear());
+    await page.keyboard.press("ControlOrMeta+c");
+
+    await expect.poll(() => app.evaluate(({ clipboard }) => clipboard.readText())).toBe(commentText);
+    await expect(popover).toBeVisible();
   } finally {
     await app.close();
   }


### PR DESCRIPTION
## 问题

用户反馈:文档浏览划选文本后按 Ctrl/Cmd+C 无法复制,只能点浮动工具栏的复制按钮,反直觉。

## 根因

无快捷键拦截。`useTextSelection` 在 mouseup 时快照选区后调用 `selection.removeAllRanges()` 销毁原生选区(2026-06-02 bugfix 引入,为让弹窗打开后高亮不消失),副作用是 Ctrl/Cmd+C 无从复制。

## 方案

保留「快照 + 自绘高亮」设计,快照存活期间监听 keydown,Ctrl/Cmd+C 写入快照文本并清除选区,与工具栏复制按钮行为一致。拦截前两个放行守卫:

- 焦点在可编辑元素内(弹窗补充说明 textarea 等)不拦截
- 存在非空原生选区时不拦截(Ctrl+A、content 区域外划选等),避免旧快照覆盖新选区

设计文档:`docs/dev/bugfix/2026-08-29-text-selection-keyboard-copy/design.md`

## 验证

- lint / typecheck 通过
- `packages/desktop/e2e/text-selection-session.spec.ts` 4 个用例全部通过(含 2 个新增)

Refs #64
