### PR TITLE
fix: 增大面板右上角关闭按钮叉号尺寸（12px → 14px）

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -21,6 +21,7 @@
 - [ ] **refreshProjects 路径不回收 streaming runtime**：外部关闭/多窗口场景下项目从快照消失时，`app-store.refreshProjects` 只改 projects map，不走 `closeProjectCascade`，该项目 chat streaming runtime（WS + 重连定时器）仍存活。受「全局 store 不得依赖 feature-local store」约束，修复需 streaming runtime 生命周期整体重构，宜与 followup P1「移除 streaming/trigger 镜像」合并考虑。参见 `docs/dev/infra/2026-08-28-project-lifecycle-orchestration/design.md` 已知缺口
 - [ ] **BrowserPage render 期 navigate 重定向疑似失效**：`pages/BrowserPage.tsx` 在 render 期间调用 `navigate(...)`（React Router 反模式）。组件测试迁移（2026-08-29）中用 MemoryRouter 验证发现该调用不会完成导航，仅返回 null——web 壳访问 `/project/:id/browser` 时可能停在空白路由而非回到项目首页。修复方向：改为 `useEffect` 内导航或 `<Navigate replace />`；修复后可在 `save-export-degradation.test.tsx` 补真正的路由断言。
 - [ ] **desktop 契约测试缺位**：AGENTS.md 红线要求「core 的 PM 写入门面与 `SessionPort` 方法，消费方包（server/desktop）至少各有一条不 mock 被测方法本身的契约测试」；server 侧已有（`write-facade-contract.test.ts`），desktop 侧现有 `electron/ipc/project.test.ts`、`electron/server.test.ts` 均 vi.mock 了 server/门面，不满足红线。需补一条走真实门面（或真实 IPC 边界）的契约测试。
+- [ ] **补齐 dialog/sheet 关闭按钮 sr-only 文案 i18n**：`packages/app/src/components/ui/dialog.tsx:73` 与 `sheet.tsx:73` 的 `<span className="sr-only">Close</span>` 硬编码英文，屏幕阅读器可读的用户可见文案未走 `@spherse/i18n`（违反仓库红线）；替换为已有 `common.close` 键的 `t()` 即可（2026-08-30 关闭按钮尺寸调整 review 顺带发现）。
 
 ## 技术债（重构与收敛）
 

--- a/packages/app/src/features/chat/Header.tsx
+++ b/packages/app/src/features/chat/Header.tsx
@@ -21,7 +21,7 @@ export function Header({ agent, onClose }: HeaderProps) {
           onClick={onClose}
           title={t("chat.close")}
         >
-          <XIcon />
+          <XIcon className="size-3.5" />
         </Button>
       )}
     </div>

--- a/packages/app/src/features/chat/HtmlCard.tsx
+++ b/packages/app/src/features/chat/HtmlCard.tsx
@@ -329,7 +329,7 @@ export function HtmlCardRenderer({ card, defaultCollapsed = false }: HtmlCardRen
                 onClick={() => setExpanded(false)}
                 title={t("chat.close")}
               >
-                <XIcon />
+                <XIcon className="size-3.5" />
               </Button>
             </div>
             <div className="min-h-0 flex-1 p-2">

--- a/packages/app/src/features/content-browser/FindBar.tsx
+++ b/packages/app/src/features/content-browser/FindBar.tsx
@@ -84,7 +84,7 @@ export function FindBar({ containerRef, contentKey, onClose }: FindBarProps) {
         title={t("content-browser.find.close")}
         aria-label={t("content-browser.find.close")}
       >
-        <XIcon />
+        <XIcon className="size-3.5" />
       </Button>
     </div>
   );

--- a/packages/app/src/features/content-browser/Header.tsx
+++ b/packages/app/src/features/content-browser/Header.tsx
@@ -129,7 +129,7 @@ export function Header({
         ) : null}
         {!isEditing && (
           <Button variant="ghost" size="icon-sm" onClick={onClose} title={t("common.close")} aria-label={t("common.close")}>
-            <XIcon />
+            <XIcon className="size-3.5" />
           </Button>
         )}
       </div>


### PR DESCRIPTION
## 变更

用户反馈 chat / content browser 右上角关闭按钮叉号偏小，统一加大一点点（12px → 14px），按钮外框（icon-sm 24px）不变，与浮动窗口叉号（FloatingFrame / draggable-window 已是 14px）对齐。

4 处 `<XIcon />` 显式加 `className="size-3.5"`（跳过 Button `icon-sm` 变体的 svg 默认 `size-3`）：

- `packages/app/src/features/chat/Header.tsx` — chat 面板关闭
- `packages/app/src/features/content-browser/Header.tsx` — content browser 面板关闭
- `packages/app/src/features/chat/HtmlCard.tsx` — HTML card 全屏展开关闭
- `packages/app/src/features/content-browser/FindBar.tsx` — 查找栏关闭（同模式顺带）

**不改**：dialog.tsx / sheet.tsx（dialog 类，按需求排除）；FloatingFrame / draggable-window（已是 14px）；其余 XIcon 为行内操作按钮（撤回、附件移除、审批拒绝等），非面板关闭。

纯 className 视觉微调，无逻辑/文案/导出变更，现有测试不受影响（FindBar / save-export-degradation 测试不涉及 class）。lint 通过（仅存量 warning）。

## Doc-sync 自查

| 项 | 结论 |
|---|---|
| project-structure / architecture / ADR / data-conventions / glossary / package README | 无影响（无结构、架构、数据、规范变更） |
| i18n | 无影响（复用既有 key，无新增文案） |
| theme skills | 无影响（未触碰 themeable selector 与 CSS token） |
| backlog | 无对应待完成条目；review 顺带发现的 dialog/sheet sr-only "Close" 硬编码英文缺口已记入 backlog（commit 2） |