### PR TITLE
refactor: chat runtime 拆分（reconcile 状态机 / 事件管线去重 / history 提取）

### DIFF
--- a/docs/dev/features/2026-09-02-chat-runtime-refactor/design.md
+++ b/docs/dev/features/2026-09-02-chat-runtime-refactor/design.md
@@ -1,0 +1,146 @@
+# Chat runtime 重构：reconcile 状态机提取、事件管线去重与 history 提取
+
+- 日期：2026-09-02
+- 状态：实施中（design review 已处理：onclose 降级语义补接口、#4 行为变更补测试、泛型 `as T` 定案、`HistoryPaginationState` 约束修正、批处理 `now` 单值、reconciler 不设 dispose）
+- 分支：`refactor/chat-runtime-analysis-8f3k2`
+
+## 背景与问题
+
+`packages/app/src/features/chat/runtime/` 下两个核心文件行数偏多且职责有混合：
+
+- `streaming-store.ts`（525 行）：zustand feature-local store，混杂会话生命周期管理、rAF 事件批处理、withdraw 结算纯逻辑、用户 action、history 分页、runtime wiring 六类关注点
+- `chat-session-runtime.ts`（449 行）：per-session WebSocket runtime，`connect()` 为 ~180 行巨石方法，内嵌完整 history-reconcile 状态机（闭包状态 `connectionEvents` / `reconcilingHistory` / `historyWasReady` + ~60 行带退避重试的 `reconcileHistory()`），四个 ws handler 全部捕获这些闭包
+
+`model/` 层已把纯逻辑（reducer / chat-history / retry-plan / withdrawable）拆干净，`streaming-store.test.ts`（702 行）作为穿过 store 的集成安全网已覆盖 heartbeat / reconnect / reconcile / probe / withdraw / history。本次为行为保持重构，不改变任何对外契约。
+
+## 决策
+
+| # | 决策点 | 结论 |
+|---|---|---|
+| 1 | reconcile 状态机归属 | 提取为 `runtime/history-reconciler.ts` 的 `HistoryReconciler` 类，**每次 `connect()` 新建实例**（对齐现状：闭包状态随单个 socket 生命周期，重连即重置）。回调接口 `isCurrent` / `getSession` / `updateSession` / `applyEvents` / `setStreaming`，由 runtime 在 `connect()` 内绑定到当前 ws 与 store callbacks。**不设 `dispose()`**：现状 reconcile 退避 setTimeout 在 socket 更替后仍会触发、由 `isCurrent()` gate 拒绝，直接移植保持该时序 | 
+| 2 | 事件管线去重形态 | reduce→merge→settle 管线整体下沉 `model/chat-session-reducer.ts`，导出纯函数 `applySessionEvents<T>(session, events, now): T`（内部复用 `reduceSessionEvents` + `settlePendingWithdraw`）。store 两处消费点（`flushQueuedEvents`、runtime `applyEvents` callback）改为调用同一函数，删除复制。**泛型返回处用单点 `as T` 断言**（spread 泛型不可赋回 `T` 是 TS 既定限制；安全性由构造保证——所有键均源自 `session`），不退非泛型 |
+| 3 | `settlePendingWithdraw` 位置 | 随 #2 移入 `model/chat-session-reducer.ts`（泛型 `<T extends { messages; pendingWithdraw }>`，`flagWithdrawError` 保持模块私有）。理由：纯函数（session × events → session），与 reducer 同族，移入后获得 reducer 级单测 |
+| 4 | `applyEvents` 通知语义 | 现状：updateSession 后**无条件**调 `projectDataStore.setStreaming`（该 setter 无 guard，每次都新 Set + set，触发冗余订阅通知）。改为**仅 streaming 值实际变化时通知**，与 `flushQueuedEvents` 既有 streamingChanges 收集语义对齐。值等价（幂等 set），消费方无感知 |
+| 5 | probe 去重 | 提取私有 `armProbeTimeout(ws, since)` 消除 re-arm 分支与 fresh-ping 分支两段相同 timeout body |
+| 6 | send 方法收窄 | 提取私有 `sendPayload(payload): boolean`（isOpen 检查 + send + true），六个发送方法（`sendMessage` / `abort` / `retry` / `withdraw` / `respondApproval` / `respondQuestion`）改为一行委托 |
+| 7 | history action 提取 | `loadMore` / `refreshHistory` 主体移入新文件 `runtime/history-actions.ts`，导出 `loadMoreHistory` / `refreshSessionHistory`，通过 port 接口（`getSession` / `updateSession`）与状态解耦；store action 保留原名做薄委托（公共面 10+ 消费方不动）。`retryHistory`（2 行）留 store。分页状态（`hasMore` / `oldestLoadedId` / `loadingMore` / `historyStatus` / `historyError`）**留在 session 对象内**——UI 直接选择这些字段，外移需重接 selector，不值得。`HistoryPaginationState` 含 `loadingMore`，当前仅 store 的 `StreamingSession` 结构满足（runtime 状态不含 `loadingMore`，本就不接 history-actions） |
+| 8 | reconciler 不复用 history-actions | reconcile 流程（退避重试循环 + 事件缓冲 + 历史合并原子单次 updateSession）与分页动作（guard + 单次 fetch）形态不同，强行共享会造出假抽象。保持两套 |
+| 9 | store 本体不拆 | `useStreamingStore` 是消费方稳定面；registry（23 行）不动 |
+| 10 | 尾部 re-export 清理 | `streaming-store.ts` 末尾的 `parseHistoryMessages` / `appendErrorMessage` / `StreamingSessionData` 三个 re-export 外部零消费方（已核实），按导出面红线删除 |
+| 11 | 日志前缀 | `console.warn` 前缀随代码走：history 逻辑移入 `history-actions.ts` 后前缀改为 `[history-actions]`，与各模块以自身名打前缀的既有惯例一致 |
+
+## 必须保持的语义（直接移植，不"顺手修复"）
+
+1. **reconcile 成功路径不做 withdraw settle**：原代码 reduce 后直接返回，不走 `settlePendingWithdraw`；仅缓冲区走 `applyEvents`（含 settle）路径时结算。此不对称原样保留（重构不改行为）。
+2. **reconcile 成功路径的原子性**：历史合并 + 缓冲事件归约必须在**同一次** `updateSession` 内完成（中间不得让 rAF flush 插入）。
+3. **`finally` 通知条件**：`isCurrent() && session 存在 && (succeeded \|\| historyWasReady)` 时 `setStreaming(session.streaming)`——注意重试耗尽但 `historyWasReady=true` 时**仍会通知**。
+4. **onclose 的 historyStatus 降级**：`"syncing" → (historyWasReady ? "ready" : "pending")` 依赖闭包内的 `historyWasReady`，reconciler 需暴露对应能力（见实现节 `applyClosedState`）。
+5. **onclose 时仍在 reconcile** → 先 flush 缓冲事件（走 `applyEvents` 路径），再 `flushEvents()`。
+6. **onopen 顺序**：心跳 → 捕获 `historyWasReady`（在置 `syncing` 之前）→ 状态更新（open/syncing）→ 发起 reconcile → 发送 initialMessage。
+7. **`flushQueuedEvents` 批量单次 `set()`**（多 session 同帧合并）保留；批内**共用同一个 `now`**（`Date.now()` 只取一次传入 `applySessionEvents`，保持同帧 session 的 `lastActivityAt` 一致）。
+8. referential-equality 跳过语义：所有 updateSession/updater 无变化时返回原引用，zustand 层面避免无效渲染。
+
+## 各文件实现
+
+### `model/chat-session-reducer.ts`（+#2/#3）
+
+```ts
+export interface PendingWithdrawSession {
+  messages: ChatMessage[];
+  pendingWithdraw: boolean;
+}
+
+export function settlePendingWithdraw<T extends PendingWithdrawSession>(session: T, events: AgentEvent[]): T;
+
+export interface SessionEventState extends StreamingSessionData, PendingWithdrawSession {}
+
+export function applySessionEvents<T extends SessionEventState>(session: T, events: AgentEvent[], now: number): T;
+```
+
+`applySessionEvents` = 现Store 内 reduce → `{...session, ...reduced}` → settle 三步的逐字移植。
+
+### `runtime/history-reconciler.ts`（+#1，新文件）
+
+```ts
+const RECONCILE_BACKOFFS = [1000, 2000, 5000];
+
+export interface HistoryReconcilerCallbacks<T extends ChatSessionRuntimeState> {
+  isCurrent(): boolean;                    // this.ws === ws && session 存在
+  getSession(): T | undefined;
+  updateSession(updater: (session: T) => T): void;
+  applyEvents(events: AgentEvent[]): void;
+  setStreaming(streaming: boolean): void;
+}
+
+export class HistoryReconciler<T extends ChatSessionRuntimeState> {
+  // 状态：buffered: AgentEvent[] / reconciling: boolean / historyWasReady: boolean
+  shouldBuffer(): boolean;
+  buffer(event: AgentEvent): void;
+  flushBuffered(): void;                   // 经 callbacks.applyEvents
+  onOpen(): void;                          // 捕获 historyWasReady、置 reconciling
+  applyClosedState(session: T): T;         // onclose 降级："syncing" → historyWasReady ? "ready" : "pending"，其余原引用字段不动
+  reconcile(client: ApiClient, agentId: string, sessionId: string): Promise<void>;
+}
+```
+
+`reconcile` 逐字移植原 `reconcileHistory()`（含成功原子合并、退避重试、重试耗尽 flush + historyError、finally 通知）。`ChatSessionRuntimeState` 以 `import type` 从 runtime 文件引入（类型单向，无运行时环）。
+
+### `chat-session-runtime.ts`（+#1/#5/#6）
+
+- `connect()` 从 ~180 行缩至 ~80 行：建 ws → 实例化 reconciler 并绑定回调 → 四个 handler 改为薄壳（onmessage 判 `shouldBuffer` 分流；onclose 判 reconciling flush；onopen 调 `reconciler.onOpen()` 后发起 reconcile）
+- 移除自身对 `chat-history` / `chat-session-reducer` 的直接依赖（全部转入 reconciler）
+- `probe()` / 六个 send 方法按 #5/#6 收窄
+- `ChatSessionRuntimeCallbacks` 接口不变（store wiring 零改动）
+
+### `runtime/history-actions.ts`（+#7，新文件）
+
+```ts
+export interface HistoryPaginationState {
+  messages: ChatMessage[];
+  streaming: boolean;
+  hasMore: boolean;
+  oldestLoadedId: number | null;
+  loadingMore: boolean;
+  historyStatus: "pending" | "syncing" | "ready";
+  historyError: boolean;
+}
+
+export interface HistorySessionPort<T extends HistoryPaginationState> {
+  getSession(): T | undefined;
+  updateSession(updater: (session: T) => T): void;
+}
+
+export function loadMoreHistory<T extends HistoryPaginationState>(port, client, agentId, sessionId): void;
+export function refreshSessionHistory<T extends HistoryPaginationState>(port, client, agentId, sessionId): void;
+```
+
+逻辑逐字移植（含 `refreshHistory` fetch 前后双 streaming guard）。store 的 `StreamingSession` 结构上满足 `HistoryPaginationState`（runtime 状态不含 `loadingMore`，不作为此 port 的消费方）。
+
+### `streaming-store.ts`
+
+- 删除 `settlePendingWithdraw` / `flagWithdrawError` 与两处管线复制，改 import `applySessionEvents`
+- `applyEvents` callback：`updateSession(applySessionEvents)` + streaming 变化时通知（#4）
+- `loadMore` / `refreshHistory` 委托 `history-actions`
+- 删除尾部三个零消费 re-export（#10）
+- 预计 525 → ~410 行；`chat-session-runtime.ts` 预计 449 → ~280 行
+
+## 测试
+
+- **存量不动**：`streaming-store.test.ts` 34 个用例全部原样通过（行为安全网，含 reconcile / reconnect / probe / withdraw 全路径）
+- `model/chat-session-reducer.test.ts` 新增 `applySessionEvents` / `settlePendingWithdraw` 纯函数用例（error 结算 `_withdrawError`、`turn_withdrawn` 清 pendingWithdraw、无事件命中原引用返回）
+- 新增 `runtime/history-reconciler.test.ts`：fake callbacks + fake timer，覆盖 reconcile 期间缓冲、onclose flush、退避重试耗尽 → historyError、socket 更替后中止、重试耗尽但 `historyWasReady=true` 时 finally 仍通知、onclose 降级
+- 新增 `runtime/history-actions.test.ts`：port 级单测覆盖 loadMore 四重 guard、refreshHistory 双 streaming guard、页面结果合并
+- **#4 行为变更专项**（`streaming-store.test.ts` 新增）：(a) 缓冲 flush 路径中 streaming 翻转（如 reconcile 期间 `run_status active:false` → onclose）时 `projectDataStore.streamingSessionIds` 正确更新；(b) 无 streaming 变化的事件批不再触发 project store set（spy `setStreaming` setter）
+- 验证链：`npm run lint --workspace=packages/app` → `npm run typecheck --workspace=packages/app` → `npm test --workspace=packages/app`
+- E2E：无用户可见变更，不跑专项；合并前按惯例 `npm run verify:e2e`
+
+## 风险与边界
+
+- **#4 通知语义收紧**：已核查 `streamingSessionIds` 消费方（SessionRow 等）只读集合值，值等价即安全。已知边界：`disconnect` / `cleanupExpired` 移除 session 时不清 `streamingSessionIds`，陈旧 id 理论上可残留到项目关闭——现状的无条件通知恰好构成偶发自愈，收紧后不再有；该残留本身需前置 bug 才会出现，接受
+- **泛型接线**：`applySessionEvents<T>` / `settlePendingWithdraw<T>` 返回处单点 `as T`（构造安全）；`HistoryReconciler<T>` 约束经 `import type` 引入 `ChatSessionRuntimeState`，无运行时环
+- **不动 `ChatSessionRuntimeCallbacks` 接口**：收窄 event-sink 三回调（enqueue/apply/flush）为单一接口是更优长期形态，但属于契约变更，本次不做
+
+## 文档同步（doc-sync 清单）
+
+- `docs/official/project-structure.md`：新增 `runtime/history-reconciler.ts`、`runtime/history-actions.ts`
+- `docs/official/architecture/chat.md`（若维护 runtime 模块清单）：同步模块职责描述

--- a/docs/dev/features/2026-09-02-chat-runtime-refactor/design.md
+++ b/docs/dev/features/2026-09-02-chat-runtime-refactor/design.md
@@ -1,7 +1,7 @@
 # Chat runtime 重构：reconcile 状态机提取、事件管线去重与 history 提取
 
 - 日期：2026-09-02
-- 状态：实施中（design review 已处理：onclose 降级语义补接口、#4 行为变更补测试、泛型 `as T` 定案、`HistoryPaginationState` 约束修正、批处理 `now` 单值、reconciler 不设 dispose）
+- 状态：已实施（design review：onclose 降级语义补接口、#4 行为变更补测试、泛型 `as T` 定案、`HistoryPaginationState` 约束修正、批处理 `now` 单值、reconciler 不设 dispose；code review：#4 反向测试改为命中 buffered flush 路径、`PendingWithdrawSession` / `SessionEventState` 不导出）
 - 分支：`refactor/chat-runtime-analysis-8f3k2`
 
 ## 背景与问题
@@ -45,14 +45,14 @@
 ### `model/chat-session-reducer.ts`（+#2/#3）
 
 ```ts
-export interface PendingWithdrawSession {
+interface PendingWithdrawSession {   // 模块内约束类型，不导出（零外部消费）
   messages: ChatMessage[];
   pendingWithdraw: boolean;
 }
 
 export function settlePendingWithdraw<T extends PendingWithdrawSession>(session: T, events: AgentEvent[]): T;
 
-export interface SessionEventState extends StreamingSessionData, PendingWithdrawSession {}
+interface SessionEventState extends StreamingSessionData, PendingWithdrawSession {}
 
 export function applySessionEvents<T extends SessionEventState>(session: T, events: AgentEvent[], now: number): T;
 ```
@@ -122,7 +122,7 @@ export function refreshSessionHistory<T extends HistoryPaginationState>(port, cl
 - `applyEvents` callback：`updateSession(applySessionEvents)` + streaming 变化时通知（#4）
 - `loadMore` / `refreshHistory` 委托 `history-actions`
 - 删除尾部三个零消费 re-export（#10）
-- 预计 525 → ~410 行；`chat-session-runtime.ts` 预计 449 → ~280 行
+- 实际结果：streaming-store.ts 525 → 458 行；chat-session-runtime.ts 449 → 362 行；新增 history-reconciler.ts 113 行 + history-actions.ts 75 行；reducer +41 行
 
 ## 测试
 
@@ -130,7 +130,7 @@ export function refreshSessionHistory<T extends HistoryPaginationState>(port, cl
 - `model/chat-session-reducer.test.ts` 新增 `applySessionEvents` / `settlePendingWithdraw` 纯函数用例（error 结算 `_withdrawError`、`turn_withdrawn` 清 pendingWithdraw、无事件命中原引用返回）
 - 新增 `runtime/history-reconciler.test.ts`：fake callbacks + fake timer，覆盖 reconcile 期间缓冲、onclose flush、退避重试耗尽 → historyError、socket 更替后中止、重试耗尽但 `historyWasReady=true` 时 finally 仍通知、onclose 降级
 - 新增 `runtime/history-actions.test.ts`：port 级单测覆盖 loadMore 四重 guard、refreshHistory 双 streaming guard、页面结果合并
-- **#4 行为变更专项**（`streaming-store.test.ts` 新增）：(a) 缓冲 flush 路径中 streaming 翻转（如 reconcile 期间 `run_status active:false` → onclose）时 `projectDataStore.streamingSessionIds` 正确更新；(b) 无 streaming 变化的事件批不再触发 project store set（spy `setStreaming` setter）
+- **#4 行为变更专项**（`streaming-store.test.ts` 新增，两条均走 buffered flush 路径以命中被改动的 `applyEvents` 代码）：(a) 缓冲 flush 中 streaming 翻转（reconcile 挂起期间 `run_status active:true` → onclose flush）时 `projectDataStore.streamingSessionIds` 正确更新；(b) 缓冲 flush 无 streaming 变化（`message_update`）时不触发 project store set（spy 断言）
 - 验证链：`npm run lint --workspace=packages/app` → `npm run typecheck --workspace=packages/app` → `npm test --workspace=packages/app`
 - E2E：无用户可见变更，不跑专项；合并前按惯例 `npm run verify:e2e`
 

--- a/docs/dev/features/2026-09-02-chat-runtime-refactor/plan.md
+++ b/docs/dev/features/2026-09-02-chat-runtime-refactor/plan.md
@@ -1,0 +1,12 @@
+# Chat runtime 重构实施计划
+
+设计：[design.md](./design.md)
+
+- [x] 1. `model/chat-session-reducer.ts`：新增 `settlePendingWithdraw` / `applySessionEvents`（含 `flagWithdrawError` 私有化）
+- [x] 2. 新建 `runtime/history-reconciler.ts`（reconcile 状态机逐字移植，含 `applyClosedState`）
+- [x] 3. 新建 `runtime/history-actions.ts`（`loadMoreHistory` / `refreshSessionHistory` + port 接口）
+- [x] 4. 重写 `chat-session-runtime.ts`：connect 接 reconciler、`armProbeTimeout`、`sendPayload`
+- [x] 5. 精简 `streaming-store.ts`：管线去重（`applyEventsAndNotify`）、history 委托、删 re-export
+- [x] 6. 测试：reducer 纯函数用例（7）、history-reconciler 套件（9）、history-actions 套件（6）、streaming-store #4 专项（2）
+- [x] 7. 验证：lint（0 error）+ typecheck 通过 + `npm test --workspace=packages/app` 1006 用例全绿（存量 34 个 streaming-store 用例原样通过）
+- [ ] 8. commit + code-review + doc-sync + PR

--- a/docs/official/architecture/chat.md
+++ b/docs/official/architecture/chat.md
@@ -58,9 +58,9 @@ Composer.send
 
 ## Renderer：runtime / store / reducer 三层
 
-- **`ChatSessionRuntime`（非响应式）**：持有 WS、心跳、重连 timer、连接期事件缓冲、历史对账；经 `ChatRuntimeRegistry` 管理生命周期，transport 不进 Zustand
-- **`streaming-store`（Zustand）**：只持 UI 可观察状态与 actions；`connectionStatus`（disconnected/connecting/open）与 `historyStatus`（pending/syncing/ready）是正交维度
-- **`chat-session-reducer`（纯函数）**：事件 → view state 归约；历史解析与稳定 ID 合并在 `chat-history.ts`，tool/card 投影在 `chat-tool-projection.ts`
+- **`ChatSessionRuntime`（非响应式）**：持有 WS、心跳、重连/探活 timer 与发送动作；每次连接组合一个 `HistoryReconciler`（连接期事件缓冲 + 历史对账状态机，`history-reconciler.ts`，随 socket 生命周期新建）；经 `ChatRuntimeRegistry` 管理生命周期，transport 不进 Zustand
+- **`streaming-store`（Zustand）**：只持 UI 可观察状态与 actions；`connectionStatus`（disconnected/connecting/open）与 `historyStatus`（pending/syncing/ready）是正交维度；history 分页动作（loadMore / refreshHistory）在 `history-actions.ts`，经 port 接口（getSession / updateSession）与 session 状态解耦
+- **`chat-session-reducer`（纯函数）**：事件 → view state 归约，`applySessionEvents` 为归约 + withdraw 结算（`settlePendingWithdraw`）的完整管线；历史解析与稳定 ID 合并在 `chat-history.ts`，tool/card 投影在 `chat-tool-projection.ts`
 - 事件按 **animation frame 批量归约**：单次 `set()` 内 flush 整个 eventQueue，避免高频 token update 触发过多 render
 - `ChatMessage` 的 `_` 前缀字段是 view 投影：
   - 身份与状态：`_messageId`（= seq，历史对账去重键）、`_optimistic` / `_streaming` / `_sendFailed`

--- a/docs/official/project-structure.md
+++ b/docs/official/project-structure.md
@@ -259,7 +259,7 @@ spherse/
 │   │       │   ├── activity-bar/         # 自治型 Activity Bar（项目头像轨、设置/添加按钮），内部读 app-store/app-ui-store 与 useProjectActions；pin 按钮通过 pinToggle prop 可选注入
 │   │       │   ├── agent-trigger/        # Agent 触发器弹窗、表单、列表与运行日志，含 running 运行态 feature store 与 TriggerEventBridge（trigger 域唯一事件接线：查询失效 + 运行态 + 通知）
 │   │       │   ├── agent-session-list/   # Agent/session 分组列表，含 AgentDialog/SearchFileField 与折叠状态 feature store
-│   │       │   ├── chat/                 # 对话 feature；model/ 放事件解析、历史投影、turn 分组派生与 reducer，runtime/ 放 streaming store、WS/心跳/重连 runtime，hooks/ 放 UI hooks，lib/ 放聚合/diff/format-time 纯函数，utils/ 放图片压缩（compress-image）；根目录保留页面组件、运行时 context、chat 专属类型与附件 UI（AttachmentBar/MessageAttachments）
+│   │   │   ├── chat/                 # 对话 feature；model/ 放事件解析、历史投影、turn 分组派生与 reducer，runtime/ 放 streaming store、WS runtime（心跳/重连/探活）、history 对账（history-reconciler）与分页动作（history-actions），hooks/ 放 UI hooks，lib/ 放聚合/diff/format-time 纯函数，utils/ 放图片压缩（compress-image）；根目录保留页面组件、运行时 context、chat 专属类型与附件 UI（AttachmentBar/MessageAttachments）
 │   │       │   ├── content-browser/      # 文件浏览、预览（HTML/markdown/image）、编辑、复制路径/刷新、冲突提示，ContentQueryBridge 集中处理 fs-watch/reconnect 缓存失效；二进制文件拦截渲染占位卡 UnsupportedFileCard（桌面端经 HostCapabilities.openFileExternal 提供「用默认应用打开」按钮）
 │   │       │   ├── debug-tools/          # 调试菜单（开发模式或设置开启 debugToolsEnabled 时显示）+ Streaming Log 悬浮面板
 │   │       │   ├── floating-chat/         # 浮动聊天窗口（Portal overlay、主题隔离），复用 components/floating-frame；含 useFloatingSessionId

--- a/packages/app/src/features/chat/model/chat-session-reducer.test.ts
+++ b/packages/app/src/features/chat/model/chat-session-reducer.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import { ErrorEventCode } from "@spherse/contracts";
 import {
   appendErrorMessage,
+  applySessionEvents,
   markRetrying,
   reduceSessionEvents,
+  settlePendingWithdraw,
   type StreamingSessionData,
 } from "./chat-session-reducer";
 import {
@@ -993,5 +995,110 @@ describe("generic approval card lifecycle", () => {
       { role: "assistant", content: "Hi", _streaming: false },
     ];
     expect(markRetrying(messages)).toBe(messages);
+  });
+});
+
+describe("settlePendingWithdraw", () => {
+  interface WithdrawSession {
+    messages: ChatMessage[];
+    streaming: boolean;
+    lastActivityAt: number;
+    scrollPosition: number;
+    pendingWithdraw: boolean;
+  }
+
+  function withdrawSession(overrides: Partial<WithdrawSession> = {}): WithdrawSession {
+    return {
+      messages: [
+        { role: "user", content: "q1" },
+        { role: "assistant", content: "a1" },
+      ],
+      streaming: false,
+      lastActivityAt: 1,
+      scrollPosition: 0,
+      pendingWithdraw: true,
+      ...overrides,
+    };
+  }
+
+  it("is a no-op when no withdraw is pending", () => {
+    const session = withdrawSession({ pendingWithdraw: false });
+    expect(settlePendingWithdraw(session, [{ type: "turn_withdrawn", seq: 0 } as AgentEvent])).toBe(session);
+  });
+
+  it("is a no-op when events neither fail nor withdraw", () => {
+    const session = withdrawSession();
+    expect(settlePendingWithdraw(session, [{ type: "turn_start" } as AgentEvent])).toBe(session);
+  });
+
+  it("clears pendingWithdraw when turn_withdrawn arrives", () => {
+    const session = withdrawSession();
+    const next = settlePendingWithdraw(session, [
+      { type: "turn_withdrawn", seq: 0 } as AgentEvent,
+    ]);
+    expect(next.pendingWithdraw).toBe(false);
+    expect(next.messages).toBe(session.messages);
+  });
+
+  it("flags the trailing error bubble as _withdrawError on error", () => {
+    const session = withdrawSession({
+      messages: [
+        { role: "user", content: "q1" },
+        { role: "assistant", content: "", _error: "boom", _turnError: true },
+      ],
+    });
+    const next = settlePendingWithdraw(session, [
+      { type: "error", message: "boom" } as unknown as AgentEvent,
+    ]);
+    expect(next.pendingWithdraw).toBe(false);
+    expect(next.messages[1]._withdrawError).toBe(true);
+    expect(next.messages).toHaveLength(2);
+  });
+});
+
+describe("applySessionEvents", () => {
+  interface FullSession {
+    messages: ChatMessage[];
+    streaming: boolean;
+    lastActivityAt: number;
+    scrollPosition: number;
+    pendingWithdraw: boolean;
+  }
+
+  function fullSession(overrides: Partial<FullSession> = {}): FullSession {
+    return {
+      messages: [],
+      streaming: false,
+      lastActivityAt: 1,
+      scrollPosition: 0,
+      pendingWithdraw: false,
+      ...overrides,
+    };
+  }
+
+  it("returns the same reference when nothing applies", () => {
+    const session = fullSession();
+    expect(applySessionEvents(session, [{ type: "turn_start" } as AgentEvent], 100)).toBe(session);
+  });
+
+  it("reduces events and settles a pending withdraw in one pass", () => {
+    const session = fullSession({
+      messages: [{ role: "user", content: "q1" }],
+      pendingWithdraw: true,
+    });
+    const next = applySessionEvents(session, [
+      { type: "turn_withdrawn", seq: 0 } as AgentEvent,
+    ], 200);
+    expect(next.messages).toEqual([]);
+    expect(next.pendingWithdraw).toBe(false);
+    expect(next.lastActivityAt).toBe(200);
+  });
+
+  it("flips streaming through run_status events", () => {
+    const session = fullSession({ streaming: false });
+    const next = applySessionEvents(session, [
+      { type: "run_status", active: true } as AgentEvent,
+    ], 200);
+    expect(next.streaming).toBe(true);
   });
 });

--- a/packages/app/src/features/chat/model/chat-session-reducer.ts
+++ b/packages/app/src/features/chat/model/chat-session-reducer.ts
@@ -45,6 +45,47 @@ export function reduceSessionEvents(
   };
 }
 
+export interface PendingWithdrawSession {
+  messages: ChatMessage[];
+  pendingWithdraw: boolean;
+}
+
+export function settlePendingWithdraw<T extends PendingWithdrawSession>(
+  session: T,
+  events: AgentEvent[],
+): T {
+  if (!session.pendingWithdraw) return session;
+  const failed = events.some((event) => event.type === "error");
+  if (!failed && !events.some((event) => event.type === "turn_withdrawn")) return session;
+  const messages = failed ? flagWithdrawError(session.messages) : session.messages;
+  return { ...session, messages, pendingWithdraw: false } as T;
+}
+
+function flagWithdrawError(messages: ChatMessage[]): ChatMessage[] {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role !== "assistant") break;
+    if (message._error) {
+      const next = [...messages];
+      next[i] = { ...message, _withdrawError: true };
+      return next;
+    }
+  }
+  return messages;
+}
+
+export interface SessionEventState extends StreamingSessionData, PendingWithdrawSession {}
+
+export function applySessionEvents<T extends SessionEventState>(
+  session: T,
+  events: AgentEvent[],
+  now: number,
+): T {
+  const reduced = reduceSessionEvents(session, events, now);
+  const merged = reduced === session ? session : ({ ...session, ...reduced } as T);
+  return settlePendingWithdraw(merged, events);
+}
+
 export function appendErrorMessage(prev: ChatMessage[], message: string, code?: ErrorEventCode): ChatMessage[] {
   const last = prev[prev.length - 1];
   if (last?.role === "assistant" && last._streaming) {

--- a/packages/app/src/features/chat/model/chat-session-reducer.ts
+++ b/packages/app/src/features/chat/model/chat-session-reducer.ts
@@ -45,7 +45,7 @@ export function reduceSessionEvents(
   };
 }
 
-export interface PendingWithdrawSession {
+interface PendingWithdrawSession {
   messages: ChatMessage[];
   pendingWithdraw: boolean;
 }
@@ -74,7 +74,7 @@ function flagWithdrawError(messages: ChatMessage[]): ChatMessage[] {
   return messages;
 }
 
-export interface SessionEventState extends StreamingSessionData, PendingWithdrawSession {}
+interface SessionEventState extends StreamingSessionData, PendingWithdrawSession {}
 
 export function applySessionEvents<T extends SessionEventState>(
   session: T,

--- a/packages/app/src/features/chat/runtime/chat-session-runtime.ts
+++ b/packages/app/src/features/chat/runtime/chat-session-runtime.ts
@@ -2,19 +2,12 @@ import { CHAT_CLOSE_CODES, parseChatServerEvent } from "@spherse/contracts";
 import type { ApiClient } from "../../../lib/api";
 import { buildWsUrl } from "../../../lib/api";
 import { parseAgentEvent, type AgentEvent } from "../model/agent-event-parse";
+import type { StreamingSessionData } from "../model/chat-session-reducer";
 import type { SendableImage } from "../types";
-import {
-  mergeHistoryMessages,
-  parseHistoryMessages,
-} from "../model/chat-history";
-import {
-  reduceSessionEvents,
-  type StreamingSessionData,
-} from "../model/chat-session-reducer";
+import { HistoryReconciler } from "./history-reconciler";
 
 const RECONNECT_BACKOFFS = [1000, 2000, 5000, 10000, 30000];
 const MAX_RECONNECT_ATTEMPTS = 10;
-const RECONCILE_BACKOFFS = [1000, 2000, 5000];
 const HEARTBEAT_INTERVAL_MS = 30 * 1000;
 const HEARTBEAT_TIMEOUT_MS = 60 * 1000;
 const RESUME_PROBE_TIMEOUT_MS = 5 * 1000;
@@ -88,74 +81,13 @@ export class ChatSessionRuntime<T extends ChatSessionRuntimeState> {
       ),
     );
     this.ws = ws;
-    const connectionEvents: AgentEvent[] = [];
-    let reconcilingHistory = false;
-    let historyWasReady = false;
-
-    const applyConnectionEvents = () => {
-      if (connectionEvents.length === 0) return;
-      this.callbacks.applyEvents(connectionEvents.splice(0));
-    };
-
-    const reconcileHistory = async () => {
-      let succeeded = false;
-      try {
-        for (let attempt = 0; attempt <= RECONCILE_BACKOFFS.length; attempt++) {
-          try {
-            const result = await params.client.getSessionMessagesPage(
-              params.agentId,
-              this.sessionId,
-              { limit: 20 },
-            );
-            if (this.ws !== ws || !this.callbacks.getSession()) return;
-            const historyMessages = parseHistoryMessages(result.entries);
-            this.callbacks.updateSession((session) => {
-              const reconciled = {
-                ...session,
-                messages: mergeHistoryMessages(session.messages, historyMessages),
-                hasMore: result.hasMore,
-                oldestLoadedId: result.oldestId,
-                historyStatus: "ready" as const,
-                historyError: false,
-              };
-              return {
-                ...reconciled,
-                ...reduceSessionEvents(
-                  reconciled,
-                  connectionEvents.splice(0),
-                  Date.now(),
-                ),
-              };
-            });
-            succeeded = true;
-            return;
-          } catch (err) {
-            console.warn(
-              "[chat-session-runtime] failed to reconcile session history:",
-              err,
-            );
-            if (this.ws !== ws || !this.callbacks.getSession()) return;
-            if (attempt < RECONCILE_BACKOFFS.length) {
-              await new Promise((r) => setTimeout(r, RECONCILE_BACKOFFS[attempt]));
-              if (this.ws !== ws || !this.callbacks.getSession()) return;
-              continue;
-            }
-            applyConnectionEvents();
-            this.callbacks.updateSession((session) => ({
-              ...session,
-              historyStatus: historyWasReady ? "ready" : "pending",
-              historyError: !historyWasReady,
-            }));
-          }
-        }
-      } finally {
-        reconcilingHistory = false;
-        const session = this.callbacks.getSession();
-        if (this.ws === ws && session && (succeeded || historyWasReady)) {
-          this.callbacks.setStreaming(session.streaming);
-        }
-      }
-    };
+    const reconciler = new HistoryReconciler<T>({
+      isCurrent: () => this.ws === ws && !!this.callbacks.getSession(),
+      getSession: () => this.callbacks.getSession(),
+      updateSession: (updater) => this.callbacks.updateSession(updater),
+      applyEvents: (events) => this.callbacks.applyEvents(events),
+      setStreaming: (streaming) => this.callbacks.setStreaming(streaming),
+    });
 
     ws.onmessage = (event) => {
       if (this.ws !== ws || !this.callbacks.getSession()) return;
@@ -167,8 +99,8 @@ export class ChatSessionRuntime<T extends ChatSessionRuntimeState> {
           return;
         }
         const parsed = parseAgentEvent(parseChatServerEvent(raw));
-        if (reconcilingHistory) {
-          connectionEvents.push(parsed);
+        if (reconciler.shouldBuffer()) {
+          reconciler.buffer(parsed);
         } else {
           this.callbacks.enqueueEvent(parsed);
         }
@@ -191,16 +123,12 @@ export class ChatSessionRuntime<T extends ChatSessionRuntimeState> {
       if (this.ws !== ws || !this.callbacks.getSession()) return;
       this.ws = null;
       this.clearHeartbeatTimer();
-      if (reconcilingHistory) applyConnectionEvents();
+      if (reconciler.shouldBuffer()) reconciler.flushBuffered();
       this.callbacks.flushEvents();
       const fatal = FATAL_CLOSE_CODES.has(event.code);
       this.callbacks.updateSession((session) => ({
-        ...session,
+        ...reconciler.applyClosedState(session),
         connectionStatus: "disconnected",
-        historyStatus:
-          session.historyStatus === "syncing"
-            ? (historyWasReady ? "ready" : "pending")
-            : session.historyStatus,
         messages: fatal
           ? session.messages.map((message) => (
               message._streaming
@@ -224,16 +152,14 @@ export class ChatSessionRuntime<T extends ChatSessionRuntimeState> {
       if (this.ws !== ws || !this.callbacks.getSession()) return;
       this.startHeartbeat(ws);
       this.reconnectAttempt = 0;
-      historyWasReady =
-        this.callbacks.getSession()?.historyStatus === "ready";
-      reconcilingHistory = true;
+      reconciler.onOpen();
       this.callbacks.updateSession((session) => ({
         ...session,
         connectionStatus: "open",
         reconnectFailed: false,
         historyStatus: "syncing",
       }));
-      void reconcileHistory();
+      void reconciler.reconcile(params.client, params.agentId, this.sessionId);
       if (
         params.initialMessage &&
         this.callbacks.takeInitialMessage(params.initialMessage)
@@ -271,18 +197,7 @@ export class ChatSessionRuntime<T extends ChatSessionRuntimeState> {
       // A ping is already pending (heartbeat or an earlier probe): re-arm the
       // short probe against it instead of silently falling back to the 60s
       // heartbeat watchdog.
-      const pendingSince = this.awaitingPongSince;
-      this.probeTimer = setTimeout(() => {
-        this.probeTimer = undefined;
-        if (this.ws !== ws || this.ws.readyState !== WebSocket.OPEN) return;
-        if (this.awaitingPongSince !== undefined && this.awaitingPongSince <= pendingSince) {
-          try {
-            ws.close();
-          } catch (err) {
-            console.warn("[chat-session-runtime] probe close failed:", err);
-          }
-        }
-      }, RESUME_PROBE_TIMEOUT_MS);
+      this.armProbeTimeout(ws, this.awaitingPongSince);
       return;
     }
     const probeStartedAt = Date.now();
@@ -294,67 +209,45 @@ export class ChatSessionRuntime<T extends ChatSessionRuntimeState> {
       console.warn("[chat-session-runtime] probe ping failed:", err);
       return;
     }
-    this.probeTimer = setTimeout(() => {
-      this.probeTimer = undefined;
-      if (this.ws !== ws || this.ws.readyState !== WebSocket.OPEN) return;
-      if (this.awaitingPongSince !== undefined && this.awaitingPongSince <= probeStartedAt) {
-        try {
-          ws.close();
-        } catch (err) {
-          console.warn("[chat-session-runtime] probe close failed:", err);
-        }
-      }
-    }, RESUME_PROBE_TIMEOUT_MS);
+    this.armProbeTimeout(ws, probeStartedAt);
   }
 
   sendMessage(content: string, image?: SendableImage): boolean {
-    if (!this.isOpen()) return false;
     const payload: Record<string, unknown> = { type: "message", content };
     if (image) {
       payload.attachments = [{ type: "image", path: image.path, mimeType: image.mimeType }];
     }
-    this.ws?.send(JSON.stringify(payload));
-    return true;
+    return this.sendPayload(payload);
   }
 
   abort(): boolean {
-    if (!this.isOpen()) return false;
-    this.ws?.send(JSON.stringify({ type: "abort" }));
-    return true;
+    return this.sendPayload({ type: "abort" });
   }
 
   retry(): boolean {
-    if (!this.isOpen()) return false;
-    this.ws?.send(JSON.stringify({ type: "retry" }));
-    return true;
+    return this.sendPayload({ type: "retry" });
   }
 
   withdraw(): boolean {
-    if (!this.isOpen()) return false;
-    this.ws?.send(JSON.stringify({ type: "withdraw" }));
-    return true;
+    return this.sendPayload({ type: "withdraw" });
   }
 
   respondApproval(requestId: string, approved: boolean): boolean {
-    if (!this.isOpen()) return false;
-    this.ws?.send(JSON.stringify({
+    return this.sendPayload({
       type: "resolve_control_request",
       requestId,
       kind: "approval",
       approved,
-    }));
-    return true;
+    });
   }
 
   respondQuestion(requestId: string, answer: string): boolean {
-    if (!this.isOpen()) return false;
-    this.ws?.send(JSON.stringify({
+    return this.sendPayload({
       type: "resolve_control_request",
       requestId,
       kind: "question",
       answer,
-    }));
-    return true;
+    });
   }
 
   dispose(): void {
@@ -379,6 +272,26 @@ export class ChatSessionRuntime<T extends ChatSessionRuntimeState> {
     this.callbacks.updateSession((session) => ({ ...session, reconnectFailed: false }));
     this.clearReconnectTimer();
     this.connect(this.params);
+  }
+
+  private sendPayload(payload: Record<string, unknown>): boolean {
+    if (!this.isOpen()) return false;
+    this.ws?.send(JSON.stringify(payload));
+    return true;
+  }
+
+  private armProbeTimeout(ws: WebSocket, since: number): void {
+    this.probeTimer = setTimeout(() => {
+      this.probeTimer = undefined;
+      if (this.ws !== ws || this.ws.readyState !== WebSocket.OPEN) return;
+      if (this.awaitingPongSince !== undefined && this.awaitingPongSince <= since) {
+        try {
+          ws.close();
+        } catch (err) {
+          console.warn("[chat-session-runtime] probe close failed:", err);
+        }
+      }
+    }, RESUME_PROBE_TIMEOUT_MS);
   }
 
   private scheduleReconnect(): void {

--- a/packages/app/src/features/chat/runtime/history-actions.test.ts
+++ b/packages/app/src/features/chat/runtime/history-actions.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "../../../lib/api";
+import type { ChatMessage } from "../types";
+import {
+  loadMoreHistory,
+  refreshSessionHistory,
+  type HistoryPaginationState,
+  type HistorySessionPort,
+} from "./history-actions";
+
+type TestSession = HistoryPaginationState;
+
+function session(overrides: Partial<TestSession> = {}): TestSession {
+  return {
+    messages: [],
+    streaming: false,
+    hasMore: false,
+    oldestLoadedId: null,
+    loadingMore: false,
+    historyStatus: "pending",
+    historyError: false,
+    ...overrides,
+  };
+}
+
+function portOf(initial: TestSession | undefined) {
+  let state = initial;
+  const port: HistorySessionPort<TestSession> = {
+    getSession: () => state,
+    updateSession: (updater) => {
+      if (state === undefined) return;
+      state = updater(state);
+    },
+  };
+  return {
+    port,
+    get state() {
+      return state;
+    },
+  };
+}
+
+function clientOf(result: () => Promise<unknown>): ApiClient {
+  return {
+    getSessionMessagesPage: vi.fn(result),
+  } as unknown as ApiClient;
+}
+
+describe("loadMoreHistory", () => {
+  it("does not fetch without a session, while loading, without hasMore, or without oldestLoadedId", async () => {
+    const client = clientOf(() => Promise.resolve({}));
+
+    loadMoreHistory(portOf(undefined).port, client, "a1", "s1");
+    loadMoreHistory(portOf(session({ loadingMore: true, hasMore: true, oldestLoadedId: 5 })).port, client, "a1", "s1");
+    loadMoreHistory(portOf(session({ hasMore: false, oldestLoadedId: 5 })).port, client, "a1", "s1");
+    loadMoreHistory(portOf(session({ hasMore: true, oldestLoadedId: null })).port, client, "a1", "s1");
+
+    expect(client.getSessionMessagesPage).not.toHaveBeenCalled();
+  });
+
+  it("fetches the page before the oldest loaded id and merges results", async () => {
+    const harness = portOf(session({
+      messages: [{ role: "assistant", content: "latest", _messageId: 10 } as ChatMessage],
+      hasMore: true,
+      oldestLoadedId: 10,
+    }));
+    const client = clientOf(() => Promise.resolve({
+      entries: [
+        { id: 5, message: { role: "user", content: "older" } },
+      ],
+      hasMore: false,
+      oldestId: 5,
+    }));
+
+    loadMoreHistory(harness.port, client, "a1", "s1");
+    expect(harness.state?.loadingMore).toBe(true);
+    await vi.waitFor(() => {
+      expect(harness.state?.loadingMore).toBe(false);
+    });
+
+    expect(client.getSessionMessagesPage).toHaveBeenCalledWith("a1", "s1", { limit: 20, before: 10 });
+    expect(harness.state?.messages.map((m) => m.content)).toEqual(["older", "latest"]);
+    expect(harness.state?.hasMore).toBe(false);
+    expect(harness.state?.oldestLoadedId).toBe(5);
+  });
+
+  it("clears loadingMore when the fetch fails", async () => {
+    const harness = portOf(session({ hasMore: true, oldestLoadedId: 10 }));
+    const client = clientOf(() => Promise.reject(new Error("boom")));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    loadMoreHistory(harness.port, client, "a1", "s1");
+    await vi.waitFor(() => {
+      expect(harness.state?.loadingMore).toBe(false);
+    });
+
+    warn.mockRestore();
+  });
+});
+
+describe("refreshSessionHistory", () => {
+  it("does not fetch without a session or while streaming", () => {
+    const client = clientOf(() => Promise.resolve({}));
+
+    refreshSessionHistory(portOf(undefined).port, client, "a1", "s1");
+    refreshSessionHistory(portOf(session({ streaming: true })).port, client, "a1", "s1");
+
+    expect(client.getSessionMessagesPage).not.toHaveBeenCalled();
+  });
+
+  it("merges the latest page and marks history ready", async () => {
+    const harness = portOf(session({
+      messages: [{ role: "assistant", content: "cached old", _messageId: 1 } as ChatMessage],
+      historyError: true,
+    }));
+    const client = clientOf(() => Promise.resolve({
+      entries: [
+        { id: 3, message: { role: "user", content: "new" } },
+        { id: 4, message: { role: "assistant", content: [{ type: "text", text: "fresh reply" }] } },
+      ],
+      hasMore: true,
+      oldestId: 9,
+    }));
+
+    refreshSessionHistory(harness.port, client, "a1", "s1");
+    await vi.waitFor(() => {
+      expect(harness.state?.historyStatus).toBe("ready");
+    });
+
+    expect(harness.state?.messages.map((m) => m.content)).toEqual([
+      "cached old",
+      "new",
+      "fresh reply",
+    ]);
+    expect(harness.state?.hasMore).toBe(true);
+    expect(harness.state?.oldestLoadedId).toBe(9);
+    expect(harness.state?.historyError).toBe(false);
+  });
+
+  it("does not clobber a session that started streaming during the fetch", async () => {
+    const harness = portOf(session());
+    let flipStreaming: (() => void) | undefined;
+    const client = clientOf(() => new Promise((resolve) => {
+      flipStreaming = () => resolve({
+        entries: [{ id: 1, message: { role: "user", content: "new" } }],
+        hasMore: false,
+        oldestId: 1,
+      });
+    }));
+
+    refreshSessionHistory(harness.port, client, "a1", "s1");
+    harness.port.updateSession((s) => ({ ...s, streaming: true }));
+    const flipped = harness.state;
+    flipStreaming?.();
+    await vi.waitFor(() => {
+      expect(harness.state?.historyStatus).toBe("pending");
+    });
+
+    expect(harness.state).toBe(flipped);
+    expect(harness.state?.messages).toEqual([]);
+  });
+});

--- a/packages/app/src/features/chat/runtime/history-actions.ts
+++ b/packages/app/src/features/chat/runtime/history-actions.ts
@@ -1,0 +1,75 @@
+import type { ApiClient } from "../../../lib/api";
+import {
+  mergeHistoryMessages,
+  parseHistoryMessages,
+} from "../model/chat-history";
+import type { ChatMessage } from "../types";
+
+export interface HistoryPaginationState {
+  messages: ChatMessage[];
+  streaming: boolean;
+  hasMore: boolean;
+  oldestLoadedId: number | null;
+  loadingMore: boolean;
+  historyStatus: "pending" | "syncing" | "ready";
+  historyError: boolean;
+}
+
+export interface HistorySessionPort<T extends HistoryPaginationState> {
+  getSession(): T | undefined;
+  updateSession(updater: (session: T) => T): void;
+}
+
+export function loadMoreHistory<T extends HistoryPaginationState>(
+  port: HistorySessionPort<T>,
+  client: ApiClient,
+  agentId: string,
+  sessionId: string,
+): void {
+  const session = port.getSession();
+  if (!session || session.loadingMore || !session.hasMore || session.oldestLoadedId === null) return;
+  port.updateSession((current) => ({ ...current, loadingMore: true }));
+  client.getSessionMessagesPage(agentId, sessionId, { limit: 20, before: session.oldestLoadedId })
+    .then((result) => {
+      const historyMessages = parseHistoryMessages(result.entries);
+      port.updateSession((current) => ({
+        ...current,
+        messages: mergeHistoryMessages(current.messages, historyMessages),
+        hasMore: result.hasMore,
+        oldestLoadedId: result.oldestId,
+        loadingMore: false,
+      }));
+    })
+    .catch((err: unknown) => {
+      console.warn("[history-actions] failed to load more history:", err);
+      port.updateSession((current) => ({ ...current, loadingMore: false }));
+    });
+}
+
+export function refreshSessionHistory<T extends HistoryPaginationState>(
+  port: HistorySessionPort<T>,
+  client: ApiClient,
+  agentId: string,
+  sessionId: string,
+): void {
+  const session = port.getSession();
+  if (!session || session.streaming) return;
+  client.getSessionMessagesPage(agentId, sessionId, { limit: 20 })
+    .then((result) => {
+      const historyMessages = parseHistoryMessages(result.entries);
+      port.updateSession((current) => {
+        if (current.streaming) return current;
+        return {
+          ...current,
+          messages: mergeHistoryMessages(current.messages, historyMessages),
+          hasMore: result.hasMore,
+          oldestLoadedId: result.oldestId,
+          historyStatus: "ready" as const,
+          historyError: false,
+        };
+      });
+    })
+    .catch((err: unknown) => {
+      console.warn("[history-actions] failed to refresh session history:", err);
+    });
+}

--- a/packages/app/src/features/chat/runtime/history-reconciler.test.ts
+++ b/packages/app/src/features/chat/runtime/history-reconciler.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "../../../lib/api";
+import type { AgentEvent } from "../model/agent-event-parse";
+import {
+  HistoryReconciler,
+  type HistoryReconcilerCallbacks,
+} from "./history-reconciler";
+import type { ChatSessionRuntimeState } from "./chat-session-runtime";
+
+interface TestSession extends ChatSessionRuntimeState {
+  pendingWithdraw: boolean;
+}
+
+function session(overrides: Partial<TestSession> = {}): TestSession {
+  return {
+    messages: [],
+    streaming: false,
+    lastActivityAt: 1,
+    scrollPosition: 0,
+    hasMore: false,
+    oldestLoadedId: null,
+    historyStatus: "pending",
+    connectionStatus: "connecting",
+    historyError: false,
+    reconnectFailed: false,
+    pendingWithdraw: false,
+    ...overrides,
+  };
+}
+
+function page(entries: object[] = []) {
+  return { entries, hasMore: false, oldestId: null };
+}
+
+function createHarness(overrides: Partial<HistoryReconcilerCallbacks<TestSession>> = {}) {
+  let current = true;
+  let state: TestSession | undefined;
+  const applied: AgentEvent[][] = [];
+  const streamingNotified: boolean[] = [];
+  const updateCount = vi.fn();
+
+  const callbacks: HistoryReconcilerCallbacks<TestSession> = {
+    isCurrent: () => current && state !== undefined,
+    getSession: () => state,
+    updateSession: (updater) => {
+      updateCount();
+      if (state === undefined) return;
+      state = updater(state);
+    },
+    applyEvents: (events) => {
+      applied.push(events);
+      if (state === undefined) return;
+      for (const event of events) {
+        if (event.type === "run_status") state = { ...state!, streaming: event.active };
+      }
+    },
+    setStreaming: (streaming) => streamingNotified.push(streaming),
+    ...overrides,
+  };
+
+  return {
+    callbacks,
+    setCurrent(next: boolean) {
+      current = next;
+    },
+    get state() {
+      return state;
+    },
+    set state(next: TestSession | undefined) {
+      state = next;
+    },
+    applied,
+    streamingNotified,
+    updateCount,
+  };
+}
+
+function createClient(result: () => Promise<unknown>): ApiClient {
+  return {
+    getSessionMessagesPage: vi.fn(result),
+  } as unknown as ApiClient;
+}
+
+describe("HistoryReconciler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("buffers events while reconciling and stops after success", async () => {
+    const harness = createHarness();
+    harness.state = session();
+    const reconciler = new HistoryReconciler<TestSession>(harness.callbacks);
+    let release: ((value: unknown) => void) | undefined;
+    const client = createClient(() => new Promise((resolve) => {
+      release = resolve;
+    }));
+
+    reconciler.onOpen();
+    expect(reconciler.shouldBuffer()).toBe(true);
+    reconciler.buffer({ type: "run_status", active: true } as AgentEvent);
+
+    const promise = reconciler.reconcile(client, "a1", "s1");
+    release?.(page());
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+
+    expect(reconciler.shouldBuffer()).toBe(false);
+    expect(harness.state?.historyStatus).toBe("ready");
+  });
+
+  it("merges history and reduces buffered events in a single update", async () => {
+    const harness = createHarness();
+    harness.state = session({ messages: [{ role: "user", content: "hi" } as never] });
+    const reconciler = new HistoryReconciler<TestSession>(harness.callbacks);
+    const client = createClient(() => Promise.resolve(page([
+      { id: 1, message: { role: "user", content: "hi", timestamp: 10 } },
+      { id: 2, message: { role: "assistant", content: [{ type: "text", text: "done" }], timestamp: 20 } },
+    ])));
+
+    reconciler.onOpen();
+    reconciler.buffer({ type: "run_status", active: false } as AgentEvent);
+    await reconciler.reconcile(client, "a1", "s1");
+
+    expect(harness.updateCount).toHaveBeenCalledTimes(1);
+    expect(harness.state?.messages.map((m) => m.content)).toEqual(["hi", "done"]);
+    expect(harness.state?.streaming).toBe(false);
+    expect(harness.state?.historyStatus).toBe("ready");
+    expect(harness.applied).toEqual([]);
+  });
+
+  it("retries with backoff before succeeding", async () => {
+    const harness = createHarness();
+    harness.state = session();
+    const reconciler = new HistoryReconciler<TestSession>(harness.callbacks);
+    let calls = 0;
+    const client = createClient(() => {
+      calls += 1;
+      if (calls === 1) return Promise.reject(new Error("boom"));
+      return Promise.resolve(page());
+    });
+
+    reconciler.onOpen();
+    const promise = reconciler.reconcile(client, "a1", "s1");
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(calls).toBe(2);
+    expect(harness.state?.historyStatus).toBe("ready");
+  });
+
+  it("marks historyError and flushes buffered events after exhausting retries", async () => {
+    const harness = createHarness();
+    harness.state = session();
+    const reconciler = new HistoryReconciler<TestSession>(harness.callbacks);
+    const client = createClient(() => Promise.reject(new Error("boom")));
+
+    reconciler.onOpen();
+    reconciler.buffer({ type: "run_status", active: false } as AgentEvent);
+    const promise = reconciler.reconcile(client, "a1", "s1");
+    await vi.advanceTimersByTimeAsync(1000 + 2000 + 5000);
+    await promise;
+
+    expect(harness.state?.historyStatus).toBe("pending");
+    expect(harness.state?.historyError).toBe(true);
+    expect(harness.applied).toEqual([[{ type: "run_status", active: false }]]);
+    expect(harness.streamingNotified).toEqual([]);
+  });
+
+  it("still notifies streaming and keeps ready status when history was ready before", async () => {
+    const harness = createHarness();
+    harness.state = session({ historyStatus: "ready" });
+    const reconciler = new HistoryReconciler<TestSession>(harness.callbacks);
+    const client = createClient(() => Promise.reject(new Error("boom")));
+
+    reconciler.onOpen();
+    const promise = reconciler.reconcile(client, "a1", "s1");
+    await vi.advanceTimersByTimeAsync(1000 + 2000 + 5000);
+    await promise;
+
+    expect(harness.state?.historyStatus).toBe("ready");
+    expect(harness.state?.historyError).toBe(false);
+    expect(harness.streamingNotified).toEqual([false]);
+  });
+
+  it("aborts without touching state when the socket was replaced", async () => {
+    const harness = createHarness();
+    harness.state = session();
+    const reconciler = new HistoryReconciler<TestSession>(harness.callbacks);
+    let release: ((value: unknown) => void) | undefined;
+    const client = createClient(() => new Promise((resolve) => {
+      release = resolve;
+    }));
+
+    reconciler.onOpen();
+    const promise = reconciler.reconcile(client, "a1", "s1");
+    harness.setCurrent(false);
+    release?.(page());
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+
+    expect(harness.updateCount).not.toHaveBeenCalled();
+    expect(harness.streamingNotified).toEqual([]);
+  });
+
+  it("flushes buffered events via applyEvents", () => {
+    const harness = createHarness();
+    harness.state = session();
+    const reconciler = new HistoryReconciler<TestSession>(harness.callbacks);
+    reconciler.onOpen();
+    const events = [{ type: "run_status", active: false } as AgentEvent];
+    reconciler.buffer(events[0]);
+
+    reconciler.flushBuffered();
+    expect(harness.applied).toEqual([events]);
+
+    reconciler.buffer(events[0]);
+    reconciler.flushBuffered();
+    expect(harness.applied).toHaveLength(2);
+  });
+
+  it("downgrades syncing historyStatus on close based on historyWasReady", () => {
+    const fresh = createHarness();
+    fresh.state = session({ historyStatus: "pending" });
+    const freshReconciler = new HistoryReconciler<TestSession>(fresh.callbacks);
+    freshReconciler.onOpen();
+    const downgraded = freshReconciler.applyClosedState(
+      session({ historyStatus: "syncing" }),
+    );
+    expect(downgraded.historyStatus).toBe("pending");
+
+    const ready = createHarness();
+    ready.state = session({ historyStatus: "ready" });
+    const readyReconciler = new HistoryReconciler<TestSession>(ready.callbacks);
+    readyReconciler.onOpen();
+    expect(
+      readyReconciler.applyClosedState(session({ historyStatus: "syncing" })).historyStatus,
+    ).toBe("ready");
+  });
+
+  it("keeps non-syncing historyStatus untouched on close", () => {
+    const harness = createHarness();
+    const reconciler = new HistoryReconciler<TestSession>(harness.callbacks);
+    const closed = session({ historyStatus: "ready" });
+    expect(reconciler.applyClosedState(closed)).toBe(closed);
+  });
+});

--- a/packages/app/src/features/chat/runtime/history-reconciler.ts
+++ b/packages/app/src/features/chat/runtime/history-reconciler.ts
@@ -1,0 +1,113 @@
+import type { ApiClient } from "../../../lib/api";
+import type { AgentEvent } from "../model/agent-event-parse";
+import {
+  mergeHistoryMessages,
+  parseHistoryMessages,
+} from "../model/chat-history";
+import { reduceSessionEvents } from "../model/chat-session-reducer";
+import type { ChatSessionRuntimeState } from "./chat-session-runtime";
+
+const RECONCILE_BACKOFFS = [1000, 2000, 5000];
+
+export interface HistoryReconcilerCallbacks<T extends ChatSessionRuntimeState> {
+  isCurrent(): boolean;
+  getSession(): T | undefined;
+  updateSession(updater: (session: T) => T): void;
+  applyEvents(events: AgentEvent[]): void;
+  setStreaming(streaming: boolean): void;
+}
+
+export class HistoryReconciler<T extends ChatSessionRuntimeState> {
+  private buffered: AgentEvent[] = [];
+  private reconciling = false;
+  private historyWasReady = false;
+
+  constructor(private readonly callbacks: HistoryReconcilerCallbacks<T>) {}
+
+  shouldBuffer(): boolean {
+    return this.reconciling;
+  }
+
+  buffer(event: AgentEvent): void {
+    this.buffered.push(event);
+  }
+
+  flushBuffered(): void {
+    if (this.buffered.length === 0) return;
+    this.callbacks.applyEvents(this.buffered.splice(0));
+  }
+
+  onOpen(): void {
+    this.historyWasReady = this.callbacks.getSession()?.historyStatus === "ready";
+    this.reconciling = true;
+  }
+
+  applyClosedState(session: T): T {
+    if (session.historyStatus !== "syncing") return session;
+    return { ...session, historyStatus: this.historyWasReady ? "ready" : "pending" };
+  }
+
+  async reconcile(
+    client: ApiClient,
+    agentId: string,
+    sessionId: string,
+  ): Promise<void> {
+    let succeeded = false;
+    try {
+      for (let attempt = 0; attempt <= RECONCILE_BACKOFFS.length; attempt++) {
+        try {
+          const result = await client.getSessionMessagesPage(
+            agentId,
+            sessionId,
+            { limit: 20 },
+          );
+          if (!this.callbacks.isCurrent()) return;
+          const historyMessages = parseHistoryMessages(result.entries);
+          this.callbacks.updateSession((session) => {
+            const reconciled = {
+              ...session,
+              messages: mergeHistoryMessages(session.messages, historyMessages),
+              hasMore: result.hasMore,
+              oldestLoadedId: result.oldestId,
+              historyStatus: "ready" as const,
+              historyError: false,
+            };
+            return {
+              ...reconciled,
+              ...reduceSessionEvents(
+                reconciled,
+                this.buffered.splice(0),
+                Date.now(),
+              ),
+            };
+          });
+          succeeded = true;
+          return;
+        } catch (err) {
+          console.warn(
+            "[history-reconciler] failed to reconcile session history:",
+            err,
+          );
+          if (!this.callbacks.isCurrent()) return;
+          if (attempt < RECONCILE_BACKOFFS.length) {
+            await new Promise((r) => setTimeout(r, RECONCILE_BACKOFFS[attempt]));
+            if (!this.callbacks.isCurrent()) return;
+            continue;
+          }
+          this.flushBuffered();
+          this.callbacks.updateSession((session) => ({
+            ...session,
+            historyStatus: this.historyWasReady ? "ready" : "pending",
+            historyError: !this.historyWasReady,
+          }));
+        }
+      }
+    } finally {
+      this.reconciling = false;
+      const session = this.callbacks.getSession();
+      if (this.callbacks.isCurrent() && session && (succeeded || this.historyWasReady)) {
+        this.callbacks.setStreaming(session.streaming);
+      }
+    }
+  }
+}

--- a/packages/app/src/features/chat/runtime/streaming-store.test.ts
+++ b/packages/app/src/features/chat/runtime/streaming-store.test.ts
@@ -699,4 +699,50 @@ describe("streaming-store resilience", () => {
       expect(() => useStreamingStore.getState().resumeProbeAll()).not.toThrow();
     });
   });
+
+  describe("applyEvents streaming notification", () => {
+    it("notifies the project store when a buffered flush flips streaming", async () => {
+      const client: ApiClient = {
+        getSessionMessagesPage: vi.fn(() => new Promise(() => {})),
+      } as unknown as ApiClient;
+      useStreamingStore.getState().attach(client, "sn1", BASE_URL, "p1", "a1");
+      const socket = mock.instances[mock.instances.length - 1];
+      socket.readyState = OPEN;
+      socket.onopen?.({} as Event);
+
+      expect(useStreamingStore.getState().sessions.sn1.streaming).toBe(false);
+      socket.onmessage?.({
+        data: JSON.stringify({ type: "run_status", active: true }),
+      } as MessageEvent);
+      socket.close();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(useStreamingStore.getState().sessions.sn1.streaming).toBe(true);
+      expect(
+        useProjectDataStore.getState().projects.p1.streamingSessionIds.has("sn1"),
+      ).toBe(true);
+    });
+
+    it("does not notify the project store when streaming is unchanged", async () => {
+      const setStreamingSpy = vi.spyOn(
+        useProjectDataStore.getState(),
+        "setStreaming",
+      );
+      const client = createMockClient();
+      useStreamingStore.getState().attach(client, "sn2", BASE_URL, "p1", "a1");
+      const socket = mock.instances[mock.instances.length - 1];
+      socket.readyState = OPEN;
+      socket.onopen?.({} as Event);
+      await vi.advanceTimersByTimeAsync(0);
+      setStreamingSpy.mockClear();
+
+      socket.onmessage?.({
+        data: JSON.stringify({ type: "message_update", message: { role: "assistant", content: [{ type: "text", text: "partial" }] } }),
+      } as MessageEvent);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(useStreamingStore.getState().sessions.sn2.streaming).toBe(false);
+      expect(setStreamingSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/app/src/features/chat/runtime/streaming-store.test.ts
+++ b/packages/app/src/features/chat/runtime/streaming-store.test.ts
@@ -723,25 +723,27 @@ describe("streaming-store resilience", () => {
       ).toBe(true);
     });
 
-    it("does not notify the project store when streaming is unchanged", async () => {
-      const setStreamingSpy = vi.spyOn(
-        useProjectDataStore.getState(),
-        "setStreaming",
-      );
-      const client = createMockClient();
+    it("does not notify the project store when a buffered flush leaves streaming unchanged", async () => {
+      const client: ApiClient = {
+        getSessionMessagesPage: vi.fn(() => new Promise(() => {})),
+      } as unknown as ApiClient;
       useStreamingStore.getState().attach(client, "sn2", BASE_URL, "p1", "a1");
       const socket = mock.instances[mock.instances.length - 1];
       socket.readyState = OPEN;
       socket.onopen?.({} as Event);
-      await vi.advanceTimersByTimeAsync(0);
-      setStreamingSpy.mockClear();
+      const setStreamingSpy = vi.spyOn(
+        useProjectDataStore.getState(),
+        "setStreaming",
+      );
 
       socket.onmessage?.({
         data: JSON.stringify({ type: "message_update", message: { role: "assistant", content: [{ type: "text", text: "partial" }] } }),
       } as MessageEvent);
+      socket.close();
       await vi.advanceTimersByTimeAsync(0);
 
       expect(useStreamingStore.getState().sessions.sn2.streaming).toBe(false);
+      expect(useStreamingStore.getState().sessions.sn2.messages).toHaveLength(1);
       expect(setStreamingSpy).not.toHaveBeenCalled();
     });
   });

--- a/packages/app/src/features/chat/runtime/streaming-store.ts
+++ b/packages/app/src/features/chat/runtime/streaming-store.ts
@@ -2,20 +2,21 @@ import { create } from "zustand";
 import type { ApiClient } from "../../../lib/api";
 import { useProjectDataStore } from "../../../stores/project-data-store";
 import type { AgentEvent } from "../model/agent-event-parse";
-import {
-  mergeHistoryMessages,
-  parseHistoryMessages,
-} from "../model/chat-history";
 import { ChatRuntimeRegistry } from "./chat-runtime-registry";
 import { ChatSessionRuntime } from "./chat-session-runtime";
 import {
+  loadMoreHistory,
+  refreshSessionHistory,
+  type HistorySessionPort,
+} from "./history-actions";
+import {
+  applySessionEvents,
   markRetrying,
-  reduceSessionEvents,
   type StreamingSessionData,
 } from "../model/chat-session-reducer";
 import { planRetry } from "../model/retry-plan";
 import { lastWithdrawableUserIndex } from "../model/withdrawable";
-import type { SendableImage, ChatMessage } from "../types";
+import type { SendableImage } from "../types";
 
 const DEFAULT_TTL_MS = 5 * 60 * 1000;
 const CLEANUP_INTERVAL_MS = 30 * 1000;
@@ -121,28 +122,13 @@ export const useStreamingStore = create<StreamingStoreState & StreamingStoreActi
     get().sendMessage(sessionId, plan.content, plan.attachment);
   }
 
-  function settlePendingWithdraw(
-    session: StreamingSession,
-    events: AgentEvent[],
-  ): StreamingSession {
-    if (!session.pendingWithdraw) return session;
-    const failed = events.some((event) => event.type === "error");
-    if (!failed && !events.some((event) => event.type === "turn_withdrawn")) return session;
-    const messages = failed ? flagWithdrawError(session.messages) : session.messages;
-    return { ...session, messages, pendingWithdraw: false };
-  }
-
-  function flagWithdrawError(messages: ChatMessage[]): ChatMessage[] {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const message = messages[i];
-      if (message.role !== "assistant") break;
-      if (message._error) {
-        const next = [...messages];
-        next[i] = { ...message, _withdrawError: true };
-        return next;
-      }
+  function applyEventsAndNotify(sessionId: string, events: AgentEvent[]) {
+    const before = get().sessions[sessionId]?.streaming;
+    updateSession(sessionId, (session) => applySessionEvents(session, events, Date.now()));
+    const after = get().sessions[sessionId];
+    if (after && after.streaming !== before) {
+      useProjectDataStore.getState().setStreaming(after.projectId, sessionId, after.streaming);
     }
-    return messages;
   }
 
   function flushQueuedEvents() {
@@ -160,9 +146,7 @@ export const useStreamingStore = create<StreamingStoreState & StreamingStoreActi
       for (const [sessionId, events] of queued) {
         const session = next[sessionId];
         if (!session) continue;
-        const reduced = reduceSessionEvents(session, events, now);
-        const merged = reduced === session ? session : { ...session, ...reduced };
-        const settled = settlePendingWithdraw(merged, events);
+        const settled = applySessionEvents(session, events, now);
         if (settled === session) continue;
         if (settled.streaming !== session.streaming) {
           streamingChanges.push({ projectId: session.projectId, sessionId, streaming: settled.streaming });
@@ -242,6 +226,13 @@ export const useStreamingStore = create<StreamingStoreState & StreamingStoreActi
     });
   }
 
+  function sessionPort(sessionId: string): HistorySessionPort<StreamingSession> {
+    return {
+      getSession: () => get().sessions[sessionId],
+      updateSession: (updater) => updateSession(sessionId, updater),
+    };
+  }
+
   function connect(client: ApiClient, sessionId: string, baseUrl: string, projectId: string, agentId: string, initialMessage: string | undefined, accessToken: string | null) {
     let runtime = runtimes.get(sessionId);
     if (!runtime) {
@@ -249,21 +240,7 @@ export const useStreamingStore = create<StreamingStoreState & StreamingStoreActi
         getSession: () => get().sessions[sessionId],
         updateSession: (updater) => updateSession(sessionId, updater),
         enqueueEvent: (event) => enqueueEvent(sessionId, event),
-        applyEvents: (events) => {
-          updateSession(sessionId, (session) => {
-            const reduced = reduceSessionEvents(session, events, Date.now());
-            const merged = reduced === session ? session : { ...session, ...reduced };
-            return settlePendingWithdraw(merged, events);
-          });
-          const session = get().sessions[sessionId];
-          if (session) {
-            useProjectDataStore.getState().setStreaming(
-              session.projectId,
-              sessionId,
-              session.streaming,
-            );
-          }
-        },
+        applyEvents: (events) => applyEventsAndNotify(sessionId, events),
         flushEvents: flushQueuedEvents,
         setStreaming: (streaming) => {
           setStreamingAndNotify(sessionId, projectId, streaming);
@@ -471,55 +448,11 @@ export const useStreamingStore = create<StreamingStoreState & StreamingStoreActi
     },
 
     loadMore(client, sessionId, agentId) {
-      const session = get().sessions[sessionId];
-      if (!session || session.loadingMore || !session.hasMore || session.oldestLoadedId === null) return;
-      updateSession(sessionId, (s) => ({ ...s, loadingMore: true }));
-      client.getSessionMessagesPage(agentId, sessionId, { limit: 20, before: session.oldestLoadedId })
-        .then((result) => {
-          const historyMessages = parseHistoryMessages(result.entries);
-          updateSession(sessionId, (s) => {
-            const messages = mergeHistoryMessages(s.messages, historyMessages);
-            return {
-              ...s,
-              messages,
-              hasMore: result.hasMore,
-              oldestLoadedId: result.oldestId,
-              loadingMore: false,
-            };
-          });
-        })
-        .catch((err: unknown) => {
-          console.warn("[streaming-store] failed to load more history:", err);
-          updateSession(sessionId, (s) => ({ ...s, loadingMore: false }));
-        });
+      loadMoreHistory(sessionPort(sessionId), client, agentId, sessionId);
     },
 
     refreshHistory(client, agentId, sessionId) {
-      const session = get().sessions[sessionId];
-      if (!session || session.streaming) return;
-      client.getSessionMessagesPage(agentId, sessionId, { limit: 20 })
-        .then((result) => {
-          const historyMessages = parseHistoryMessages(result.entries);
-          updateSession(sessionId, (s) => {
-            if (s.streaming) return s;
-            const messages = mergeHistoryMessages(s.messages, historyMessages);
-            return {
-              ...s,
-              messages,
-              hasMore: result.hasMore,
-              oldestLoadedId: result.oldestId,
-              historyStatus: "ready",
-              historyError: false,
-            };
-          });
-        })
-        .catch((err: unknown) => {
-          console.warn("[streaming-store] failed to refresh session history:", err);
-        });
+      refreshSessionHistory(sessionPort(sessionId), client, agentId, sessionId);
     },
   };
 });
-
-export { parseHistoryMessages } from "../model/chat-history";
-export { appendErrorMessage } from "../model/chat-session-reducer";
-export type { StreamingSessionData } from "../model/chat-session-reducer";


### PR DESCRIPTION
## 概要

`streaming-store.ts`（525 行）与 `chat-session-runtime.ts`（449 行）的行为保持重构，设计文档见 `docs/dev/features/2026-09-02-chat-runtime-refactor/design.md`。

- **HistoryReconciler 提取**：`connect()` 内嵌的 history-reconcile 状态机（~180 行闭包）提取为 `runtime/history-reconciler.ts`，每次连接新建实例，`connect()` 回到纯 wiring；runtime 449 → 362 行
- **事件管线去重**：reduce→merge→settle 管线下沉 `model/chat-session-reducer.ts`（`applySessionEvents` / `settlePendingWithdraw`），store 两处复制删除；store 525 → 458 行
- **history actions 提取**：`loadMore` / `refreshHistory` 移入 `runtime/history-actions.ts`，经 port 接口与状态解耦，store action 保留原名薄委托
- **probe / sendPayload 小修**：消除 probe 两段重复 timeout body；六个发送方法收窄为 `sendPayload` 委托
- **唯一有意行为变更**（设计决策 #4）：runtime `applyEvents` 回调对 project store 的通知从无条件改为仅 streaming 值变化时触发（`setStreaming` 无 guard，原路径每次触发冗余订阅通知；已核查消费方只读集合值，值等价即安全）

## 验证

- `npm run lint --workspace=packages/app`：0 error（15 warning 均为存量）
- `npm run typecheck --workspace=packages/app`：通过
- `npm test --workspace=packages/app`：1006/1006 全绿；存量 34 个 streaming-store 用例原样通过（未改断言）
- 新增：reducer 纯函数 7 例、history-reconciler 9 例、history-actions 6 例、#4 专项 2 例（buffered flush 路径正反向）
- E2E：无用户可见变更，未跑专项（合并前按惯例 verify:e2e）

## Review report

**Design review**（sub agent，反馈均已落实）：
- [important] onclose 的 historyWasReady 降级语义缺接口 → 已修：`applyClosedState` + 语义清单补条目
- [important] #4 行为变更无测试覆盖 → 已修：补 buffered flush 正反向专项 2 例
- [medium] 泛型 spread 不可赋回 T → 定案单点 `as T`；`HistoryPaginationState` 约束修正；批内单 `now` 明确
- [minor] onopen 顺序笔误 / 尾部 re-export 清理 / 日志前缀跟随 → 均落实

**Code review**（sub agent，commit 5c94519 → 0e7e4e7）：
- [important] #4 反向测试未命中被改动的 applyEvents 路径（无新旧区分力）→ **已修**：改为 never-resolving client + buffered `message_update` + onclose flush 走 `applyEventsAndNotify`
- [minor] `PendingWithdrawSession` / `SessionEventState` 零消费导出 → **已修**：取消导出
- 语义保持 8 条逐条核对全部满足；reconcile / probe / sendPayload / history 移植逐字等价；未修项：无

**未验证项**：`npm run verify:e2e` 未在本分支执行（无用户可见变更，留合并前惯例执行）