### PR TITLE
docs: official 测试体系文档（分层/选型/验证链）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 
 - 全局架构、package 边界、跨包契约 → [`docs/official/architecture/index.md`](docs/official/architecture/index.md)，按任务路由查 [`docs/official/README.md`](docs/official/README.md)
 - 数据文件格式与存储约定 → [`docs/official/data-conventions.md`](docs/official/data-conventions.md)
+- 测试分层、选型规则、验证链 → [`docs/official/testing.md`](docs/official/testing.md)
 - 术语对齐 / 查一个词指什么 → [`docs/official/glossary.md`](docs/official/glossary.md)
 - 目录结构 → [`docs/official/project-structure.md`](docs/official/project-structure.md)
 - 包内规范 → 对应 package 的 README
@@ -141,9 +142,7 @@ npm run build:landing   # 构建 landing page（含 @spherse/i18n 依赖构建�
 
 ## 开发规范
 
-- **E2E 验证选择**：feature 实现完成后，按变更影响面选择可能受影响的 E2E 场景运行，不要求全量；单 spec：`npm run test:e2e --workspace=packages/desktop -- e2e/file-tree.spec.ts`，或 `-g` 按 case 名过滤
-  - 改动涉及 Electron 启动、项目恢复、路由、store、server API、文件树、content browser、chat/session、文本选择发起会话、native dependency 或 E2E helper 时，优先运行对应 E2E；合并/发布前再跑 `npm run verify:e2e`
-  - 改动涉及打包链（electron-builder 配置、asar / 外置 node_modules、native dependency 重编、安装包产物）时，跑 `npm run pack -w @spherse/desktop && SPHERSE_SMOKE=1 npm run test:smoke -w @spherse/desktop` 验证打包产物本身（release CI 会在 arch 匹配的 job 上自动执行该 smoke）
+- **E2E 验证选择**：按变更影响面选择受影响的 E2E 场景运行，不要求全量；分层选型规则与命令见 [`docs/official/testing.md`](docs/official/testing.md)。合并/发布前跑 `npm run verify:e2e`
 
 ## 编码规范（仓库级红线）
 

--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -19,6 +19,7 @@
 - [ ] **恢复 Windows 自动更新 feed（latest.yml，双 arch）**：CI 自 OSS 镜像改造（ba8c049）起统一 `--publish never` + `gh release upload`，release 上不再有 `latest.yml`，Windows 客户端 electron-updater 检查更新因 404 报 `update-error`。恢复需研究多 arch 语义：一个 `latest.yml` 只指向一个安装包，x64 与 arm64 需按 electron-updater 的 channel 文件约定（如 `latest.yml` / `latest-arm64.yml`）分别生成并上传，避免 arm64 设备被推 x64 包（或反向）。可考虑在 `publish-oss` 或 build job 中集中生成。
 - [ ] **refreshProjects 路径不回收 streaming runtime**：外部关闭/多窗口场景下项目从快照消失时，`app-store.refreshProjects` 只改 projects map，不走 `closeProjectCascade`，该项目 chat streaming runtime（WS + 重连定时器）仍存活。受「全局 store 不得依赖 feature-local store」约束，修复需 streaming runtime 生命周期整体重构，宜与 followup P1「移除 streaming/trigger 镜像」合并考虑。参见 `docs/dev/infra/2026-08-28-project-lifecycle-orchestration/design.md` 已知缺口
 - [ ] **BrowserPage render 期 navigate 重定向疑似失效**：`pages/BrowserPage.tsx` 在 render 期间调用 `navigate(...)`（React Router 反模式）。组件测试迁移（2026-08-29）中用 MemoryRouter 验证发现该调用不会完成导航，仅返回 null——web 壳访问 `/project/:id/browser` 时可能停在空白路由而非回到项目首页。修复方向：改为 `useEffect` 内导航或 `<Navigate replace />`；修复后可在 `save-export-degradation.test.tsx` 补真正的路由断言。
+- [ ] **desktop 契约测试缺位**：AGENTS.md 红线要求「core 的 PM 写入门面与 `SessionPort` 方法，消费方包（server/desktop）至少各有一条不 mock 被测方法本身的契约测试」；server 侧已有（`write-facade-contract.test.ts`），desktop 侧现有 `electron/ipc/project.test.ts`、`electron/server.test.ts` 均 vi.mock 了 server/门面，不满足红线。需补一条走真实门面（或真实 IPC 边界）的契约测试。
 
 ## 技术债（重构与收敛）
 

--- a/docs/official/README.md
+++ b/docs/official/README.md
@@ -18,6 +18,7 @@
 | 改主题、token、可主题化 DOM 入口 | [`architecture/theming.md`](architecture/theming.md) |
 | 改 i18n | [`architecture/i18n.md`](architecture/i18n.md) |
 | 改数据文件格式与存储位置 | [`data-conventions.md`](data-conventions.md) |
+| 写测试 / 选测试层 / 改测试基建 | [`testing.md`](testing.md) |
 | 对齐术语 / 查一个词指什么 | [`glossary.md`](glossary.md) |
 | 找文件 / 目录在哪 | [`project-structure.md`](project-structure.md) |
 

--- a/docs/official/project-structure.md
+++ b/docs/official/project-structure.md
@@ -383,6 +383,7 @@ spherse/
 │   │   │   ├── theming.md            # token 体系/三级主题/DOM 入口
 │   │   │   └── i18n.md               # i18n 架构
 │   │   ├── data-conventions.md       # 数据文件格式与存储约定
+│   │   ├── testing.md                # 测试体系：分层、选型规则、验证链
 │   │   ├── glossary.md               # 术语表：一词一行 + 权威文档指针
 │   │   └── project-structure.md      # 本文件：完整目录索引
 │   └── dev/                          # 开发过程文档（容易过时）

--- a/docs/official/testing.md
+++ b/docs/official/testing.md
@@ -1,0 +1,81 @@
+# 测试体系
+
+> 覆盖范围：全仓测试分层、各层职责与选型规则、共享测试工具、验证链。
+> 命令速查见根 `AGENTS.md`「启动和联调方式」；renderer 组件测试细则见 `packages/app/README.md`「测试与验证」；各域架构见 `architecture/`。
+> 测试基建的设计过程与迁移归档见 `docs/dev/infra/2026-08-29-react-component-testing/`。
+
+## 分层总览
+
+| 层 | 运行环境 | 覆盖对象 | 归属 | 反馈 |
+|---|---|---|---|---|
+| 纯逻辑单测 | Node / jsdom | store、query、reducer、纯函数、hook 数据流 | core / server / app / contracts / sdk 等 | 秒级 |
+| 组件测试 | jsdom + Testing Library | React 组件渲染、ARIA 状态、交互 | `packages/app` | 秒级 |
+| 契约测试 | Node | 跨层接缝：PM 写入门面、`SessionPort`、HTTP/WS contract | core / server / desktop 各自持有 | 秒级 |
+| 架构不变量 | Node（源码扫描） | 跨文件完整性、层边界负断言 | `packages/app`（`*.structure.test.ts`） | 秒级 |
+| E2E | 真实 Electron + Playwright | 启动链、路由、多面板集成、UI SDK | `packages/desktop/e2e/` | 分钟级 |
+| 打包 smoke | 打包产物（asar） | electron-builder 配置、native dependency、安装包可启动 | `packages/desktop/e2e/packaged-smoke.spec.ts` | 分钟级 |
+
+## 各层职责
+
+### 纯逻辑单测
+
+- 覆盖 stores / queries / lib / hooks 的数据流与不变量：项目隔离、缓存失效、竞态、清理路径。
+- 不变密集的纯逻辑（fold、access policy、错误分类、tree model）先写测试再实现；UI 与集成路径实现后补（不强求 TDD）。
+- Query 相关测试每测试新建 `QueryClient`（app 用 `createTestQueryClient`），禁止跨测试泄漏缓存状态。
+
+### 组件测试（packages/app）
+
+- 工具链：Vitest + jsdom + `@testing-library/react` + `user-event` + `jest-dom`。
+- 共享工具在 `src/test/`：`renderWithProviders` / `createTestQueryClient` / `createMockHostBridge` / bus MockWebSocket harness。
+- 红线（查询优先级、fake timers、卸载副作用清理顺序、禁止 `createRoot` 样板）见 `packages/app/README.md`「测试与验证」，不在本文件重复。
+
+### 契约测试（跨层接缝）
+
+- 跨包红线（core 的 PM 写入门面与 `SessionPort` 方法，消费方包至少各有一条不 mock 被测方法本身的契约测试）见根 `AGENTS.md`。
+- HTTP/WS 边界 schema 在 `@spherse/contracts`，server 侧 contract 测试驱动真实路由校验 wire 协议；renderer 复用同一套 parser，不另写第二份边界校验。
+
+### 架构不变量（structure test）
+
+- `*.structure.test.ts` 只允许：全 src 扫描的完整性清单（如所有定义 `clearProject` 的 store 必须进 `closeProjectCascade`）、层边界负断言（如 App shell 不向 feature 透传数据）。
+- 禁止断言单文件实现细节（className 字符串、函数名、源码模式、调用顺序）——行为断言一律写组件/逻辑测试，样式约束交给 ESLint 规则。
+
+### E2E（packages/desktop）
+
+- 覆盖 Electron 启动、项目恢复、路由、文件树、content browser、chat/session、文本选择发起会话、UI SDK bridge、浮窗等跨面板集成。
+- **按变更影响面选择受影响的 spec 运行，不要求全量**；单 spec：`npm run test:e2e --workspace=packages/desktop -- e2e/file-tree.spec.ts`，或追加 `-g "<case 名>"` 过滤。合并/发布前跑 `npm run verify:e2e`。
+- 涉及打包链（electron-builder 配置、asar/外置 node_modules、native dependency 重编、安装包产物）时，跑 `npm run pack -w @spherse/desktop && SPHERSE_SMOKE=1 npm run test:smoke -w @spherse/desktop` 验证产物本身；release CI 会在 arch 匹配的 job 上自动执行该 smoke。
+
+### i18n 一致性
+
+- `npm run check:i18n` 校验三 locale key 一致与插值变量匹配，纳入 `npm run verify` 链；新增用户可见文案必须同时过检（流程见 **i18n** skill）。
+
+## 选型规则
+
+新增测试时按以下顺序判断落点：
+
+1. 纯逻辑或数据流（无 DOM）→ 纯逻辑单测
+2. 组件渲染、ARIA 状态、用户交互（渲染一个 feature 内的组件可测）→ 组件测试
+3. 跨进程/跨层接缝行为 → 契约测试（不 mock 被测方法本身）
+4. 跨面板/需要真实 Electron 环境（窗口、IPC、启动链）→ E2E
+5. 跨文件结构约束（无法用行为表达）→ structure test（先确认不是第 1–4 层能覆盖）
+6. 布局、CSS、主题视觉效果 → 不写自动化断言，E2E 冒烟 + 人工验证；主题 hook 的存在性可归入组件渲染断言
+
+不落的层：
+
+- 组件测试不断言真实布局/CSS（jsdom 无样式）；此类回归由 E2E 与主题 skill 守卫。
+- E2E 不测单组件内部行为——反馈慢且脆，下沉到组件测试。
+
+## 验证链
+
+```bash
+npm run verify        # lint + build + typecheck + 全部单测 + i18n check
+npm run verify:e2e    # verify + desktop 全量 E2E（合并/发布前）
+```
+
+- 单包快速回路：`npm test --workspace=packages/<pkg>`（app 组件测试依赖 i18n/presets 等 dist，跨包改动后先 `npm run build`）。
+- pre-commit 钩子执行 `npm run lint`；CI 在 push/PR 上执行 `verify`，release 流程附 E2E 与打包 smoke。
+
+## 维护规则
+
+- 测试基建变更（新工具、新 harness、规则修订）同步本文件与受影响的 package README。
+- structure test 与 ESLint 规则的边界：可 lint 表达的约束（import 边界、样式 token）优先 ESLint；需要跨文件图谱或运行时信息的才进 structure test。

--- a/docs/official/testing.md
+++ b/docs/official/testing.md
@@ -10,7 +10,7 @@
 |---|---|---|---|---|
 | 纯逻辑单测 | Node / jsdom | store、query、reducer、纯函数、hook 数据流 | core / server / app / contracts / sdk 等 | 秒级 |
 | 组件测试 | jsdom + Testing Library | React 组件渲染、ARIA 状态、交互 | `packages/app` | 秒级 |
-| 契约测试 | Node | 跨层接缝：PM 写入门面、`SessionPort`、HTTP/WS contract | core / server / desktop 各自持有 | 秒级 |
+| 契约测试 | Node | 跨层接缝：PM 写入门面、`SessionPort`、HTTP/WS contract | core / server | 秒级 |
 | 架构不变量 | Node（源码扫描） | 跨文件完整性、层边界负断言 | `packages/app`（`*.structure.test.ts`） | 秒级 |
 | E2E | 真实 Electron + Playwright | 启动链、路由、多面板集成、UI SDK | `packages/desktop/e2e/` | 分钟级 |
 | 打包 smoke | 打包产物（asar） | electron-builder 配置、native dependency、安装包可启动 | `packages/desktop/e2e/packaged-smoke.spec.ts` | 分钟级 |
@@ -41,7 +41,7 @@
 
 ### E2E（packages/desktop）
 
-- 覆盖 Electron 启动、项目恢复、路由、文件树、content browser、chat/session、文本选择发起会话、UI SDK bridge、浮窗等跨面板集成。
+- 覆盖 Electron 启动、项目恢复、路由、store、server API、文件树、content browser、chat/session、文本选择发起会话、UI SDK bridge、浮窗等跨面板集成；改动涉及上述面或 native dependency、E2E helper 时优先运行对应 spec。
 - **按变更影响面选择受影响的 spec 运行，不要求全量**；单 spec：`npm run test:e2e --workspace=packages/desktop -- e2e/file-tree.spec.ts`，或追加 `-g "<case 名>"` 过滤。合并/发布前跑 `npm run verify:e2e`。
 - 涉及打包链（electron-builder 配置、asar/外置 node_modules、native dependency 重编、安装包产物）时，跑 `npm run pack -w @spherse/desktop && SPHERSE_SMOKE=1 npm run test:smoke -w @spherse/desktop` 验证产物本身；release CI 会在 arch 匹配的 job 上自动执行该 smoke。
 
@@ -73,7 +73,7 @@ npm run verify:e2e    # verify + desktop 全量 E2E（合并/发布前）
 ```
 
 - 单包快速回路：`npm test --workspace=packages/<pkg>`（app 组件测试依赖 i18n/presets 等 dist，跨包改动后先 `npm run build`）。
-- pre-commit 钩子执行 `npm run lint`；CI 在 push/PR 上执行 `verify`，release 流程附 E2E 与打包 smoke。
+- pre-commit 钩子执行 `npm run lint`；PR（非 docs-only）上 CI 跑 `npm run verify` 与全量 E2E；tag push 发版跑 verify 与 arch 匹配 job 上的打包 smoke（发版不跑 E2E，拦截在 PR 阶段）。
 
 ## 维护规则
 


### PR DESCRIPTION
## 概要

新增 `docs/official/testing.md`：全仓测试体系的单一权威来源——六层分层总览（纯逻辑单测 / 组件测试 / 契约测试 / 架构不变量 / E2E / 打包 smoke）、各层职责边界、新增测试的选型规则（6 步决策序）、验证链（verify / verify:e2e / smoke）与维护规则。

配套收敛：
- `docs/official/README.md` 路由表 + `AGENTS.md`「读」导航各加一行
- `AGENTS.md`「E2E 验证选择」细则（单 spec 命令、smoke 命令、影响面清单）移入 testing.md，AGENTS.md 留红线级一句话 + 链接，消除双份真相
- `docs/official/project-structure.md` 登记 testing.md

分层原则遵守单一来源：包内规范（app 组件测试红线）留在 package README 由本文链接；跨包红线（契约测试）留在 AGENTS.md 由本文链接。

文档来源：#70 / #73 两轮组件测试迁移沉淀的规范 + 既有分层现状盘点。