### PR TITLE
feat: compaction 摘要长度预算按压缩时 context tokens 5% 动态给定

### DIFF
--- a/docs/official/architecture/core.md
+++ b/docs/official/architecture/core.md
@@ -58,6 +58,7 @@ ProjectRuntime           对外协调层，聚合以上全部
 - **控制事件（重启点）**：`turn/retried`、`turn/withdrawn`、`compaction/applied`，restore 时按语义重建；WS 协议不受存储格式影响
   - withdraw：`turn/withdrawn {seq}` 锚定被撤回的 user message，fold 从日志推导废弃区间 `[seq, 本事件 seq)`；末轮已被 digest 覆盖（lastUserEvent.seq ≤ anchorSeq）时拒绝撤回
   - compaction：阈值触发时经 agent 自身 streamFn 生成 LLM 摘要——精确复刻请求前缀（systemPrompt + tools + fold 视图 + 追加摘要指令）命中 provider prompt cache；失败且 tokens ≤ 90% window 跳过本轮，> 90% 回退机械拼接
+    摘要长度预算按压缩时 context tokens 的 5% 动态给定（clamp 1500–16000），同时约束摘要指令文本与 stream `maxTokens`（再与模型输出上限取 min）
     摘要来源以 `digestSource: "llm" | "mechanical"` 标记
 - 触发器 ⇄ 会话的循环依赖经 `SessionPort` 消解：factory 先构造 SessionManager，port 是普通对象，capability 在 `init` 中拿到它
 

--- a/packages/core/src/__tests__/capabilities/compaction-summarize.test.ts
+++ b/packages/core/src/__tests__/capabilities/compaction-summarize.test.ts
@@ -6,7 +6,7 @@ import {
   computeSummaryTokenBudget,
   summarizeForCompaction,
 } from "../../capabilities/compaction/summarize.js";
-import { createSilentLogger } from "../../logger.js";
+import { createSilentLogger, type Logger } from "../../logger.js";
 
 function fakeAgent(overrides: Record<string, unknown> = {}): Agent {
   return {
@@ -60,6 +60,11 @@ describe("computeSummaryTokenBudget", () => {
 
   it("caps very large contexts at the maximum budget", () => {
     expect(computeSummaryTokenBudget(1_000_000)).toBe(16_000);
+  });
+
+  it("falls back to the maximum budget on non-finite input", () => {
+    expect(computeSummaryTokenBudget(Number.NaN)).toBe(16_000);
+    expect(computeSummaryTokenBudget(Number.POSITIVE_INFINITY)).toBe(16_000);
   });
 });
 
@@ -128,11 +133,11 @@ describe("summarizeForCompaction", () => {
   });
 
   it("clamps the hard maxTokens to the model output limit", async () => {
-    const calls: Array<{ options?: unknown }> = [];
+    const calls: Array<{ context: unknown; options?: unknown }> = [];
     const agent = fakeAgent({
       state: { model: { id: "test-model", contextWindow: 100_000, maxTokens: 4096 } },
-      streamFunction: (_model: unknown, _context: unknown, options: unknown) => {
-        calls.push({ options });
+      streamFunction: (_model: unknown, context: unknown, options: unknown) => {
+        calls.push({ context, options });
         return {
           result: async () => ({
             stopReason: "stop",
@@ -147,6 +152,32 @@ describe("summarizeForCompaction", () => {
     }, { currentTokens: 120_000 });
 
     expect((calls[0].options as { maxTokens: number }).maxTokens).toBe(4096);
+    const context = calls[0].context as { messages: Message[] };
+    expect(context.messages[context.messages.length - 1].content).toBe(
+      buildSummaryInstruction(4096),
+    );
+  });
+
+  it("warns but keeps a budget-truncated summary", async () => {
+    const warnings: unknown[] = [];
+    const logger = {
+      warn: (obj: unknown) => warnings.push(obj),
+    } as unknown as Logger;
+    const agent = fakeAgent({
+      streamFunction: () => ({
+        result: async () => ({
+          stopReason: "length",
+          content: [{ type: "text", text: "z".repeat(80) }],
+        }),
+      }),
+    });
+
+    const result = await summarizeForCompaction(agent, foldMessages, "s", { logger }, {
+      currentTokens: 120_000,
+    });
+
+    expect(result?.digest).toBe("z".repeat(80));
+    expect(warnings).toHaveLength(1);
   });
 
   it("sends the converted (projected) messages, not the raw fold view", async () => {

--- a/packages/core/src/__tests__/capabilities/compaction-summarize.test.ts
+++ b/packages/core/src/__tests__/capabilities/compaction-summarize.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Agent } from "@earendil-works/pi-agent-core";
 import type { Message } from "@earendil-works/pi-ai";
-import { summarizeForCompaction, SUMMARY_INSTRUCTION } from "../../capabilities/compaction/summarize.js";
+import {
+  buildSummaryInstruction,
+  computeSummaryTokenBudget,
+  summarizeForCompaction,
+} from "../../capabilities/compaction/summarize.js";
 import { createSilentLogger } from "../../logger.js";
 
 function fakeAgent(overrides: Record<string, unknown> = {}): Agent {
@@ -28,13 +32,34 @@ const foldMessages: Message[] = [
   } as Message,
 ];
 
-describe("SUMMARY_INSTRUCTION", () => {
+describe("buildSummaryInstruction", () => {
   it("adapts preservation priorities to the conversation nature", () => {
-    expect(SUMMARY_INSTRUCTION).toContain("task-oriented");
-    expect(SUMMARY_INSTRUCTION).toContain("emotional companionship");
-    expect(SUMMARY_INSTRUCTION).toContain("relationship trajectory");
-    expect(SUMMARY_INSTRUCTION).toContain("unresolved emotional threads");
-    expect(SUMMARY_INSTRUCTION).toContain('Do NOT strip these as "irrelevant exploration"');
+    const instruction = buildSummaryInstruction(3000);
+    expect(instruction).toContain("task-oriented");
+    expect(instruction).toContain("emotional companionship");
+    expect(instruction).toContain("relationship trajectory");
+    expect(instruction).toContain("unresolved emotional threads");
+    expect(instruction).toContain('Do NOT strip these as "irrelevant exploration"');
+  });
+
+  it("embeds the token budget into the length constraint", () => {
+    expect(buildSummaryInstruction(4800)).toContain("at most 4800 tokens");
+  });
+});
+
+describe("computeSummaryTokenBudget", () => {
+  it("scales the budget to 5% of the context tokens at compaction time", () => {
+    expect(computeSummaryTokenBudget(96_000)).toBe(4800);
+    expect(computeSummaryTokenBudget(150_000)).toBe(7500);
+  });
+
+  it("clamps small contexts to the minimum budget", () => {
+    expect(computeSummaryTokenBudget(8_000)).toBe(1500);
+    expect(computeSummaryTokenBudget(10)).toBe(1500);
+  });
+
+  it("caps very large contexts at the maximum budget", () => {
+    expect(computeSummaryTokenBudget(1_000_000)).toBe(16_000);
   });
 });
 
@@ -70,9 +95,58 @@ describe("summarizeForCompaction", () => {
     expect(context.messages.slice(0, foldMessages.length)).toEqual(foldMessages);
     expect(context.messages[foldMessages.length]).toEqual({
       role: "user",
-      content: SUMMARY_INSTRUCTION,
+      content: buildSummaryInstruction(16_000),
     });
     expect((calls[0].options as { sessionId: string }).sessionId).toBe("session-1");
+    expect((calls[0].options as { maxTokens: number }).maxTokens).toBe(16_000);
+  });
+
+  it("scales the summary budget from the context tokens at compaction time", async () => {
+    const calls: Array<{ context: unknown; options?: unknown }> = [];
+    const agent = fakeAgent({
+      streamFunction: (model: unknown, context: unknown, options: unknown) => {
+        calls.push({ context, options });
+        return {
+          result: async () => ({
+            stopReason: "stop",
+            content: [{ type: "text", text: "z".repeat(80) }],
+          }),
+        };
+      },
+    });
+
+    const result = await summarizeForCompaction(agent, foldMessages, "session-1", {
+      logger: createSilentLogger(),
+    }, { currentTokens: 120_000 });
+
+    expect(result).not.toBeNull();
+    const context = calls[0].context as { messages: Message[] };
+    expect(context.messages[context.messages.length - 1].content).toBe(
+      buildSummaryInstruction(6000),
+    );
+    expect((calls[0].options as { maxTokens: number }).maxTokens).toBe(6000);
+  });
+
+  it("clamps the hard maxTokens to the model output limit", async () => {
+    const calls: Array<{ options?: unknown }> = [];
+    const agent = fakeAgent({
+      state: { model: { id: "test-model", contextWindow: 100_000, maxTokens: 4096 } },
+      streamFunction: (_model: unknown, _context: unknown, options: unknown) => {
+        calls.push({ options });
+        return {
+          result: async () => ({
+            stopReason: "stop",
+            content: [{ type: "text", text: "z".repeat(80) }],
+          }),
+        };
+      },
+    });
+
+    await summarizeForCompaction(agent, foldMessages, "s", {
+      logger: createSilentLogger(),
+    }, { currentTokens: 120_000 });
+
+    expect((calls[0].options as { maxTokens: number }).maxTokens).toBe(4096);
   });
 
   it("sends the converted (projected) messages, not the raw fold view", async () => {

--- a/packages/core/src/__tests__/capabilities/compaction.test.ts
+++ b/packages/core/src/__tests__/capabilities/compaction.test.ts
@@ -5,7 +5,10 @@ import os from "node:os";
 import type { Agent } from "@earendil-works/pi-agent-core";
 import { compactionCapability } from "../../capabilities/compaction/index.js";
 import type { MaybeCompactDeps } from "../../capabilities/compaction/transform.js";
-import { SUMMARY_INSTRUCTION } from "../../capabilities/compaction/summarize.js";
+import {
+  buildSummaryInstruction,
+  computeSummaryTokenBudget,
+} from "../../capabilities/compaction/summarize.js";
 import { composeTurnHooks } from "../../kernel/turn-hooks.js";
 import { SessionEventLog } from "../../session/event-log.js";
 import { deriveMessages } from "../../session/fold.js";
@@ -135,7 +138,9 @@ describe("compaction capability", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].options?.sessionId).toBe(sessionId);
     const sentMessages = calls[0].context.messages;
-    expect(sentMessages[sentMessages.length - 1].content).toBe(SUMMARY_INSTRUCTION);
+    expect(sentMessages[sentMessages.length - 1].content).toBe(
+      buildSummaryInstruction(computeSummaryTokenBudget(8_000)),
+    );
     expect(sentMessages.length).toBeGreaterThan(25);
   });
 

--- a/packages/core/src/capabilities/compaction/summarize.ts
+++ b/packages/core/src/capabilities/compaction/summarize.ts
@@ -5,7 +5,17 @@ import type { Logger } from "../../logger.js";
 
 const SUMMARIZE_TIMEOUT_MS = 60_000;
 
-export const SUMMARY_INSTRUCTION = `Summarize this conversation to compact the context window.
+const SUMMARY_BUDGET_RATIO = 0.05;
+const MIN_SUMMARY_TOKEN_BUDGET = 1500;
+const MAX_SUMMARY_TOKEN_BUDGET = 16_000;
+
+export function computeSummaryTokenBudget(currentTokens: number): number {
+  const scaled = Math.round(currentTokens * SUMMARY_BUDGET_RATIO);
+  return Math.min(MAX_SUMMARY_TOKEN_BUDGET, Math.max(MIN_SUMMARY_TOKEN_BUDGET, scaled));
+}
+
+export function buildSummaryInstruction(tokenBudget: number): string {
+  return `Summarize this conversation to compact the context window.
 
 - Focus on the earlier conversation; recent messages will be kept verbatim in the context.
 - If the conversation already starts with a <compaction-digest> summary, integrate it as prior history instead of repeating it.
@@ -14,8 +24,9 @@ export const SUMMARY_INSTRUCTION = `Summarize this conversation to compact the c
   - Emotional companionship / roleplay: preserve the relationship trajectory and how it evolved; the user's emotional context and recurring themes; key personal facts the user shared; shared jokes, nicknames and promises; unresolved emotional threads (things the user said they would follow up on). Do NOT strip these as "irrelevant exploration" — in this mode they are the substance of the conversation.
 - Drop: greetings, raw tool output details, and exploration irrelevant to the conversation's purpose.
 - Do not call any tool. Output the summary directly.
-- Output structured Markdown, at most 3000 tokens.
+- Output structured Markdown, at most ${tokenBudget} tokens.
 - Write the summary in the dominant language of the user's messages.`;
+}
 
 export interface SummarizeDeps {
   logger: Logger;
@@ -25,22 +36,37 @@ export interface SummarizeResult {
   digest: string;
 }
 
+export interface SummarizeOptions {
+  currentTokens?: number;
+}
+
 export async function summarizeForCompaction(
   agent: Agent,
   foldMessages: Message[],
   sessionId: string,
   deps: SummarizeDeps,
+  options: SummarizeOptions = {},
 ): Promise<SummarizeResult | null> {
   const model = agent.state.model;
   const streamFn = agent.streamFunction;
   if (!model || !streamFn) return null;
 
+  const tokenBudget =
+    options.currentTokens === undefined
+      ? MAX_SUMMARY_TOKEN_BUDGET
+      : computeSummaryTokenBudget(options.currentTokens);
+  const instruction = buildSummaryInstruction(tokenBudget);
+
   const llmMessages = await agent.convertToLlm(foldMessages as never);
   const context = {
     systemPrompt: agent.state.systemPrompt,
     tools: agent.state.tools,
-    messages: [...llmMessages, { role: "user", content: SUMMARY_INSTRUCTION } as Message],
+    messages: [...llmMessages, { role: "user", content: instruction } as Message],
   };
+
+  const modelMaxTokens = (model as { maxTokens?: number }).maxTokens;
+  const maxTokens =
+    modelMaxTokens === undefined ? tokenBudget : Math.min(tokenBudget, modelMaxTokens);
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), SUMMARIZE_TIMEOUT_MS);
@@ -48,6 +74,7 @@ export async function summarizeForCompaction(
   try {
     const stream = await streamFn(model, context, {
       sessionId,
+      maxTokens,
       signal: controller.signal,
     });
     const finalMessage = (await stream.result()) as {

--- a/packages/core/src/capabilities/compaction/summarize.ts
+++ b/packages/core/src/capabilities/compaction/summarize.ts
@@ -10,6 +10,7 @@ const MIN_SUMMARY_TOKEN_BUDGET = 1500;
 const MAX_SUMMARY_TOKEN_BUDGET = 16_000;
 
 export function computeSummaryTokenBudget(currentTokens: number): number {
+  if (!Number.isFinite(currentTokens)) return MAX_SUMMARY_TOKEN_BUDGET;
   const scaled = Math.round(currentTokens * SUMMARY_BUDGET_RATIO);
   return Math.min(MAX_SUMMARY_TOKEN_BUDGET, Math.max(MIN_SUMMARY_TOKEN_BUDGET, scaled));
 }
@@ -55,7 +56,10 @@ export async function summarizeForCompaction(
     options.currentTokens === undefined
       ? MAX_SUMMARY_TOKEN_BUDGET
       : computeSummaryTokenBudget(options.currentTokens);
-  const instruction = buildSummaryInstruction(tokenBudget);
+  const modelMaxTokens = (model as { maxTokens?: number }).maxTokens;
+  const maxTokens =
+    modelMaxTokens === undefined ? tokenBudget : Math.min(tokenBudget, modelMaxTokens);
+  const instruction = buildSummaryInstruction(maxTokens);
 
   const llmMessages = await agent.convertToLlm(foldMessages as never);
   const context = {
@@ -63,10 +67,6 @@ export async function summarizeForCompaction(
     tools: agent.state.tools,
     messages: [...llmMessages, { role: "user", content: instruction } as Message],
   };
-
-  const modelMaxTokens = (model as { maxTokens?: number }).maxTokens;
-  const maxTokens =
-    modelMaxTokens === undefined ? tokenBudget : Math.min(tokenBudget, modelMaxTokens);
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), SUMMARIZE_TIMEOUT_MS);
@@ -83,6 +83,12 @@ export async function summarizeForCompaction(
     };
     if (finalMessage.stopReason === "error" || finalMessage.stopReason === "aborted") {
       return null;
+    }
+    if (finalMessage.stopReason === "length") {
+      deps.logger.warn(
+        { sessionId, maxTokens },
+        "compaction summary hit the token budget, digest may be truncated",
+      );
     }
 
     const text = (finalMessage.content ?? [])

--- a/packages/core/src/capabilities/compaction/transform.ts
+++ b/packages/core/src/capabilities/compaction/transform.ts
@@ -38,7 +38,9 @@ export async function maybeCompactLog(
       return seq === undefined ? [] : [seq];
     });
 
-    const summary = await summarizeForCompaction(agent, messages, sessionId, deps);
+    const summary = await summarizeForCompaction(agent, messages, sessionId, deps, {
+      currentTokens,
+    });
     let digestContent: string;
     let digestSource: "llm" | "mechanical";
     if (summary) {


### PR DESCRIPTION
## 变更内容

原实现 compaction LLM 摘要指令固定 "at most 3000 tokens"（纯 prompt 文本约束），长 context 压缩后失忆过多。本 PR 改为按压缩时 context tokens 的 5% 动态给定摘要长度预算：

- `computeSummaryTokenBudget`：5% 缩放，clamp 1500–16000；非有限输入回退上限
- `buildSummaryInstruction(tokenBudget)`：指令文本内嵌生效预算值（与硬上限一致）
- stream options 传 `maxTokens = min(预算, model.maxTokens)` 作 API 层硬约束；`stopReason === "length"` 截断时 warn 但保留摘要
- `maybeCompactLog` 传入 `currentTokens` 接入生产链路
- 文档同步：`docs/official/architecture/core.md`

## 效果示例

| contextWindow | 压缩时 tokens (75%) | 旧预算 | 新预算 |
|---|---|---|---|
| 32k | 24k | 3000 | 1500 |
| 128k | 96k | 3000 | 4800 |
| 200k | 150k | 3000 | 7500 |
| 1M | 750k | 3000 | 16000（cap） |

## 验证

- `npm test --workspace=packages/core`：94 文件 1156 用例全过
- lint / typecheck 通过

## Review 报告

sub agent 对照需求与代码审查，**0 critical / 0 important / 3 minor / 1 未验证疑点**：

- **minor M1（已修，bcf0d0b）**：指令文本用 `tokenBudget` 而硬上限是 `min(tokenBudget, model.maxTokens)`，两者可能不一致；且 `stopReason === "length"` 截断摘要静默入库。→ 修法：指令改用生效值构建，截断时 `logger.warn`
- **minor M2（已修，bcf0d0b）**：`computeSummaryTokenBudget(NaN)` 不被 clamp 吸收，NaN 会传播到指令与 API 参数（生产不可达，防御缺失）。→ 修法：`Number.isFinite` 守卫，非有限输入回退上限
- **minor M3（不修）**：`docs/dev/features/2026-08-23-llm-compaction/design.md` 仍写 "≤ 3000 tokens"——按 AGENTS.md，`docs/dev/` 属历史记录允许过时，非同步对象
- **未验证疑点（不修）**：reasoning 模型下 maxTokens 是否覆盖 thinking tokens 未验证；即使耗尽导致空文本，`isDegenerateDigest` 会回退 mechanical/skip，行为可自愈