### PR TITLE
fix: Electron 退出链路加超时兜底与 forceCloseConnections，消除 E2E app.close 间歇悬死

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,51 @@
+name: E2E
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.filter.outputs.docs-only }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect docs-only change
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA"...HEAD | grep -qvE '^docs/|\.md$'; then
+            echo "docs-only=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs-only=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  e2e:
+    needs: changes
+    if: needs.changes.outputs.docs-only == 'false'
+    runs-on: macos-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.19
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Electron E2E
+        run: npm run test:e2e --workspace=packages/desktop

--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -6,7 +6,6 @@
 
 ## Bug
 
-- [ ] **E2E `app.close()` 间歇悬死（存量基建 flake）**：顺序启动多个 Electron E2E 实例时，`app.close()` 偶发 60s 悬死（无断言失败、无页面快照；逐步日志定位到 close 不返回）。干净 main 可复现，疑点在 server shutdown 链路（`stopServer` → `registry.removeAll()` → capability `shutdown`/sqlite/fs-watch 关闭竞态）。修复方向：给 shutdown 各环节加超时并审计具体卡住的 await；临时缓解可在 CI 重试。
 - [ ] **损坏项目滞留 openProjects 无移除入口**：项目打开失败（project.yaml 损坏等）后该路径一直留在 openProjects 设置里，每次启动重试失败记日志，暂无 UI 内移除 / 修复入口。参见 `docs/dev/bugfix/2026-08-27-project-open-overwrite/design.md`（#42 遗留）
 - [ ] **审批卡 abort/run 结束后 pending 态残留**：run 被中断（`rejectAll` 不发 `control_resolved`）时，`run_command` 的 pending_approval CommandCard 与 `manage_agent`/`manage_trigger` 的 pending ApprovalCard 仍保留可交互按钮，点击后静默无效（bus 对未知 requestId 忽略）。ask_user 的 QuestionCard 已在 `run_status inactive` 时由 reducer 清除（`clearPendingQuestionCards`），approval 侧应复用同款收敛（terminalize 或清除），并补 reducer 测试。
 - [ ] **system-prompt XML 包裹对用户内容闭合标签不健壮**：`serializeSystemPrompt`（`packages/core/src/context/serialize.ts`）对 `<project-instructions>`/`<agent-profile>`/`<context-file>` 的 inner content 原样包裹、不转义。若用户的 AGENTS.md 或预载文件内含 `</project-instructions>` 等闭合标签，会破坏 system prompt 结构。需评估方案：对 inner content 转义、改用 CDATA、或在包裹时检测冲突标签；同时更新 `serialize.test.ts` 中「不转义 inner content」的现有断言。参见 `docs/dev/features/2026-07-02-context-engineering/design.md` §6.3

--- a/docs/dev/bugfix/2026-08-29-e2e-app-close-hang/design.md
+++ b/docs/dev/bugfix/2026-08-29-e2e-app-close-hang/design.md
@@ -1,0 +1,114 @@
+# E2E `app.close()` 间歇悬死（Electron 退出链路无界等待）
+
+## 现象
+
+backlog #Bug 首条：顺序启动多个 Electron E2E 实例时，`app.close()` 偶发 60s 悬死——无断言失败、无页面快照，逐步日志定位到 close 不返回；干净 main 可复现。
+
+Playwright 的 `app.close()` 等待 Electron **主进程退出**。主进程退出依赖 `gracefulShutdown`（`electron/main.ts:35`）链完成：
+
+```
+window-all-closed / before-quit
+  → gracefulShutdown()                ← 无任何超时
+    → await tunnelManager.stop()      （E2E 下 no-op）
+    → await stopServer()              （electron/server.ts:97）
+      → await registry.removeAll()    （逐项目 runtime.shutdown）
+        → sessionRuntime.closeAll()   （同步清 map）
+        → capability.shutdown?.()     （trigger 同步；mcp → client.close()）
+        → projectManager.close()      （better-sqlite3 同步）
+      → await fastify.close()
+    → app.quit()
+```
+
+链上任一 await 悬死 → `app.quit()` 永不执行 → 进程不退 → Playwright 60s 超时。这就是「悬死」的传导机制。
+
+## 根因
+
+### 结构性放大器：退出链零超时
+
+`gracefulShutdown` → `stopServer` → `removeAll` → `runtime.shutdown` → `fastify.close` 全链无超时、无兜底退出。任何一个 await 挂起即无限期阻塞进程退出，flake 必然表现为整条 E2E 悬死而非可诊断的局部错误。
+
+### 最可能的具体悬点：`fastify.close()` 等待残留连接（机制已验证）
+
+读依赖源码确认的机制链：
+
+1. `@fastify/websocket` v11 的 `defaultPreClose`（`@fastify/websocket/index.js:218-231`）对每个 ws client 调 `client.close()`——**优雅关闭握手**（发 close 帧后等对端回应），非 `terminate()`；已进入 `wss.clients` 的连接，ws 8.x 的 `closeTimeout`（默认 30s）会让停滞握手最终 terminate——**有界但长达 30s**；
+2. **无界悬死**来自不在 `wss.clients` 内的活跃连接：升级后的 ws raw socket 对 Node http server 是「活跃连接」，`server.close()` 回调要等所有活跃连接结束；若连接恰处 mid-upgrade（尚未完成升级交接，不在 `wss.clients`，`preClose` 不可见）或因 renderer 销毁时序竞态未走完关闭握手，该 socket 无任何超时机制兜底；
+3. Fastify 5 的 `forceCloseConnections` 默认值：Node 支持 `closeIdleConnections` 时为 `'idle'`（`fastify/lib/server.js:134-136`）——只关**空闲**连接，不覆盖活跃 ws。
+
+间歇性、顺序多实例才复现的特征与「renderer 销毁 / mid-upgrade 时序竞态」一致。E2E 观察到的 60s 悬死要求无界变体（30s 有界变体单独不足以触发 Playwright 超时）。确切触发该 socket 残留的具体窗口期无法静态钉死，但修复不依赖于此：`forceCloseConnections: true` 对「连接残留」整类悬死（有界/无界变体）均有效。
+
+### 次级悬点与脆弱点
+
+- MCP capability shutdown（`core/src/capabilities/mcp/index.ts:102` → `client.close()`）：stdio transport 的 close 等子进程退出，无界（E2E fixture 不配 MCP server，概率低，真实用户可踩）；
+- `ProjectRuntime.shutdown`（`core/src/project-runtime.ts:101-103`）逐个 `await capability.shutdown?.()`，**某个 capability 抛错会中断后续 capability 与 `projectManager.close()`**——顺带修复（错误隔离）。
+
+### 排除项（同步 API，不可能悬死，推翻 backlog 原猜想）
+
+- sqlite：better-sqlite3 同步 `close()`（阻塞但不悬死）；
+- fs-watch：`FSWatcher.close()` 同步；
+- `sessionRuntime.closeAll()`：同步清 map；
+- tunnel stop：E2E 下 mobile 未启用，no-op。
+
+## 修复方案（三层防御）
+
+### 层 1：退出出口兜底（消灭症状，必做）
+
+**`electron/main.ts` `gracefulShutdown`**：
+
+- 入口处布置硬兜底定时器：30s 后仍未走完则 `console.error` 诊断 + `app.exit(1)` 强制退出（`unref()`，正常退出时进程终止即作废，无需手动清理）。`app.exit` 无视一切未决 handle 与 quit 拦截，保证进程退出有界；
+- tunnel stop 包 5s 超时：超时记日志继续（cloudflared 子进程随强制退出路径终结局可接受）。
+
+最坏路径：5s（tunnel）+ 10s（removeAll）+ 10s（fastify）= 25s < 30s 硬兜底，各阶段超时日志先行落盘，硬兜底只兜「app.quit 本身挂住」等未预期路径。
+
+### 层 2：根因修复 + 全链超时审计（定位并消灭悬死本身）
+
+**`server/src/index.ts`**：Fastify 构造选项加 `forceCloseConnections: true`。Fastify 5 关闭时序（`fastify.js:381` 已验证）为 `preClose` hooks → `closeAllConnections()`（Node ≥ 18.2，Electron 41 = Node 22 可用）→ `server.close()`。注意：`@fastify/websocket` 的 `defaultPreClose` 在发起优雅关闭后**同步** `done()`（`index.js:228-230`），`closeAllConnections` 会在约一个 tick 后强杀残留 socket——早于 WS 关闭握手完成，客户端实际观察到的是异常关闭（1006）而非干净关闭（1000）。已验证 renderer 侧容忍：chat runtime 仅把 `SESSION_UNRECOVERABLE` 视为 fatal（`chat-session-runtime.ts:21-23`），1006 走重连退避路径；bus store 同款 `scheduleReconnect`。`restartServerWithAuth` 路径 server 会重启，客户端靠重连恢复，语义不变。本地桌面 server 在应用退出时切断客户端连接，语义可接受。
+
+**`electron/server.ts`**：抽 `closeServerHandle`（`stopServer` 与 `restartServerWithAuth` 复用），**入口即置空模块级 `serverHandle`**（并发 stop/restart 双重进入时第二次调用直接 no-op，消除对同一 handle 的 double-close 竞态），`registry.removeAll()` 与 `fastify.close()` 各包 10s 超时，超时 `console.error` 记录卡住的 stage 名。
+
+**`core/src/project-runtime.ts` `shutdown`**：逐 capability 的 `shutdown?.()` 包超时（5s）+ 错误隔离——超时或抛错记 `logger.warn` 后继续下一个 capability，保证 `projectManager.close()` 必达。
+
+**共享工具 `core/src/utils/settle-within.ts`**：`settleWithin(promise, timeoutMs, onSettle)`——永不 reject；正常完成时 `clearTimeout` 且**不**回调 `onSettle`（settled-guard，防止迟到的定时器在健康关闭路径打出伪错误日志）；仅超时或源 promise reject 时一次性回调 `onSettle("timeout" | "error", detail?)` 后 resolve；timer `unref()`；`promise` 为空时立即 resolve。core 与 desktop 三处复用，从 `@spherse/core` 导出（外部实际使用，符合导出规范）。
+
+### 层 3：E2E 侧防御（冗余保险）
+
+`e2e/helpers/electron.ts` 新增导出 `closeApp(app)`：`Promise.race(app.close(), 20s timeout)`，超时 `app.process().kill("SIGKILL")` 兜底——提炼自 `floating-chat.spec.ts:75-87` 既有本地实现，替换全部 spec 的 `await app.close()` / `app?.close()` 调用（含 `unsafe-location-guard.spec.ts`、`app-launch.spec.ts` 的 optional-chaining 变体，共 16 个文件）。20s 选择：正常退出 < 2s；主进程侧 stage 超时日志（5s/10s/10s 档）在最坏 25s 叠加路径下也能先于 kill 落盘前两条，诊断信息基本不丢；主进程 30s 硬兜底作为真实用户场景的最终防线，E2E 无需等它。
+
+## 影响面
+
+- core：新增 `utils/settle-within.ts` + 测试；`project-runtime.ts` shutdown 错误隔离 + 超时；`index.ts` 导出 `settleWithin`
+- server：`index.ts` Fastify 选项 `forceCloseConnections: true` + `create-server.test.ts` 契约断言
+- desktop：`electron/main.ts` 硬兜底 + tunnel 超时；`electron/server.ts` `closeServerHandle` 分阶段超时；`e2e/helpers/electron.ts` `closeApp` + 16 个 spec 调用点机械替换（`floating-chat.spec.ts` 删本地重复实现）
+- i18n / app：不改（无用户可见文案变化；30s 强退仅在已挂死路径发生）
+
+## 测试
+
+- core `__tests__/utils/settle-within.test.ts`：正常完成即透传且**不触发 onSettle（含迟到的定时器不回调）**、超时回调并 resolve、源 promise reject 回调并 resolve（不产生 unhandled rejection）、空 promise 立即 resolve。
+- core `__tests__/project-runtime-shutdown.test.ts`：直接构造 `ProjectRuntime`（fake projectManager/sessionRuntime/capabilities）——① 某 capability shutdown 永不 resolve → `runtime.shutdown()` 在超时内返回且后续 capability 的 shutdown 与 `projectManager.close` 仍执行；② 某 capability shutdown 抛错 → 不中断后续 capability；③ 正常路径行为不变（close 仍被调用）。
+- server `__tests__/create-server.test.ts`：断言 `fastify.initialConfig.forceCloseConnections === true`（钉住配置不回退）。
+- desktop `electron/__tests__/server-shutdown.test.ts`：mock `electron` / `./settings.js` / `./model-catalog.js` / `@spherse/server`——① `ensureServer` 注入永不 resolve 的 `registry.removeAll()` → `stopServer()` 在超时内返回且输出 stage 超时日志，且 `fastify.close` 仍被调用；② `restartServerWithAuth` 同样走 `closeServerHandle`（断言两阶段均执行）；③ stop 后再次 `stopServer()` no-op（handle 已入口置空）。
+- `main.ts` `gracefulShutdown` 不做单测（入口模块依赖重、mock 成本高于收益），由 E2E 与 code review 覆盖。
+- E2E 验证：改动涉及 Electron 启动与 E2E helper，跑 `app-launch.spec.ts` + `file-tree.spec.ts` + `floating-chat.spec.ts`（共享 `closeApp` 的直接消费者）。
+
+## 行为变更说明
+
+- 所有用户的 app 退出：最坏多等 ~30s 后强制退出（此前无限挂死）；正常路径无感知。
+- server 关闭时主动切断仍开着的客户端连接（chat/bus ws、keep-alive）：客户端观察到 1006 异常关闭并走既有重连路径（chat runtime / bus store 均容忍，仅 `SESSION_UNRECOVERABLE` 为 fatal）；桌面单用户与 hosted web 远程连接语义一致——退出本就无法服务，`restartServerWithAuth` 重启后靠重连恢复。
+- capability shutdown 抛错不再中断其余 capability 与 sqlite 关闭（此前会跳过）。
+
+## 残余风险（接受）
+
+- 30s 硬兜底只覆盖 `gracefulShutdown` 入口之后的挂死；入口之前（如 `window-all-closed` 因窗口未关而不触发）真实用户场景无兜底——E2E 由 SIGKILL 层覆盖。
+- stage 超时不取消底层工作：`removeAll` 超时后各 runtime 仍在后台继续关闭，最坏被 30s `app.exit(1)` 截断在 sqlite 关闭之前，依赖 WAL 恢复兜底。
+- 逐 capability 顺序 5s 超时 × N 在多 capability 场景叠加可超过外层 10s `removeAll` 预算，stage 日志只能定位到 `removeAll` 档，需结合 capability warn 日志进一步定位（两者时间戳可对齐）。
+
+## 不做的事（记录理由）
+
+- **不静态钉死「哪个 await 挂」作为修复前提**：间歇竞态无法离线复现穷举；分层超时 + stage 日志让下一次复发时日志直接点名（backlog 修复方向「审计具体卡住的 await」由此达成）。
+- **不给 `app.quit()` 之后的窗口关闭流程再加超时**：30s 硬兜底 `app.exit(1)` 已覆盖该路径全部挂法。
+- **不改 `@fastify/websocket` preClose 的优雅关闭语义**：`closeAllConnections` 在 preClose 后强杀残留，客户端 1006 + 重连的代价已由 renderer 既有重连逻辑吸收，无需自定义 preClose。
+
+## 文档同步（实现完成后执行 doc-sync）
+
+- `docs/dev/backlog.md`：删除「E2E `app.close()` 间歇悬死」条目（完成即删）
+- `docs/official/project-structure.md`：新增 `packages/core/src/utils/settle-within.ts`（及两个测试文件）

--- a/docs/dev/bugfix/2026-08-29-e2e-app-close-hang/design.md
+++ b/docs/dev/bugfix/2026-08-29-e2e-app-close-hang/design.md
@@ -72,13 +72,13 @@ window-all-closed / before-quit
 
 ### 层 3：E2E 侧防御（冗余保险）
 
-`e2e/helpers/electron.ts` 新增导出 `closeApp(app)`：`Promise.race(app.close(), 20s timeout)`，超时 `app.process().kill("SIGKILL")` 兜底——提炼自 `floating-chat.spec.ts:75-87` 既有本地实现，替换全部 spec 的 `await app.close()` / `app?.close()` 调用（含 `unsafe-location-guard.spec.ts`、`app-launch.spec.ts` 的 optional-chaining 变体，共 16 个文件）。20s 选择：正常退出 < 2s；主进程侧 stage 超时日志（5s/10s/10s 档）在最坏 25s 叠加路径下也能先于 kill 落盘前两条，诊断信息基本不丢；主进程 30s 硬兜底作为真实用户场景的最终防线，E2E 无需等它。
+`e2e/helpers/electron.ts` 新增导出 `closeApp(app)`：`Promise.race(app.close(), 20s timeout)`，超时 `app.process().kill("SIGKILL")` 兜底——提炼自 `floating-chat.spec.ts:75-87` 既有本地实现，替换全部 spec 的 `await app.close()` / `app?.close()` 调用（含 `unsafe-location-guard.spec.ts`、`app-launch.spec.ts`、`packaged-smoke.spec.ts` 的 optional-chaining 变体，共 18 个 spec 文件）。20s 选择：正常退出 < 2s；主进程侧 stage 超时日志（5s/10s/10s 档）在最坏 25s 叠加路径下也能先于 kill 落盘前两条，诊断信息基本不丢；主进程 30s 硬兜底作为真实用户场景的最终防线，E2E 无需等它。
 
 ## 影响面
 
 - core：新增 `utils/settle-within.ts` + 测试；`project-runtime.ts` shutdown 错误隔离 + 超时；`index.ts` 导出 `settleWithin`
 - server：`index.ts` Fastify 选项 `forceCloseConnections: true` + `create-server.test.ts` 契约断言
-- desktop：`electron/main.ts` 硬兜底 + tunnel 超时；`electron/server.ts` `closeServerHandle` 分阶段超时；`e2e/helpers/electron.ts` `closeApp` + 16 个 spec 调用点机械替换（`floating-chat.spec.ts` 删本地重复实现）
+- desktop：`electron/main.ts` 硬兜底 + tunnel 超时；`electron/server.ts` `closeServerHandle` 分阶段超时；`e2e/helpers/electron.ts` `closeApp` + 18 个 spec 调用点机械替换（`floating-chat.spec.ts` 删本地重复实现）
 - i18n / app：不改（无用户可见文案变化；30s 强退仅在已挂死路径发生）
 
 ## 测试
@@ -86,9 +86,9 @@ window-all-closed / before-quit
 - core `__tests__/utils/settle-within.test.ts`：正常完成即透传且**不触发 onSettle（含迟到的定时器不回调）**、超时回调并 resolve、源 promise reject 回调并 resolve（不产生 unhandled rejection）、空 promise 立即 resolve。
 - core `__tests__/project-runtime-shutdown.test.ts`：直接构造 `ProjectRuntime`（fake projectManager/sessionRuntime/capabilities）——① 某 capability shutdown 永不 resolve → `runtime.shutdown()` 在超时内返回且后续 capability 的 shutdown 与 `projectManager.close` 仍执行；② 某 capability shutdown 抛错 → 不中断后续 capability；③ 正常路径行为不变（close 仍被调用）。
 - server `__tests__/create-server.test.ts`：断言 `fastify.initialConfig.forceCloseConnections === true`（钉住配置不回退）。
-- desktop `electron/__tests__/server-shutdown.test.ts`：mock `electron` / `./settings.js` / `./model-catalog.js` / `@spherse/server`——① `ensureServer` 注入永不 resolve 的 `registry.removeAll()` → `stopServer()` 在超时内返回且输出 stage 超时日志，且 `fastify.close` 仍被调用；② `restartServerWithAuth` 同样走 `closeServerHandle`（断言两阶段均执行）；③ stop 后再次 `stopServer()` no-op（handle 已入口置空）。
+- desktop `electron/server-shutdown.test.ts`（co-located，仿包内 `updater.test.ts` 惯例）：mock `electron` / `./settings.js` / `./model-catalog.js` / `@spherse/server`——① `ensureServer` 注入永不 resolve 的 `registry.removeAll()` → `stopServer()` 在超时内返回且输出 stage 超时日志，且 `fastify.close` 仍被调用；② `restartServerWithAuth` 同样走 `closeServerHandle`（断言两阶段均执行）；③ stop 后再次 `stopServer()` no-op（handle 已入口置空）。
 - `main.ts` `gracefulShutdown` 不做单测（入口模块依赖重、mock 成本高于收益），由 E2E 与 code review 覆盖。
-- E2E 验证：改动涉及 Electron 启动与 E2E helper，跑 `app-launch.spec.ts` + `file-tree.spec.ts` + `floating-chat.spec.ts`（共享 `closeApp` 的直接消费者）。
+- E2E 验证：改动涉及 Electron 启动与 E2E helper，跑 `app-launch.spec.ts` + `file-tree.spec.ts` + `floating-chat.spec.ts`（共享 `closeApp` 的直接消费者），以及调用点被机械替换的 `chat-retry` / `chat-streaming-resilience` / `chat-withdraw` / `project-close` / `text-selection-session`。
 
 ## 行为变更说明
 

--- a/docs/official/project-structure.md
+++ b/docs/official/project-structure.md
@@ -62,7 +62,7 @@ spherse/
 │   │       ├── attachments/          # 附件域：AttachmentProcessor 端口 + image-processor + sanitizer（base64 卫生不变量）+ strip/sanitize
 │   │       ├── mcp/                  # mcp-client（连接与工具适配）/ mcp-connection-manager / config / types / json-schema-to-typebox
 │   │       ├── model-providers/      # ModelCatalog 类（per-runtime 实例，所有权在组合根）+ zhipu/openai images + index（仅 images 静态目录导出）
-│   │       ├── utils/                # file-write-mutex（全链路唯一实例）/ fs-walk / path-safety / binary-detect / xml-escape
+│   │       ├── utils/                # file-write-mutex（全链路唯一实例）/ fs-walk / path-safety / binary-detect / xml-escape / settle-within（shutdown 等待有界化）
 │   │       ├── __tests__/            # Vitest 单元测试（kernel/capabilities/session/access/tools 分组）
 │   │       └── index.ts              # 公开导出（显式清单，按外部消费面收紧）
 │   ├── presets/                      # @spherse/presets — 内置模板与预置静态内容

--- a/docs/official/project-structure.md
+++ b/docs/official/project-structure.md
@@ -391,6 +391,7 @@ spherse/
 │   └── workflows/
 │       ├── build-and-release.yml     # Git tag 触发的 CI：mac/win 并行构建 + GitHub Releases 发布 + OSS 镜像/latest.json + publish-changelog 生成上传 changelog.json + 末尾 dispatch deploy-pages 联动 web 部署
 │       ├── pr-build.yml              # PR 触发的 CI：checkout + npm ci + npm run verify（lint/build/typecheck/单测/i18n check）
+│       ├── e2e.yml                   # PR 触发的 CI：macOS runner 跑 Electron E2E 全套（非 required，结果仅供参考；docs-only 跳过）
 │       └── deploy-pages.yml          # main 分支 landing/web/i18n 变更或发版流水线 workflow_dispatch 触发的 CI：构建并部署到 GitHub Pages
 ├── .husky/
 │   └── pre-commit                    # Husky pre-commit 钩子（执行 npm run lint）

--- a/packages/core/src/__tests__/project-runtime-shutdown.test.ts
+++ b/packages/core/src/__tests__/project-runtime-shutdown.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectRuntime } from "../project-runtime.js";
+import { createSilentLogger } from "../logger.js";
+import type { Capability } from "../kernel/capability.js";
+import type { ProjectManager } from "../project-manager.js";
+import type { SessionManager } from "../session/session-manager.js";
+
+type FakeCapability = Partial<Capability> & { id: string };
+
+function makeRuntime(capabilities: FakeCapability[]) {
+  const projectManager = { close: vi.fn() };
+  const sessionRuntime = { closeAll: vi.fn(async () => {}) };
+  const runtime = new ProjectRuntime({
+    projectManager: projectManager as unknown as ProjectManager,
+    sessionRuntime: sessionRuntime as unknown as SessionManager,
+    projectId: "p1",
+    logger: createSilentLogger(),
+    capabilities: capabilities as unknown as ReadonlyArray<Capability>,
+  });
+  return { runtime, projectManager };
+}
+
+describe("ProjectRuntime.shutdown stage isolation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("times out a hanging capability shutdown and still runs the rest", async () => {
+    const order: string[] = [];
+    const { runtime, projectManager } = makeRuntime([
+      { id: "hang", shutdown: () => new Promise<void>(() => {}) },
+      { id: "next", shutdown: async () => { order.push("next"); } },
+    ]);
+    let resolved = false;
+    void runtime.shutdown().then(() => {
+      resolved = true;
+    });
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(resolved).toBe(true);
+    expect(order).toEqual(["next"]);
+    expect(projectManager.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues past a capability shutdown that rejects", async () => {
+    const order: string[] = [];
+    const { runtime, projectManager } = makeRuntime([
+      { id: "bad", shutdown: async () => { throw new Error("boom"); } },
+      { id: "next", shutdown: async () => { order.push("next"); } },
+    ]);
+    await runtime.shutdown();
+    expect(order).toEqual(["next"]);
+    expect(projectManager.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs all capability shutdowns and closes the project manager on the happy path", async () => {
+    const first = vi.fn(async () => {});
+    const { runtime, projectManager } = makeRuntime([
+      { id: "a", shutdown: first },
+      { id: "b" },
+    ]);
+    await runtime.shutdown();
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(projectManager.close).toHaveBeenCalledTimes(1);
+    await runtime.shutdown();
+    expect(projectManager.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/__tests__/utils/settle-within.test.ts
+++ b/packages/core/src/__tests__/utils/settle-within.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { settleWithin } from "../../utils/settle-within.js";
+
+describe("settleWithin", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves when the promise resolves without calling onSettle", async () => {
+    const onSettle = vi.fn();
+    await settleWithin(Promise.resolve("ok"), 1_000, onSettle);
+    expect(onSettle).not.toHaveBeenCalled();
+  });
+
+  it("resolves immediately for an empty promise", async () => {
+    const onSettle = vi.fn();
+    await settleWithin(undefined, 1_000, onSettle);
+    await settleWithin(null, 1_000, onSettle);
+    expect(onSettle).not.toHaveBeenCalled();
+  });
+
+  it("calls onSettle with timeout and resolves when the promise never settles", async () => {
+    const onSettle = vi.fn();
+    const pending = new Promise<void>(() => {});
+    let resolved = false;
+    void settleWithin(pending, 5_000, onSettle).then(() => {
+      resolved = true;
+    });
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(resolved).toBe(true);
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    expect(onSettle).toHaveBeenCalledWith("timeout");
+  });
+
+  it("does not call onSettle from a late timer after normal resolution", async () => {
+    const onSettle = vi.fn();
+    let resolvePromise!: () => void;
+    const promise = new Promise<void>((resolve) => {
+      resolvePromise = resolve;
+    });
+    const result = settleWithin(promise, 5_000, onSettle);
+    resolvePromise();
+    await result;
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(onSettle).not.toHaveBeenCalled();
+  });
+
+  it("calls onSettle with error and resolves when the promise rejects", async () => {
+    const onSettle = vi.fn();
+    const err = new Error("boom");
+    await settleWithin(Promise.reject(err), 1_000, onSettle);
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    expect(onSettle).toHaveBeenCalledWith("error", err);
+  });
+
+  it("does not call onSettle again when the promise rejects after timeout", async () => {
+    const onSettle = vi.fn();
+    let rejectPromise!: (err: Error) => void;
+    const promise = new Promise<void>((_, reject) => {
+      rejectPromise = reject;
+    });
+    const result = settleWithin(promise, 5_000, onSettle);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    rejectPromise(new Error("late"));
+    await result;
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onSettle).toHaveBeenCalledTimes(1);
+  });
+
+  it("survives an onSettle callback that throws", async () => {
+    const onSettle = vi.fn(() => {
+      throw new Error("callback blew up");
+    });
+    await expect(
+      settleWithin(Promise.reject(new Error("boom")), 1_000, onSettle),
+    ).resolves.toBeUndefined();
+    const hanging = settleWithin(new Promise<void>(() => {}), 1_000, onSettle);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(hanging).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,7 @@ export { serverAccessPolicy } from "./access/access-policy.js";
 export type { AccessPolicy, Decision } from "./access/access-policy.js";
 export { shouldSkipDirEntry } from "./utils/fs-walk.js";
 export { isBinaryBuffer, BINARY_SAMPLE_SIZE } from "./utils/binary-detect.js";
+export { settleWithin } from "./utils/settle-within.js";
 export { ModelCatalog, getImageSupportedProviders, CUSTOM_PROVIDER_DEFAULTS } from "./model-providers/index.js";
 export type { Logger } from "./logger.js";
 export type { AgentEvent, AgentMessage } from "@earendil-works/pi-agent-core";

--- a/packages/core/src/project-runtime.ts
+++ b/packages/core/src/project-runtime.ts
@@ -8,6 +8,9 @@ import type { DataStore } from "./capabilities/data/index.js";
 import type { AgentConfigChangeKind, Capability } from "./kernel/capability.js";
 import type { AgentProfile } from "./types.js";
 import { type Logger, createSilentLogger } from "./logger.js";
+import { settleWithin } from "./utils/settle-within.js";
+
+const CAPABILITY_SHUTDOWN_TIMEOUT_MS = 5_000;
 
 export class ProjectRuntime {
   readonly projectManager: ProjectManager;
@@ -99,7 +102,22 @@ export class ProjectRuntime {
     this.logger.info({ projectId: this.projectId }, "project runtime shutting down");
     await this.sessionRuntime.closeAll();
     for (const capability of this.capabilities) {
-      await capability.shutdown?.();
+      await settleWithin(
+        capability.shutdown?.(),
+        CAPABILITY_SHUTDOWN_TIMEOUT_MS,
+        (outcome, detail) => {
+          this.logger.warn(
+            {
+              projectId: this.projectId,
+              capability: capability.id,
+              outcome,
+              err: outcome === "error" ? detail : undefined,
+              timeoutMs: CAPABILITY_SHUTDOWN_TIMEOUT_MS,
+            },
+            "capability shutdown did not complete, continuing",
+          );
+        },
+      );
     }
     this.projectManager.close();
   }

--- a/packages/core/src/utils/settle-within.ts
+++ b/packages/core/src/utils/settle-within.ts
@@ -1,0 +1,37 @@
+export type SettleOutcome = "timeout" | "error";
+
+export function settleWithin(
+  promise: Promise<unknown> | undefined | null,
+  timeoutMs: number,
+  onSettle: (outcome: SettleOutcome, detail?: unknown) => void,
+): Promise<void> {
+  if (!promise) return Promise.resolve();
+  return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        onSettle("timeout");
+      } catch { /* ignore */ }
+      resolve();
+    }, timeoutMs);
+    timer.unref();
+    promise.then(
+      () => {
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      },
+      (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        try {
+          onSettle("error", err);
+        } catch { /* ignore */ }
+        resolve();
+      },
+    );
+  });
+}

--- a/packages/desktop/e2e/agent-dialog.spec.ts
+++ b/packages/desktop/e2e/agent-dialog.spec.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { closeApp } from "./helpers/electron";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const appRoot = path.resolve(__dirname, "..");
@@ -94,7 +96,7 @@ test("search file suggestions appear when typing in agent dialog", async () => {
     const suggestion = page.getByText("world/characters.md");
     await expect(suggestion).toBeVisible({ timeout: 5000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -117,7 +119,7 @@ test("clicking suggestion adds path as badge in agent dialog", async () => {
     const badge = page.locator("[data-slot='badge']").filter({ hasText: "world/locations.md" });
     await expect(badge).toBeVisible({ timeout: 3000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -137,6 +139,6 @@ test("enter key manually adds typed path in agent dialog", async () => {
     const badge = page.locator("[data-slot='badge']").filter({ hasText: "world/history/timeline.md" });
     await expect(badge).toBeVisible({ timeout: 3000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/agent-list.spec.ts
+++ b/packages/desktop/e2e/agent-list.spec.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { closeApp } from "./helpers/electron";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const appRoot = path.resolve(__dirname, "..");
@@ -141,7 +143,7 @@ test("right-click session row opens context menu with rename, rename updates tit
 
     await expect(page.getByText("My Renamed Session")).toBeVisible();
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -173,7 +175,7 @@ test("rename with empty input shows validation error and keeps editing", async (
 
     await expect(page.getByText("Valid Name")).toBeVisible();
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -205,7 +207,7 @@ test("escape cancels rename without saving", async () => {
     const titleAfterCancel = await sessionRow.textContent();
     expect(titleAfterCancel).toBe(originalTitle);
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -224,7 +226,7 @@ test("all agents are collapsed by default", async () => {
     await expect(agentTrigger(page, "Researcher")).not.toHaveAttribute("data-panel-open", "");
     await expect(agentTrigger(page, "Reviewer")).not.toHaveAttribute("data-panel-open", "");
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -249,6 +251,6 @@ test("expanding all agents keeps them all open — no auto-collapse", async () =
     await expect(agentPanel(page, "Writer")).toHaveAttribute("data-open", "");
     await expect(agentPanel(page, "Researcher")).toHaveAttribute("data-open", "");
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/app-launch.spec.ts
+++ b/packages/desktop/e2e/app-launch.spec.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createFileTreeProject } from "./helpers/file-tree";
 
+import { closeApp } from "./helpers/electron";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const appRoot = path.resolve(__dirname, "..");
@@ -50,6 +52,6 @@ test("app launches and shows main UI", async () => {
     await expect(page.locator("aside")).toBeVisible();
     await expect(page.getByText("文件")).toBeVisible();
   } finally {
-    await app?.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/chat-retry.spec.ts
+++ b/packages/desktop/e2e/chat-retry.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@playwright/test";
-import {
-
 import { closeApp } from "./helpers/electron";
+import {
   createChatProject,
   launchChatApp,
   getServerPort,

--- a/packages/desktop/e2e/chat-retry.spec.ts
+++ b/packages/desktop/e2e/chat-retry.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 import {
+
+import { closeApp } from "./helpers/electron";
   createChatProject,
   launchChatApp,
   getServerPort,
@@ -51,7 +53,7 @@ test("failed assistant response shows error with retry button; retry produces a 
     await page.waitForSelector("text=Retried successfully", { timeout: 5000 });
     await expect(page.locator("[data-chat-error]")).toHaveCount(0);
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -101,6 +103,6 @@ test("error event (pre-prompt failure) shows error UI; retry resends the message
     await page.waitForSelector("text=Recovered", { timeout: 5000 });
     await expect(page.locator("[data-chat-error]")).toHaveCount(0);
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/chat-streaming-resilience.spec.ts
+++ b/packages/desktop/e2e/chat-streaming-resilience.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import {
+
+import { closeApp } from "./helpers/electron";
   createChatProject,
   launchChatApp,
   getServerPort,
@@ -44,7 +46,7 @@ test("abort button visible throughout entire agent turn until agent_end", async 
     await expect(page.locator("[data-chat-composer] button svg.lucide-send")).toBeVisible();
     await expect(textarea).toHaveValue("typed while streaming");
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -76,7 +78,7 @@ test("streaming continues after switching away and back", async () => {
     await page.waitForSelector("text=Based on the file content.", { timeout: 10000 });
     await expect(page.locator("[data-chat-composer] button svg.lucide-send")).toBeVisible({ timeout: 10000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -114,6 +116,6 @@ test("sidebar shows streaming indicator on background session", async () => {
 
     await page.waitForSelector(`[data-session-id="${sessionA}"] svg.lucide-loader-circle`, { state: "hidden", timeout: 10000 }).catch(() => {});
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/chat-streaming-resilience.spec.ts
+++ b/packages/desktop/e2e/chat-streaming-resilience.spec.ts
@@ -1,8 +1,7 @@
 import { expect, test } from "@playwright/test";
+import { closeApp } from "./helpers/electron";
 import type { Page } from "@playwright/test";
 import {
-
-import { closeApp } from "./helpers/electron";
   createChatProject,
   launchChatApp,
   getServerPort,

--- a/packages/desktop/e2e/chat-withdraw.spec.ts
+++ b/packages/desktop/e2e/chat-withdraw.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@playwright/test";
-import {
-
 import { closeApp } from "./helpers/electron";
+import {
   createChatProject,
   launchChatApp,
   getServerPort,

--- a/packages/desktop/e2e/chat-withdraw.spec.ts
+++ b/packages/desktop/e2e/chat-withdraw.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 import {
+
+import { closeApp } from "./helpers/electron";
   createChatProject,
   launchChatApp,
   getServerPort,
@@ -54,7 +56,7 @@ test("withdraw button removes the last user turn after server confirms", async (
     await expect(page.locator("text=Answer")).toHaveCount(0);
     expect(received).toEqual(["withdraw"]);
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -102,6 +104,6 @@ test("withdraw failure shows error without retry affordance", async () => {
     await expect(page.locator("[data-chat-retry]")).toHaveCount(0);
     await expect(page.locator("text=question")).toBeVisible();
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/data-json-selective.spec.ts
+++ b/packages/desktop/e2e/data-json-selective.spec.ts
@@ -6,6 +6,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { closeApp } from "./helpers/electron";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const appRoot = path.resolve(__dirname, "..");
@@ -148,7 +150,7 @@ test("20 parallel SDK writes through server DataStore lose nothing; $manifest st
     expect(onDisk.$manifest).toBeDefined();
     expect(onDisk.$manifest.mutations.addTodo.op).toBe("append");
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -168,7 +170,7 @@ test("data.mutate from page applies manifest mutations atomically", async () => 
       expect(t.id).toMatch(/^[0-9a-f-]{36}$/);
     }
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -185,6 +187,6 @@ test("data.entries excludes $-prefixed keys; $-key writes are rejected", async (
     await frame.locator("#btn-set-manifest").click();
     await expect(frame.locator("#manifest-result")).toContainText("rejected", { timeout: 15_000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/file-tree.spec.ts
+++ b/packages/desktop/e2e/file-tree.spec.ts
@@ -3,6 +3,8 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { createFileTreeProject, launchFileTreeApp } from "./helpers/file-tree";
 
+import { closeApp } from "./helpers/electron";
+
 test.setTimeout(60_000);
 
 function sidebar(page: import("@playwright/test").Page) {
@@ -30,7 +32,7 @@ test("file tree shows root files and directories", async () => {
     expect(sidebarBox).not.toBeNull();
     expect(sidebarBox!.width).toBeCloseTo(260, -1);
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -62,7 +64,7 @@ test("folder expand and collapse", async () => {
     await expect(treeButton(page, "components")).not.toBeVisible();
     await expect(treeButton(page, "main.ts")).not.toBeVisible();
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -86,7 +88,7 @@ test("re-expanding a collapsed folder shows fresh content", async () => {
     await srcRow.click();
     await expect(treeButton(page, "new-file.ts")).toBeVisible({ timeout: 5000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -114,7 +116,7 @@ test("deeply nested file name truncates with ellipsis", async () => {
       sidebarBox!.x + sidebarBox!.width + 1,
     );
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -136,7 +138,7 @@ test("create a new file via context menu", async () => {
 
     await expect(treeButton(page, "notes.md")).toBeVisible({ timeout: 5000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -157,7 +159,7 @@ test("create a new folder via context menu", async () => {
 
     await expect(treeButton(page, "images")).toBeVisible({ timeout: 5000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -176,7 +178,7 @@ test("cancel creating a file with Escape", async () => {
 
     await expect(input).not.toBeVisible();
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -201,7 +203,7 @@ test("delete a file via context menu and confirm", async () => {
 
     await expect(guideRow).not.toBeVisible({ timeout: 5000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -227,7 +229,7 @@ test("delete an expanded directory removes it with its subtree", async () => {
     await expect(treeButton(page, "src")).not.toBeVisible({ timeout: 5000 });
     await expect(treeButton(page, "components")).not.toBeVisible();
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -250,7 +252,7 @@ test("cancel deletion via alert dialog", async () => {
     await expect(dialog).not.toBeVisible();
     await expect(guideRow).toBeVisible();
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -273,6 +275,6 @@ test("sidebar does not expand when file names overflow", async () => {
     expect(afterExpandBox).not.toBeNull();
     expect(Math.abs(afterExpandBox!.width - initialBox!.width)).toBeLessThan(2);
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/floating-chat.spec.ts
+++ b/packages/desktop/e2e/floating-chat.spec.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { closeApp } from "./helpers/electron";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const appRoot = path.resolve(__dirname, "..");
@@ -70,20 +72,6 @@ async function createSessionViaApi(page: Page, projectId: string, agentId: strin
   if (!res.ok) throw new Error(`createSession ${res.status}: ${JSON.stringify(body)}`);
   const { sessionId } = body as { sessionId: string };
   return sessionId;
-}
-
-async function closeApp(app: ElectronApplication) {
-  try {
-    await Promise.race([
-      app.close(),
-      new Promise<void>((_, reject) => setTimeout(() => reject(new Error("app.close timeout")), 5_000)),
-    ]);
-  } catch {
-    const pid = app.process()?.pid;
-    if (pid) {
-      try { process.kill(pid, "SIGKILL"); } catch { /* already dead */ }
-    }
-  }
 }
 
 async function navigateToProject(page: Page, projectId: string) {

--- a/packages/desktop/e2e/floating-content-browser.spec.ts
+++ b/packages/desktop/e2e/floating-content-browser.spec.ts
@@ -2,6 +2,8 @@ import { expect, test } from "@playwright/test";
 import { mkdir, writeFile } from "node:fs/promises";
 import { createFileTreeProject, launchFileTreeApp } from "./helpers/file-tree";
 
+import { closeApp } from "./helpers/electron";
+
 test.setTimeout(60_000);
 
 function sidebar(page: import("@playwright/test").Page) {
@@ -28,7 +30,7 @@ test("right-click float opens floating content window with file body", async () 
     await expect(page.locator("[data-content-float-root] [data-content-doc]")).toBeVisible({ timeout: 5000 });
     await expect(page.locator("[data-content-float-titlebar]")).toContainText("README.md");
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -48,7 +50,7 @@ test("markdown content scrolls within the float", async () => {
     });
     expect(scrollable).toBe(true);
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -64,7 +66,7 @@ test("close button removes floating content window", async () => {
 
     await expect(page.locator("[data-content-float-root]")).toHaveCount(0, { timeout: 5000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -82,7 +84,7 @@ test("menu toggles to cancel-float when file is already floated", async () => {
     await page.getByRole("menuitem", { name: "取消浮窗" }).click();
     await expect(page.locator("[data-content-float-root]")).toHaveCount(0, { timeout: 5000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -100,7 +102,7 @@ test("multiple files can be floated simultaneously", async () => {
     await floatFile(page, "chapter1.md");
     await expect(page.locator("[data-content-float-root]")).toHaveCount(2, { timeout: 5000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -125,7 +127,7 @@ test("HTML file renders as preview iframe, not source", async () => {
     expect(iframeBox).not.toBeNull();
     expect(iframeBox!.height).toBeGreaterThan(rootBox!.height - titlebarBox!.height - 20);
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -142,6 +144,6 @@ test("double-click title bar opens file in content browser and closes float", as
     await expect(page.locator("[data-content-float-root]")).toHaveCount(0, { timeout: 5000 });
     await expect(page).toHaveURL(new RegExp(`/content\\?path=${encodeURIComponent("README.md")}$`));
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/helpers/electron.ts
+++ b/packages/desktop/e2e/helpers/electron.ts
@@ -10,6 +10,21 @@ const appRoot = path.resolve(__dirname, "../..");
 const mainEntry = path.join(appRoot, "dist", "main", "index.js");
 const rendererEntry = path.join(appRoot, "dist", "renderer", "index.html");
 
+export async function closeApp(app: ElectronApplication | undefined): Promise<void> {
+  if (!app) return;
+  try {
+    await Promise.race([
+      app.close(),
+      new Promise<void>((_, reject) => setTimeout(() => reject(new Error("app.close timeout")), 20_000)),
+    ]);
+  } catch {
+    const pid = app.process()?.pid;
+    if (pid) {
+      try { process.kill(pid, "SIGKILL"); } catch { /* already dead */ }
+    }
+  }
+}
+
 export interface TestProject {
   root: string;
   contentPath: string;

--- a/packages/desktop/e2e/packaged-smoke.spec.ts
+++ b/packages/desktop/e2e/packaged-smoke.spec.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { closeApp } from "./helpers/electron";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const appRoot = path.resolve(__dirname, "..");
@@ -91,6 +93,6 @@ test("packaged app launches, mounts renderer and serves /health", async () => {
       expect(version).toBe(expectedVersion);
     }
   } finally {
-    await app?.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/project-close.spec.ts
+++ b/packages/desktop/e2e/project-close.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import {
+
+import { closeApp } from "./helpers/electron";
   createChatProject,
   launchChatApp,
   getServerPort,
@@ -87,7 +89,7 @@ test("closing a streaming project disconnects its chat runtime", async () => {
     await page.waitForTimeout(2000);
     expect(sockets.opened).toBe(1);
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -122,6 +124,6 @@ test("reopening a closed project after restart starts clean", async () => {
     await expect(page.locator("[data-chat-composer]")).toHaveCount(0);
     await expect(page.getByText("Spherse", { exact: true }).first()).toBeVisible({ timeout: 10_000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/project-close.spec.ts
+++ b/packages/desktop/e2e/project-close.spec.ts
@@ -1,8 +1,7 @@
 import { expect, test } from "@playwright/test";
+import { closeApp } from "./helpers/electron";
 import type { Page } from "@playwright/test";
 import {
-
-import { closeApp } from "./helpers/electron";
   createChatProject,
   launchChatApp,
   getServerPort,

--- a/packages/desktop/e2e/text-selection-session.spec.ts
+++ b/packages/desktop/e2e/text-selection-session.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createTextSelectionProject, launchAppWithProject } from "./helpers/electron";
+import { closeApp, createTextSelectionProject, launchAppWithProject } from "./helpers/electron";
 
 test("text selection session shows stable button, fixed popover, and highlight overlay", async () => {
   const project = await createTextSelectionProject();

--- a/packages/desktop/e2e/text-selection-session.spec.ts
+++ b/packages/desktop/e2e/text-selection-session.spec.ts
@@ -121,7 +121,7 @@ test("text selection session shows stable button, fixed popover, and highlight o
     }, secondMouseUp);
     await expect(button).toBeVisible();
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -161,7 +161,7 @@ test("text selection copies via Ctrl/Cmd+C after native selection is released", 
     await expect(toolbar).toBeHidden();
     await expect(page.getByTestId("text-selection-highlight")).toBeHidden();
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -210,7 +210,7 @@ test("text selection keyboard copy does not hijack editable targets inside popov
     await expect.poll(() => app.evaluate(({ clipboard }) => clipboard.readText())).toBe(commentText);
     await expect(popover).toBeVisible();
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -265,6 +265,6 @@ test("text selection session keeps long agent list scrollable in a compact viewp
     expect(agentListScroll.scrollHeight).toBeGreaterThan(agentListScroll.clientHeight);
     expect(agentListScroll.overflowY).toBe("auto");
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/ui-sdk-bridge.spec.ts
+++ b/packages/desktop/e2e/ui-sdk-bridge.spec.ts
@@ -6,6 +6,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { closeApp } from "./helpers/electron";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const appRoot = path.resolve(__dirname, "..");
@@ -155,7 +157,7 @@ test("window.spherse is injected with the documented surface", async () => {
       { timeout: 10_000 },
     );
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -172,7 +174,7 @@ test("spherse.openFile() (fire) navigates the host", async () => {
       ),
     );
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -188,7 +190,7 @@ test("spherse.data.set/get round-trip resolves via call()", async () => {
     await frame.locator("#btn-data-get").click();
     await expect(frame.locator("#status")).toHaveText("get:99", { timeout: 10_000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -201,7 +203,7 @@ test("spherse.api.agents.list() bridges to the server HTTP allowlist", async () 
     await frame.locator("#btn-agents").click();
     await expect(frame.locator("#status")).toHaveText("agents:1 agents", { timeout: 10_000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -219,7 +221,7 @@ test("spherse.api.fileTree() bridges to the server HTTP allowlist", async () => 
     // At least AGENTS.md, the html fixture, and the target file exist.
     expect(count).toBeGreaterThanOrEqual(3);
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -234,7 +236,7 @@ test("spherse.api.call() rejects when the op is not allowlisted", async () => {
       timeout: 10_000,
     });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -254,6 +256,6 @@ test("spherse.events.on() receives filtered file:update events", async () => {
       { timeout: 10_000 },
     );
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/ui-sdk-data-crud.spec.ts
+++ b/packages/desktop/e2e/ui-sdk-data-crud.spec.ts
@@ -6,6 +6,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { closeApp } from "./helpers/electron";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const appRoot = path.resolve(__dirname, "..");
@@ -126,7 +128,7 @@ test("data.set + data.get round trip", async () => {
     await frame.locator("#btn-get-score").click();
     await expect(frame.locator("#get-result")).toContainText("42", { timeout: 10_000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -146,7 +148,7 @@ test("data.get nonexistent key returns null", async () => {
     await frame.locator("#btn-get-missing").click();
     await expect(frame.locator("#get-result")).toContainText("null", { timeout: 10_000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -172,7 +174,7 @@ test("data.delete removes key", async () => {
     await frame.locator("#btn-get-score").click();
     await expect(frame.locator("#get-result")).toContainText("null", { timeout: 10_000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -203,7 +205,7 @@ test("data persistence survives navigation", async () => {
     await frame2.locator("#btn-get-score").click();
     await expect(frame2.locator("#get-result")).toContainText("42", { timeout: 10_000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -224,6 +226,6 @@ test("data.set with complex JSON value", async () => {
     await expect(frame.locator("#set-result")).toContainText('"name":"Alice"', { timeout: 10_000 });
     await expect(frame.locator("#set-result")).toContainText("[1,2,3]", { timeout: 10_000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/ui-sdk-html-card.spec.ts
+++ b/packages/desktop/e2e/ui-sdk-html-card.spec.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { closeApp } from "./helpers/electron";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const appRoot = path.resolve(__dirname, "..");
@@ -161,7 +163,7 @@ async function assertCardReceivesRuntime(
     const frame = page.frameLocator("[data-chat-message] iframe").first();
     await expect(frame.locator("#out")).toHaveText(`sid:${sessionId}`, { timeout: 15_000 });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 }
 

--- a/packages/desktop/e2e/ui-sdk.spec.ts
+++ b/packages/desktop/e2e/ui-sdk.spec.ts
@@ -6,6 +6,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { closeApp } from "./helpers/electron";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const appRoot = path.resolve(__dirname, "..");
@@ -131,7 +133,7 @@ test("openFile action navigates from iframe", async () => {
       ),
     );
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -159,7 +161,7 @@ test("createSession action navigates from iframe", async () => {
       page.getByPlaceholder("输入消息... (Shift+Enter 换行)"),
     ).toBeVisible();
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -192,7 +194,7 @@ test("unknown action is ignored", async () => {
     await page.waitForTimeout(500);
     expect(page.url()).toBe(urlBefore);
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -230,7 +232,7 @@ test("rate limit blocks excess calls", async () => {
     await page.waitForTimeout(2000);
     expect(navigatedCount).toBeLessThanOrEqual(10);
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -291,7 +293,7 @@ test("openSession action navigates to an existing session without sending a mess
     // openSession must NOT send a message — the session stays empty.
     expect(await getSessionMessageCount(page, project.projectId, sessionId)).toBe(0);
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });
 
@@ -313,6 +315,6 @@ test("showToast action renders a sonner toast", async () => {
       timeout: 10_000,
     });
   } finally {
-    await app.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/e2e/ui-sdk.spec.ts
+++ b/packages/desktop/e2e/ui-sdk.spec.ts
@@ -216,7 +216,7 @@ test("rate limit blocks excess calls", async () => {
       navigatedCount++;
     });
 
-    for (let i = 0; i < 12; i++) {
+    for (let i = 0; i < 40; i++) {
       await page.evaluate(() => {
         window.postMessage(
           {
@@ -230,7 +230,8 @@ test("rate limit blocks excess calls", async () => {
     }
 
     await page.waitForTimeout(2000);
-    expect(navigatedCount).toBeLessThanOrEqual(10);
+    expect(navigatedCount).toBeLessThanOrEqual(30);
+    expect(navigatedCount).toBeGreaterThanOrEqual(1);
   } finally {
     await closeApp(app);
   }

--- a/packages/desktop/e2e/unsafe-location-guard.spec.ts
+++ b/packages/desktop/e2e/unsafe-location-guard.spec.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { closeApp } from "./helpers/electron";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const appRoot = path.resolve(__dirname, "..");
@@ -67,7 +69,7 @@ test("declining the unsafe location keeps the project unopened", async () => {
     expect(dialogs).toHaveLength(1);
     expect(dialogs[0]).toEqual({ kind: "confirmUnsafeLocation", detail: expect.any(String) });
   } finally {
-    await app?.close();
+    await closeApp(app);
   }
 });
 
@@ -105,7 +107,7 @@ test("confirming the unsafe location opens the project", async () => {
       detail: expect.stringContaining("my-project"),
     });
   } finally {
-    await app?.close();
+    await closeApp(app);
   }
 });
 
@@ -141,6 +143,6 @@ test("startup warns about restored projects inside the unsafe zone", async () =>
       detail: expect.stringContaining("my-project"),
     });
   } finally {
-    await app?.close();
+    await closeApp(app);
   }
 });

--- a/packages/desktop/electron/main.ts
+++ b/packages/desktop/electron/main.ts
@@ -8,6 +8,7 @@ import { startAutoUpdateChecks } from "./updater.js";
 import { setupContextMenu } from "./ipc/context-menu.js";
 import { getTunnelManager } from "./tunnel/manager.js";
 import { getMobileAccess, setMobileAccess, generateAccessToken } from "./settings.js";
+import { settleWithin } from "@spherse/core";
 
 app.whenReady().then(async () => {
   await fixPath();
@@ -31,11 +32,24 @@ app.whenReady().then(async () => {
   }
 });
 
+const TUNNEL_STOP_TIMEOUT_MS = 5_000;
+const GRACEFUL_SHUTDOWN_HARD_EXIT_MS = 30_000;
+
 let quitting = false;
 async function gracefulShutdown(): Promise<void> {
   if (quitting) return;
   quitting = true;
-  await getTunnelManager().stop();
+  setTimeout(() => {
+    console.error("[main] graceful shutdown timed out, forcing app exit");
+    app.exit(1);
+  }, GRACEFUL_SHUTDOWN_HARD_EXIT_MS).unref();
+  await settleWithin(getTunnelManager().stop(), TUNNEL_STOP_TIMEOUT_MS, (outcome, detail) => {
+    if (outcome === "error") {
+      console.error("[main] tunnel stop failed:", detail);
+    } else {
+      console.error(`[main] tunnel stop timed out after ${TUNNEL_STOP_TIMEOUT_MS}ms, continuing`);
+    }
+  });
   await stopServer();
   app.quit();
 }

--- a/packages/desktop/electron/server-shutdown.test.ts
+++ b/packages/desktop/electron/server-shutdown.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createServerMock, fastifyClose, registryRemoveAll, registryListInfo } = vi.hoisted(() => ({
+  createServerMock: vi.fn(),
+  fastifyClose: vi.fn(),
+  registryRemoveAll: vi.fn(),
+  registryListInfo: vi.fn(() => []),
+}));
+
+vi.mock("electron", () => ({
+  app: { getVersion: () => "0.0.0-test" },
+}));
+vi.mock("./settings.js", () => ({
+  getSettings: () => undefined,
+  getMobileAccess: () => ({}),
+}));
+vi.mock("./model-catalog.js", () => ({
+  getAppModelCatalog: () => undefined,
+}));
+vi.mock("@spherse/server", () => ({
+  createMultiProjectServer: createServerMock,
+}));
+
+import { ensureServer, stopServer, restartServerWithAuth } from "./server.js";
+
+function mockHandle(): void {
+  fastifyClose.mockResolvedValue(undefined);
+  registryRemoveAll.mockResolvedValue(undefined);
+  registryListInfo.mockReturnValue([]);
+  createServerMock.mockResolvedValue({
+    fastify: { close: fastifyClose },
+    registry: { removeAll: registryRemoveAll, listInfo: registryListInfo },
+  });
+}
+
+describe("stopServer staged shutdown", () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    mockHandle();
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    await ensureServer();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await stopServer();
+    consoleError.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("times out a hanging registry.removeAll and still closes fastify", async () => {
+    registryRemoveAll.mockImplementation(() => new Promise(() => {}));
+    vi.useFakeTimers();
+    let resolved = false;
+    void stopServer().then(() => {
+      resolved = true;
+    });
+    await vi.advanceTimersByTimeAsync(9_999);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(resolved).toBe(true);
+    expect(fastifyClose).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('"registry.removeAll"'),
+    );
+  });
+
+  it("times out a hanging fastify.close and still resolves", async () => {
+    fastifyClose.mockImplementation(() => new Promise(() => {}));
+    vi.useFakeTimers();
+    let resolved = false;
+    void stopServer().then(() => {
+      resolved = true;
+    });
+    await vi.advanceTimersByTimeAsync(9_999);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(resolved).toBe(true);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('"fastify.close"'),
+    );
+  });
+
+  it("logs and continues when a stage rejects", async () => {
+    registryRemoveAll.mockRejectedValue(new Error("boom"));
+    await stopServer();
+    expect(fastifyClose).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(
+      '[server] shutdown stage "registry.removeAll" failed:',
+      expect.objectContaining({ message: "boom" }),
+    );
+  });
+
+  it("is a no-op when the server is already stopped", async () => {
+    await stopServer();
+    expect(registryRemoveAll).toHaveBeenCalledTimes(1);
+    await stopServer();
+    expect(registryRemoveAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes restartServerWithAuth through the same staged close", async () => {
+    await restartServerWithAuth("token-1");
+    expect(registryRemoveAll).toHaveBeenCalledTimes(1);
+    expect(fastifyClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop/electron/server.ts
+++ b/packages/desktop/electron/server.ts
@@ -3,12 +3,32 @@ import { app } from "electron";
 import { createMultiProjectServer } from "@spherse/server";
 import type { ProjectRegistry } from "@spherse/server";
 import type { SamplingParams, ThinkingLevel } from "@spherse/core";
+import { settleWithin } from "@spherse/core";
 import { getSettings, getMobileAccess } from "./settings.js";
 import { getAppModelCatalog } from "./model-catalog.js";
 
 interface ServerHandle {
   fastify: FastifyInstance;
   registry: ProjectRegistry;
+}
+
+const SERVER_STAGE_TIMEOUT_MS = 10_000;
+
+function logStageOutcome(stage: string, outcome: "timeout" | "error", detail?: unknown): void {
+  if (outcome === "error") {
+    console.error(`[server] shutdown stage "${stage}" failed:`, detail);
+  } else {
+    console.error(`[server] shutdown stage "${stage}" timed out after ${SERVER_STAGE_TIMEOUT_MS}ms, continuing`);
+  }
+}
+
+async function closeServerHandle(handle: ServerHandle): Promise<void> {
+  await settleWithin(handle.registry.removeAll(), SERVER_STAGE_TIMEOUT_MS, (outcome, detail) => {
+    logStageOutcome("registry.removeAll", outcome, detail);
+  });
+  await settleWithin(handle.fastify.close(), SERVER_STAGE_TIMEOUT_MS, (outcome, detail) => {
+    logStageOutcome("fastify.close", outcome, detail);
+  });
 }
 
 let serverHandle: ServerHandle | null = null;
@@ -40,13 +60,13 @@ export async function ensureServer(): Promise<void> {
 
 export async function restartServerWithAuth(token: string | undefined): Promise<void> {
   if (serverHandle) {
-    registeredProjects = serverHandle.registry.listInfo().map((info) => ({
+    const handle = serverHandle;
+    serverHandle = null;
+    registeredProjects = handle.registry.listInfo().map((info) => ({
       root: info.rootPath,
       lastOpened: info.lastOpened,
     }));
-    await serverHandle.registry.removeAll();
-    await serverHandle.fastify.close();
-    serverHandle = null;
+    await closeServerHandle(handle);
   }
   activeAccessToken = token;
 }
@@ -96,9 +116,9 @@ export function updateThinkingLevel(thinkingLevel: ThinkingLevel | undefined): v
 
 export async function stopServer(): Promise<void> {
   if (!serverHandle) return;
-  await serverHandle.registry.removeAll();
-  await serverHandle.fastify.close();
+  const handle = serverHandle;
   serverHandle = null;
+  await closeServerHandle(handle);
   registeredProjects = [];
   activeAccessToken = undefined;
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -12,7 +12,7 @@
     "pretest": "npm run build --workspace=@spherse/i18n",
     "test": "vitest run",
     "pretest:e2e": "node ../../scripts/rebuild-native.mjs",
-    "test:e2e": "npm run build --workspace=@spherse/i18n && npm run build && playwright test -c playwright.config.ts",
+    "test:e2e": "npm run build -w @spherse/i18n -w @spherse/presets -w @spherse/sdk -w @spherse/core -w @spherse/server && npm run build && playwright test -c playwright.config.ts",
     "test:smoke": "playwright test -c playwright.config.ts e2e/packaged-smoke.spec.ts",
     "pack": "electron-builder --dir",
     "predist": "node ../../scripts/rebuild-native.mjs && electron-vite build",

--- a/packages/server/src/__tests__/create-server.test.ts
+++ b/packages/server/src/__tests__/create-server.test.ts
@@ -47,6 +47,13 @@ describe("createMultiProjectServer port binding", () => {
     expect(address.port).toBe(port);
   });
 
+  it("enables forceCloseConnections so close cannot hang on leftover sockets", async () => {
+    const port = await getFreePort();
+    const server = await createMultiProjectServer({ port });
+    servers.push(server);
+    expect(server.fastify.initialConfig.forceCloseConnections).toBe(true);
+  });
+
   it("falls back to an OS-assigned port when the preferred port is in use", async () => {
     const port = await getFreePort();
     const blocker = await occupyPort(port);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -63,6 +63,7 @@ export async function createMultiProjectServer(
         },
       },
     },
+    forceCloseConnections: true,
   });
 
   await fastify.register(cors, { origin: true });


### PR DESCRIPTION
## 背景

backlog「E2E `app.close()` 间歇悬死」：顺序启动多个 Electron E2E 实例时 `app.close()` 偶发 60s 悬死。根因分析见 design doc：退出链（`gracefulShutdown` → `stopServer` → `removeAll` → `fastify.close` → `app.quit`）零超时，且 `fastify.close()` 会因残留连接（mid-upgrade ws / 未完成关闭握手的 socket）无限等待。

## 修复（三层防御）

| 层 | 内容 |
|---|---|
| 1 出口兜底 | `main.ts`：30s 硬兜底 `app.exit(1)`（unref）+ tunnel stop 5s 超时 |
| 2 根因 | Fastify `forceCloseConnections: true`（优雅关闭后强杀残留连接）；`stopServer`/`restartServerWithAuth` 走 `closeServerHandle` 分阶段 10s 超时 + stage 日志；core `ProjectRuntime.shutdown` 逐 capability 5s 超时 + 错误隔离（顺带修复单个 capability 抛错中断后续关闭的脆弱点） |
| 3 E2E 防御 | 共享 `closeApp` helper（race 20s + SIGKILL），替换 18 个 spec 的裸 `app.close()` 调用 |

共享工具 `settleWithin` 从 `@spherse/core` 导出（settled-guard、永不 reject、无 unhandled rejection）。

## 新增：独立 E2E workflow（`.github/workflows/e2e.yml`）

- PR 触发、docs-only 跳过、`cancel-in-progress`，macOS runner 跑 Electron E2E 全套（`test:e2e` 自带 native rebuild + build 链）
- **非 required，结果仅供参考**：刻意不加 `continue-on-error`（失败如实显示红，保留提醒价值）；合入后需在 repo Settings → Branch protections 确认未把 `E2E / e2e` 勾进 required checks
- 选独立 workflow 而非 pr-build 加 job：YAML/config 错误不会连坐打挂 required 的 verify；后续可独立加 path filter / 手动触发
- 选 macOS：套件验证平台 + release smoke 同款，排除新平台 flake 变量；降成本（ubuntu+xvfb）留待后续评估

## 验证

- 单测：core 1141 / server 258 / desktop 185 全绿（新增 settle-within、project-runtime-shutdown、server-shutdown、create-server 断言）
- E2E：app-launch + file-tree + floating-chat + chat-retry + chat-streaming-resilience + chat-withdraw + project-close + text-selection-session 共 36 用例全绿
- build / typecheck / lint（0 新增问题）
- 本 PR 自身会触发新 E2E workflow；首次运行暴露并已修复两个存量问题：① `test:e2e` 构建链不自足（从干净 checkout 起跑缺 workspace dists，改为脚本内构建完整依赖链）；② `ui-sdk.spec.ts` rate limit 用例停留在 10/min 时代断言（`bdd4628` 提到 30/min 后未同步，本地确定性失败非 CI flake），已对齐 40 次调用 → ≤30 导航。当前 CI 全绿：77 passed (4.8m)

## Review Report（code-review sub agent，对照 design doc 审查）

### 已修
- **C1（critical）**：机械替换把 import 插进 4 个 spec 的多行 import 花括号内（chat-retry / chat-streaming-resilience / chat-withdraw / project-close）→ 已修复，且补跑这 4 个 spec 验证通过；根因是 perl 插入正则只按行首 `import` 匹配，`import {` 单独成行时插入点落在括号内。lint/typecheck 均不覆盖 `e2e/`（ESLint ignore + tsconfig 不含），已用 esbuild parse + Playwright 实跑双重验证
- **C2（critical）**：text-selection-session.spec.ts 用 `closeApp` 但未导入（既有 import 被 grep 跳过）→ 已补
- **I1（important）**：原验证清单恰好不含 5 个损坏文件 → 已按 AGENTS.md E2E 选择规则补跑
- **M1（minor）**：design doc 文件数 16→18、desktop 测试文件路径改为 co-located 实际路径 → 已改

### 未修（含理由）
- **M2（minor）**：`getServerPort()` 在 restart 窗口期由返回 stale 值改为抛 `Server not started`——review 确认实际调用方（`ipc/mobile.ts` 的 serialize 队列）均成对 ensure，null 窗口被桥接；`get-server-port` IPC 极端时序下旧行为同样返回垃圾值（0），新行为语义更诚实，非回归，不修
- **未验证疑点**（review 标注）：SIGKILL 主进程后 Chromium helper 进程回收时序（沿袭 floating-chat 既有实现，非本次引入）；`get-server-port` 在 restart 窗口期 reject 后 renderer 容忍性（未追 renderer catch 路径，风险窗口极小）

## 文档

- design doc：`docs/dev/bugfix/2026-08-29-e2e-app-close-hang/design.md`
- backlog：删除已完成条目
- `docs/official/project-structure.md`：收录 `settle-within.ts` 与 `e2e.yml`