### PR TITLE
fix: 重连对账回补历史页直至覆盖已加载窗口（user 消息堆叠修复）

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -10,6 +10,7 @@
 
 ## Bug
 
+- [ ] **chat 重连对账丢 in-flight 流式回复（H1 竞态）**：reconcile fetch 落在 run 持久化窗口内（`user/message` run 前落库、`assistant/message` `message_end` 才落库）且 run 在 fetch 响应前结束（hub `runEvents` 已清空、replay 为空）时，客户端 `mergeHistoryMessages` 的 transient 过滤器丢弃未持久化的流式回复且无补回路径。方向：hub 的 `runEvents` 在 run 结束后保留短 TTL 供窗口期内重连客户端 replay。复现测试片段见 `docs/dev/investigation/2026-09-02-chat-user-messages-cluster/repro.test.snippet.ts`（未入测试套件）
 - [ ] **补齐 session/agent/project abort-and-drain 生命周期**：destroy/evict/close 当前仅删除 map entry，删除或 shutdown 后 turn、trigger 和 hub channel 仍可能执行工具或写入已关闭 store。先设计并实现 admission 关闭、preflight 取消、完整 turn/pending restore/trigger drain、hub project/agent/session quiesce、capability teardown、store close 顺序及共享 shutdown Promise；顺手收口 turn finally 清理链的单点抛错风险（如 `sanitizer.finalize` 抛错会跳过 unsubscribe/sink 恢复/释放 busy）。参见 `docs/dev/investigation/2026-08-29-session-lifecycle-concurrency/README.md`
 - [ ] **损坏项目滞留 openProjects 无移除入口**：项目打开失败（project.yaml 损坏等）后该路径一直留在 openProjects 设置里，每次启动重试失败记日志，暂无 UI 内移除 / 修复入口。参见 `docs/dev/bugfix/2026-08-27-project-open-overwrite/design.md`（#42 遗留）
 - [ ] **审批卡 abort/run 结束后 pending 态残留**：run 被中断（`rejectAll` 不发 `control_resolved`）时，`run_command` 的 pending_approval CommandCard 与 `manage_agent`/`manage_trigger` 的 pending ApprovalCard 仍保留可交互按钮，点击后静默无效（bus 对未知 requestId 忽略）。ask_user 的 QuestionCard 已在 `run_status inactive` 时由 reducer 清除（`clearPendingQuestionCards`），approval 侧应复用同款收敛（terminalize 或清除），并补 reducer 测试。

--- a/docs/dev/bugfix/2026-09-02-chat-history-page-coverage/design.md
+++ b/docs/dev/bugfix/2026-09-02-chat-history-page-coverage/design.md
@@ -1,0 +1,49 @@
+# Fix：重连对账 fetch 窗口未覆盖已加载视图时 user 消息堆叠到最近处
+
+- 日期：2026-09-02
+- 状态：已实施（design review 反馈已处理：循环内 merge 必须原子归约缓冲事件、refreshHistory 循环逐迭代重读 streaming、空页不回写分页、加页数上限、共享 helper 改为两处独立实现）
+- 调查文档：[`docs/dev/investigation/2026-09-02-chat-user-messages-cluster/README.md`](../../investigation/2026-09-02-chat-user-messages-cluster/README.md)
+- 分支：`fix/chat-history-page-coverage`，**叠在 `refactor/chat-runtime-analysis-8f3k2`（PR #81）之上**——修复直接落在重构后的 `history-reconciler.ts` / `history-actions.ts`，PR base 为重构分支，须在 #81 合并后合并
+
+## 症状与根因（摘要）
+
+对话 A,1,B,2,C + 超长 run（≥20 条消息）后重连（合盖开盖 / 移动端挂起恢复），已发送的 A/B/C 集中堆叠到最近处、对应回复消失。根因三条件：user 消息发送后永远 `_optimistic`（无 id 回显）；超长 run 占满 `limit:20` 的最新页使页内无 user 消息；`mergeHistoryMessages` 的 transient 尾部追加假设（"optimistic 比已加载内容新"）在 fetch 窗口未覆盖视图跨度时失效。
+
+## 决策
+
+| # | 决策点 | 结论 |
+|---|---|---|
+| 1 | 修复层 | **客户端保证覆盖**（fetch 窗口必须覆盖重连前已加载视图的低水位），merge 语义不动。理由：merge 的 transient 追加在"窗口覆盖视图"前提下是正确的；改 merge 保留无 id 中段需要新去重钥匙（现有仅 id 与 optimistic-content 两把），复杂度与出错面远大于补拉 |
+| 2 | 低水位定义 | 重连 reconcile 首次 merge **前**的 `session.oldestLoadedId`（上次成功对账的页首 seq）。为 null 时：视图非空（存在无 `_messageId` 的 live 内容）→ 低水位取 0（全量回补）；视图为空或全有 id → 无需回补（null 直接跳过） |
+| 3 | 回补循环 | 成功完成最新页原子 merge 后，循环 `while hasMore && oldestLoadedId > lowWater && 页数 < 上限` 逐页 `before: oldestLoadedId` 拉取更早页并 merge。**每页 merge 与首次 merge 同构：同一次 `updateSession` 内先 merge 历史再原子归约缓冲事件**（循环 await 期间新到的 WS 事件继续进缓冲，若不随页归约会静默丢失或被后续页 merge 的 transient 过滤器丢弃）。终止条件：`!hasMore` / `oldestLoadedId <= lowWater` / `isCurrent()` 失效 / 单页 fetch 失败（warn + 终止，部分覆盖优于卡死）/ 空页（**不回写分页字段**，保住 `oldestLoadedId` 防止 null 锁死全量回补）/ 页数上限 50（防止极端积压下重连风暴）。`oldestLoadedId` 严格单调递减，无死循环 |
+| 4 | 循环内失败 | 单页 fetch 失败 → warn + 终止循环；已成功的页 merge 已落 session（部分进度持久化） |
+| 5 | refreshHistory 同修 | `refreshSessionHistory` 存在同样窗口，采用同一低水位回补规则；**循环每迭代从 session 重读 `streaming`**，翻转为 true 即终止（防止主 merge 被 streaming guard 跳过后 `oldestLoadedId` 不变导致循环卡同一页） |
+| 6 | 共享 helper | **不提取**：reconciler 循环（缓冲事件原子归约 + isCurrent 终止）与 refresh 循环（streaming 终止 + plain merge）的 merge 体与终止条件不同，回调化共享得不偿失；两处独立实现同一不变量，终止规则（含空页/上限）由测试双侧覆盖。仅共享低水位计算 `resolveHistoryLowWater` 与页数上限常量（由 `history-actions.ts` 导出） |
+| 7 | 不修的部分 | `loadMore` 手动逐页路径的中途闪烁（加载覆盖到 user 消息区间前暂居末尾，覆盖后自愈）——渐进加载语义下接受，记录为已知边界；`loadMore` 与回补循环并发时靠 id 去重保证正确性（浪费少量请求，接受）；H1（run 持久化竞态丢流式回复）为独立已知问题，不在本 fix 范围 |
+
+## 实现
+
+### `runtime/history-reconciler.ts`
+
+- `reconcile` 成功路径：首次 fetch 后、merge 前捕获 `lowWater`（`resolveHistoryLowWater`：`oldestLoadedId` 非空取之；为空且视图存在无 `_messageId` 的 live 内容取 0 全量回补；否则 null 跳过）；原子 merge 不变；随后执行私有 `coverLoadedWindow` 回补循环（决策 #3，每页 merge 含缓冲事件原子归约）
+- `finally` 通知语义不变（`succeeded` 以最新页 merge 成功为准；回补循环失败不改变 succeeded）
+
+### `runtime/history-actions.ts`
+
+- 导出 `resolveHistoryLowWater` 与 `COVERAGE_MAX_PAGES`（reconciler 复用）
+- `refreshSessionHistory`：fetch 前捕获 lowWater；主 merge 后执行回补循环（逐迭代重读 streaming，决策 #5）
+- `loadMoreHistory` 不变
+
+## 测试
+
+- streaming-store.test.ts 复现用例（验收）：30+ 消息场景断言最终视图为完整交错序列 `["old question","old answer","A","1","B","2","C","m1".."m25"]`
+- history-reconciler.test.ts：多页回补循环（终止于 `oldestLoadedId <= lowWater`）+ 循环期间缓冲事件随页原子归约
+- history-actions.test.ts：`refreshSessionHistory` 回补——低水位 1 + 服务端 25 条，断言单次 refresh 后覆盖至低水位
+- 存量用例（含 reconcile / reconnect / 分页全套）必须原样通过——验证回补不破坏既有对账语义
+- 验证链：lint → typecheck → `npm test --workspace=packages/app`
+
+## 风险与边界
+
+- **重连补拉放大请求量**：极端情况下（上次对账很早、其间积压大量消息）一次重连会连续拉 N 页；每页 20 条、串行执行，量级可控且只发生在重连时
+- **中间态闪烁**：回补过程中 user 消息短暂位于末尾，页到位后归位——与现状"永久堆叠"相比是净改善
+- **H1 未修**：`repro.test.snippet.ts` 仍为 failing 场景（未纳入测试套件），hub runEvents TTL 另行立项

--- a/docs/dev/bugfix/2026-09-02-chat-history-page-coverage/design.md
+++ b/docs/dev/bugfix/2026-09-02-chat-history-page-coverage/design.md
@@ -1,7 +1,7 @@
 # Fix：重连对账 fetch 窗口未覆盖已加载视图时 user 消息堆叠到最近处
 
 - 日期：2026-09-02
-- 状态：已实施（design review 反馈已处理：循环内 merge 必须原子归约缓冲事件、refreshHistory 循环逐迭代重读 streaming、空页不回写分页、加页数上限、共享 helper 改为两处独立实现）
+- 状态：已实施（design review 反馈已处理：循环内 merge 必须原子归约缓冲事件、refreshHistory 循环逐迭代重读 streaming、空页不回写分页、加页数上限、共享 helper 改为两处独立实现；code review 反馈已处理：回补早退路径补 `flushBuffered` 防丢缓冲事件、页级 catch 纳入 parseHistoryMessages、补齐空页/页上限/streaming 翻转三组终止规则测试）
 - 调查文档：[`docs/dev/investigation/2026-09-02-chat-user-messages-cluster/README.md`](../../investigation/2026-09-02-chat-user-messages-cluster/README.md)
 - 分支：`fix/chat-history-page-coverage`，**叠在 `refactor/chat-runtime-analysis-8f3k2`（PR #81）之上**——修复直接落在重构后的 `history-reconciler.ts` / `history-actions.ts`，PR base 为重构分支，须在 #81 合并后合并
 
@@ -44,6 +44,6 @@
 
 ## 风险与边界
 
-- **重连补拉放大请求量**：极端情况下（上次对账很早、其间积压大量消息）一次重连会连续拉 N 页；每页 20 条、串行执行，量级可控且只发生在重连时
+- **回补请求放大**：除重连外，`TriggerEventBridge` 在每次 `trigger_completed` 都会触发 `refreshHistory`（同样回补）——深滚动会话在触发器频发时可能反复补拉；上限 50 页/次 + 串行执行约束了最坏情况（每页 20 条），接受
 - **中间态闪烁**：回补过程中 user 消息短暂位于末尾，页到位后归位——与现状"永久堆叠"相比是净改善
 - **H1 未修**：`repro.test.snippet.ts` 仍为 failing 场景（未纳入测试套件），hub runEvents TTL 另行立项

--- a/docs/dev/investigation/2026-09-02-chat-user-messages-cluster/README.md
+++ b/docs/dev/investigation/2026-09-02-chat-user-messages-cluster/README.md
@@ -1,0 +1,79 @@
+# 调查：多客户端场景下已发送 user message 集中出现在最近处
+
+- 日期：2026-09-02
+- 状态：**根因确认（用户 desktop 复现信息修正诊断后单测复现）**——见「最终根因」节；此前 H1（run 持久化竞态）降级为独立已知问题
+- 用户复现补充：对话序列 A,1,B,2,C + 超长 run 3（消息数 > 一页历史上限 20），client 重连后（如电脑合盖再打开）A/B,C 集中堆叠到最近处
+- 复现测试：`repro.test.snippet.ts`（run 持久化竞态机制）；最终根因的复现测试在 fix 分支的 streaming-store.test.ts 内
+- 报告症状：连接移动端（web）后在移动端连发若干条消息，这些 user message 偶尔会"集中出现在最近处"
+- 前置确认：bug 早于 2026-09-02 chat runtime 重构（PR #81）存在，重构后未回归验证；重构为行为保持型，两个候选机制在重构前后代码路径等价
+
+## 已排除的假设（附证据）
+
+| # | 假设 | 排除证据 |
+|---|---|---|
+| E1 | 服务端 event log 出现重复 `user/message` 行（高 seq 排到末尾） | events 表 `PRIMARY KEY (session_id, seq)`（session.ts:104-111），并发写同 seq 直接抛错不会插重复行；`SessionEventLog.open` 在每次 restore 校验 seq 连续性（event-log.ts:76-80），分叉会显式炸掉而非静默 |
+| E2 | fold 投影重复产出 user 消息 | `deriveHistoryEntries` 对每个 message event 投影恰好一次（fold.ts:27-37），abandoned seq 排除逻辑正确 |
+| E3 | restore/repairLog/compaction 重写历史产生重复 | `initForRestore` 只为 open turn 追加合成 tool/result + turn/end（fold.ts:109-167），不追加 user/message；compaction 走 `deriveMessageEntries`（digest 语义），且 `deriveHistoryEntries`（分页用）不受其影响 |
+| E4 | 双 AgentRunner 并发写同一 session | `SessionManager.sessions` Map 去重（session-manager.ts:53-60）；hub channel key `${projectId}:${sessionId}` 与 `getOrCreateChannel` 同步执行，无 double-restore 窗口 |
+| E5 | 持久化读过期（fetch 拿到旧数据） | better-sqlite3 同步事务，append 与 readEvents 同进程串行（session.ts:213-257） |
+| E6 | WS 广播 user 消息导致 reducer 重复插入 | `user/message` 只落 eventLog（agent-runner.ts:149-159），不经 onEvent 广播；reducer 对 user 角色 message 事件也显式忽略（assistant-only guard，chat-session-reducer.ts:81-119） |
+
+## 关键链路事实
+
+1. **另一客户端发的 user 消息没有实时到达路径**：hub 只广播 pi agent 事件（assistant 流式 + tool + run_status），`user/message` 不广播。桌面端看移动端发的消息**只能**等 reconcile（重连）或 refreshHistory。
+2. **user/message 在 run 开始前同步落库**（agent-runner.ts:149 appendBatch），**assistant/message 在 message_end 才落库**（persistMiddleware，agent-runner.ts:422-445）——两者持久化时机不对称，构成竞态窗口。
+3. **hub 对重连客户端的补发只有"当前 run 的 runEvents"**（chat-session-hub.ts:61-69），run 结束时 `runEvents = []`（chat-session-hub.ts:212-215）。**run 结束后 attach 的客户端 replay 为空，完全依赖 reconcile fetch。**
+4. 客户端 `mergeHistoryMessages` 的 transient 过滤器（chat-history.ts:54-61）：current 中无 `_messageId`、无 `_error`、非 `_optimistic` 的消息（= **所有经 WS 实时收到的 assistant 回复**）在 merge 时被**无条件丢弃**，赌 fetch 会带回它们的持久化版本。
+5. 移动端 web 特有：挂起 ≥30s / bfcage 恢复 → `web-resume-probe` 主动探测 → 死链 close → 重连 → reconcile（web-resume-probe.ts）。
+
+## 候选机制
+
+### H1（最可能）：reconcile fetch 落在 run 持久化窗口内 → 回复丢失 + user 消息堆在末尾
+
+时间线：
+
+1. 移动端连发 u1..uN（每轮 [u_i → a_i 流式 → 完成]），live 视图交错 `[.., u1, a1, .., uN, aN]`；a_i 均无 `_messageId`（实时事件路径不携带 seq）
+2. 移动端挂起（run 仍可能 in-flight，或恰在最后一条 run 的持久化边界）
+3. 恢复 → probe → close → reconnect → onopen → **reconcile fetch 立即发出**；此刻 DB 含全部 u_i（run 前落库）但缺尾部若干 a_i（message_end 未到/未落）
+4. run 结束 → hub `runEvents = []` → 重连 attach 的 replay 为空（或 replay 先于 fetch 响应到达、被 reconcile 缓冲后随 fetch 合并——若 run 结束于 fetch 响应之前，replay 缺失尾部）
+5. merge：fetch 里的 u_i（带 id）进入 merged 排序；**current 里的 live a_i 被 transient 过滤器丢弃，且 fetch 里没有它们** → 视图 = `[..., u_{N-k}, .., u_{N-1}, u_N]`——**若干条 user 消息连续堆在最近处，对应回复消失**
+6. 无后续事件可自愈，直到下一次重连/刷新——但下次通常 fetch 全量即恢复 → 与"偶尔出现"吻合
+
+症状预测：**user 消息本身不重复**（同一条只出现一次），而是**从交错位置"塌缩"到尾部 + 回复缺失**；重开会话/刷新后恢复。
+
+### H2（次可能，症状为真·重复）：optimistic 消息内容不匹配 → 同一 user 消息两份
+
+`mergeHistoryMessages` 用**内容字符串全等**（`historyUserContents`，chat-history.ts:49-57）判 optimistic 消息是否已被 fetch 带回；不匹配则 optimistic 副本作为 transient **追加在末尾**，与 merged 里带 id 的持久化副本并存 → 同一消息出现两份（原位 + 底部）。触发条件：persisted 内容与本地 optimistic 内容不同（附件消息的 strip/重建路径、或历史轮换导致 fetch 页不含该消息）。
+
+症状预测：**同一条消息出现两次**，其中一份在底部；重开会话后恢复为一份。
+
+## 最终根因（2026-09-02，用户 desktop 复现修正后确认）
+
+三个条件叠加，**完全确定性**（非竞态）：
+
+1. **发送端的 user 消息永远 `_optimistic`**：`user/message` 不经 WS 广播、无 id 回显，发送后直到下一次成功 reconcile 才获得 `_messageId`
+2. **超长 run 占满最新一页**：run 3 产出 ≥20 条消息时，reconnect reconcile 的 `limit:20` fetch 只带回 run 3 尾部（全是 assistant/toolResult），**页内不含任何 user 消息**
+3. **`mergeHistoryMessages` 的 transient 追加假设失效**：`historyUserContents` 只从**本次 fetch 的页**构建（chat-history.ts:49-53），A/B/C 内容匹配全部失败 → 作为 transients **追加到视图末尾**（该追加位置假设"optimistic 消息比已加载内容新"，在 fetch 窗口未覆盖视图时错误）；同时 1/2/m1..m5（无 id、无 error、非 optimistic）被无条件丢弃
+
+最终视图 `[old…, m6..m25, A, B, C]`，与用户报告逐字吻合。触发面：任意重连（合盖开盖 / 移动端挂起恢复）+ 发送端存在未 reconcile 的 user 消息 + 其后被 ≥20 条消息的 run 推出页外。`loadMore` 逐页加载同样途经此 merge，在覆盖到 user 消息区间前同样出现堆叠（加载到后自愈，视觉闪烁）。
+
+## 既有假设修正
+
+- 之前认定的 H1（reconcile fetch 与 run 持久化的竞态窗口）真实存在但**不是本 bug**（其复现需 fetch 恰落在 run 持久化瞬间，罕见且丢失的是流式回复而非 user 消息堆叠）。保留 `repro.test.snippet.ts`，作为独立已知问题，修法（hub runEvents TTL replay）另行评估。
+
+## 修复方向（确认后展开 design）
+
+- **A'（服务端治本，改动小）**：hub 的 `runEvents` 在 run 结束后不再立即清空，保留一个短 TTL（如 30s）供窗口期内重连的客户端 attach replay。重连客户端无论 fetch 竞态如何，都能拿到完整 run 事件流归约（replay 早于 fetch 响应 → 进 reconcile 缓冲随 fetch 原子合并；晚于 → 走正常 enqueue 归约），回复不再丢失。注意 replay 与 run_status 的语义对齐（run 已结束，replay 尾部应带 run_status false）
+- **B（客户端兜底）**：merge 的 transient 过滤器保留尾部无 id 的流式 assistant 消息。缺点：reconcile 带回带 id 完整版后无去重钥匙（现有钥匙只有 id 与 optimistic-content），会双份；不取
+- **C（契约治本，最干净但改动面大）**：广播事件携带 seq（`persistMiddleware` append 后注入再转发），客户端实时消息打 `_messageId`，merge 走 id 去重。**但 C 单独解决不了本 bug 的窗口**（fetch 响应后 run 才完成时，完整版根本不在 fetch 结果里，仍需 replay/补拉配合）
+- **E（客户端自愈兜底）**：reconcile 合并时若丢弃了 `_streaming` 尾巴，安排一次延迟 refreshHistory 补拉。契约零变更，可与 A' 组合作为防御纵深
+
+推荐 **A'（+ 复现测试转绿）**；E 可作为后续独立小增强。
+
+## 关联文件
+
+- `packages/app/src/features/chat/model/chat-history.ts:23-62`（mergeHistoryMessages）
+- `packages/app/src/features/chat/runtime/history-reconciler.ts`（reconcile 时序）
+- `packages/server/src/chat-session-hub.ts:61-69, 197-218`（replay 与 runEvents 生命周期）
+- `packages/core/src/session/agent-runner.ts:149-159, 422-445`（user/assistant 持久化时机不对称）
+- `packages/app/src/lib/web-resume-probe.ts`（移动端挂起恢复触发器）

--- a/docs/dev/investigation/2026-09-02-chat-user-messages-cluster/repro.test.snippet.ts
+++ b/docs/dev/investigation/2026-09-02-chat-user-messages-cluster/repro.test.snippet.ts
@@ -1,0 +1,40 @@
+  it("loses the in-flight reply when the run completes between fetch dispatch and response", async () => {
+    let lateResolve: ((value: unknown) => void) | undefined;
+    const client: ApiClient = {
+      getSessionMessagesPage: vi.fn()
+        .mockResolvedValueOnce({ entries: [], hasMore: false, oldestId: null })
+        .mockImplementationOnce(() => new Promise((resolve) => {
+          lateResolve = resolve;
+        })),
+    } as unknown as ApiClient;
+    useStreamingStore.getState().attach(client, "bg1", BASE_URL, "p1", "a1");
+    const socket = mock.instances[mock.instances.length - 1];
+    socket.readyState = OPEN;
+    socket.onopen?.({} as Event);
+    await vi.advanceTimersByTimeAsync(0);
+
+    useStreamingStore.getState().sendMessage("bg1", "hello");
+    socket.onmessage?.({ data: JSON.stringify({ type: "message_start", message: { role: "assistant" } }) } as MessageEvent);
+    socket.onmessage?.({ data: JSON.stringify({ type: "message_update", message: { role: "assistant", content: [{ type: "text", text: "partial answer" }] } }) } as MessageEvent);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(useStreamingStore.getState().sessions.bg1.messages).toHaveLength(2);
+
+    socket.close();
+    await vi.advanceTimersByTimeAsync(1000);
+    const reopened = mock.instances[mock.instances.length - 1];
+    reopened.readyState = OPEN;
+    reopened.onopen?.({} as Event);
+    await vi.advanceTimersByTimeAsync(0);
+
+    lateResolve?.({
+      entries: [
+        { id: 1, message: { role: "user", content: "hello", timestamp: 10 } },
+      ],
+      hasMore: false,
+      oldestId: 1,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    const messages = useStreamingStore.getState().sessions.bg1.messages;
+    expect(messages.map((m) => m.content)).toEqual(["hello", "partial answer"]);
+  });

--- a/docs/official/architecture/chat.md
+++ b/docs/official/architecture/chat.md
@@ -60,6 +60,7 @@ Composer.send
 
 - **`ChatSessionRuntime`（非响应式）**：持有 WS、心跳、重连/探活 timer 与发送动作；每次连接组合一个 `HistoryReconciler`（连接期事件缓冲 + 历史对账状态机，`history-reconciler.ts`，随 socket 生命周期新建）；经 `ChatRuntimeRegistry` 管理生命周期，transport 不进 Zustand
 - **`streaming-store`（Zustand）**：只持 UI 可观察状态与 actions；`connectionStatus`（disconnected/connecting/open）与 `historyStatus`（pending/syncing/ready）是正交维度；history 分页动作（loadMore / refreshHistory）在 `history-actions.ts`，经 port 接口（getSession / updateSession）与 session 状态解耦
+- **重连对账保证覆盖**：reconcile / refreshHistory 在最新页 merge 后，按 `before: oldestLoadedId` 逐页回补直到覆盖重连前的已加载低水位（`oldestLoadedId`），防止超长 run 把 optimistic user 消息推出页外后 `mergeHistoryMessages` 的 transient 尾部追加将其堆叠到视图末尾；终止条件：覆盖低水位 / `hasMore` 耗尽 / 单页失败 / 空页 / 50 页上限
 - **`chat-session-reducer`（纯函数）**：事件 → view state 归约，`applySessionEvents` 为归约 + withdraw 结算（`settlePendingWithdraw`）的完整管线；历史解析与稳定 ID 合并在 `chat-history.ts`，tool/card 投影在 `chat-tool-projection.ts`
 - 事件按 **animation frame 批量归约**：单次 `set()` 内 flush 整个 eventQueue，避免高频 token update 触发过多 render
 - `ChatMessage` 的 `_` 前缀字段是 view 投影：

--- a/packages/app/src/features/chat/runtime/history-actions.test.ts
+++ b/packages/app/src/features/chat/runtime/history-actions.test.ts
@@ -200,4 +200,31 @@ describe("refreshSessionHistory", () => {
     );
     expect(client.getSessionMessagesPage).toHaveBeenCalledTimes(2);
   });
+
+  it("stops the backfill when the session starts streaming mid-refresh", async () => {
+    const harness = portOf(session({
+      messages: [{ role: "user", content: "q1", _messageId: 1 } as ChatMessage],
+      hasMore: true,
+      oldestLoadedId: 5,
+      historyStatus: "ready",
+    }));
+    const fetch = vi.fn(() =>
+      Promise.resolve({
+        entries: [{ id: 9, message: { role: "user", content: "new" } }],
+        hasMore: true,
+        oldestId: 9,
+      }));
+    const client = { getSessionMessagesPage: fetch } as unknown as ApiClient;
+
+    refreshSessionHistory(harness.port, client, "a1", "s1");
+    harness.port.updateSession((s) => ({ ...s, streaming: true }));
+    await vi.waitFor(() => {
+      expect(harness.state?.oldestLoadedId).toBe(5);
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(harness.state?.oldestLoadedId).toBe(5);
+    expect(harness.state?.hasMore).toBe(true);
+  });
 });

--- a/packages/app/src/features/chat/runtime/history-actions.test.ts
+++ b/packages/app/src/features/chat/runtime/history-actions.test.ts
@@ -159,4 +159,45 @@ describe("refreshSessionHistory", () => {
     expect(harness.state).toBe(flipped);
     expect(harness.state?.messages).toEqual([]);
   });
+
+  it("backfills older pages until the loaded window covers the previous low watermark", async () => {
+    const serverEntries = Array.from({ length: 25 }, (_, i) => ({
+      id: i + 1,
+      message:
+        i % 2 === 0
+          ? { role: "user", content: `q${i + 1}` }
+          : { role: "assistant", content: [{ type: "text", text: `a${i + 1}` }] },
+    }));
+    const client: ApiClient = {
+      getSessionMessagesPage: vi.fn((_agentId: string, _sessionId: string, params: { limit?: number; before?: number }) => {
+        const eligible = serverEntries.filter((entry) => params?.before === undefined || entry.id < params.before);
+        const selected = eligible.slice(-(params?.limit ?? 20));
+        return Promise.resolve({
+          entries: selected,
+          hasMore: selected.length < eligible.length,
+          oldestId: selected[0]?.id ?? null,
+        });
+      }),
+    } as unknown as ApiClient;
+    const harness = portOf(session({
+      messages: [
+        { role: "user", content: "q1", _messageId: 1 } as ChatMessage,
+        { role: "assistant", content: "a2", _messageId: 2 } as ChatMessage,
+      ],
+      hasMore: true,
+      oldestLoadedId: 1,
+      historyStatus: "ready",
+    }));
+
+    refreshSessionHistory(harness.port, client, "a1", "s1");
+    await vi.waitFor(() => {
+      expect(harness.state?.oldestLoadedId).toBe(1);
+      expect(harness.state?.hasMore).toBe(false);
+    });
+
+    expect(harness.state?.messages.map((m) => m.content)).toEqual(
+      serverEntries.map((entry, i) => (i % 2 === 0 ? `q${i + 1}` : `a${i + 1}`)),
+    );
+    expect(client.getSessionMessagesPage).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/app/src/features/chat/runtime/history-actions.ts
+++ b/packages/app/src/features/chat/runtime/history-actions.ts
@@ -20,6 +20,16 @@ export interface HistorySessionPort<T extends HistoryPaginationState> {
   updateSession(updater: (session: T) => T): void;
 }
 
+export const COVERAGE_MAX_PAGES = 50;
+
+export function resolveHistoryLowWater(session: {
+  oldestLoadedId: number | null;
+  messages: ChatMessage[];
+}): number | null {
+  if (session.oldestLoadedId !== null) return session.oldestLoadedId;
+  return session.messages.some((message) => message._messageId === undefined) ? 0 : null;
+}
+
 export function loadMoreHistory<T extends HistoryPaginationState>(
   port: HistorySessionPort<T>,
   client: ApiClient,
@@ -54,22 +64,54 @@ export function refreshSessionHistory<T extends HistoryPaginationState>(
 ): void {
   const session = port.getSession();
   if (!session || session.streaming) return;
-  client.getSessionMessagesPage(agentId, sessionId, { limit: 20 })
-    .then((result) => {
-      const historyMessages = parseHistoryMessages(result.entries);
-      port.updateSession((current) => {
-        if (current.streaming) return current;
+  const lowWater = resolveHistoryLowWater(session);
+  void refreshWithCoverage(port, client, agentId, sessionId, lowWater);
+}
+
+async function refreshWithCoverage<T extends HistoryPaginationState>(
+  port: HistorySessionPort<T>,
+  client: ApiClient,
+  agentId: string,
+  sessionId: string,
+  lowWater: number | null,
+): Promise<void> {
+  try {
+    const result = await client.getSessionMessagesPage(agentId, sessionId, { limit: 20 });
+    const historyMessages = parseHistoryMessages(result.entries);
+    port.updateSession((current) => {
+      if (current.streaming) return current;
+      return {
+        ...current,
+        messages: mergeHistoryMessages(current.messages, historyMessages),
+        hasMore: result.hasMore,
+        oldestLoadedId: result.oldestId,
+        historyStatus: "ready" as const,
+        historyError: false,
+      };
+    });
+    if (lowWater === null) return;
+    for (let page = 0; page < COVERAGE_MAX_PAGES; page++) {
+      const current = port.getSession();
+      if (!current || current.streaming) return;
+      if (!current.hasMore || current.oldestLoadedId === null) return;
+      if (current.oldestLoadedId <= lowWater) return;
+      const olderResult = await client.getSessionMessagesPage(agentId, sessionId, {
+        limit: 20,
+        before: current.oldestLoadedId,
+      });
+      if (olderResult.entries.length === 0) return;
+      const olderMessages = parseHistoryMessages(olderResult.entries);
+      port.updateSession((session) => {
+        if (session.streaming) return session;
         return {
-          ...current,
-          messages: mergeHistoryMessages(current.messages, historyMessages),
-          hasMore: result.hasMore,
-          oldestLoadedId: result.oldestId,
-          historyStatus: "ready" as const,
-          historyError: false,
+          ...session,
+          messages: mergeHistoryMessages(session.messages, olderMessages),
+          hasMore: olderResult.hasMore,
+          oldestLoadedId: olderResult.oldestId,
         };
       });
-    })
-    .catch((err: unknown) => {
-      console.warn("[history-actions] failed to refresh session history:", err);
-    });
+    }
+  } catch (err) {
+    console.warn("[history-actions] failed to refresh session history:", err);
+  }
 }

--- a/packages/app/src/features/chat/runtime/history-reconciler.test.ts
+++ b/packages/app/src/features/chat/runtime/history-reconciler.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient } from "../../../lib/api";
 import type { AgentEvent } from "../model/agent-event-parse";
+import { applySessionEvents } from "../model/chat-session-reducer";
 import {
   HistoryReconciler,
   type HistoryReconcilerCallbacks,
@@ -50,9 +51,7 @@ function createHarness(overrides: Partial<HistoryReconcilerCallbacks<TestSession
     applyEvents: (events) => {
       applied.push(events);
       if (state === undefined) return;
-      for (const event of events) {
-        if (event.type === "run_status") state = { ...state!, streaming: event.active };
-      }
+      state = applySessionEvents(state, events, Date.now());
     },
     setStreaming: (streaming) => streamingNotified.push(streaming),
     ...overrides,
@@ -340,5 +339,70 @@ describe("HistoryReconciler", () => {
     const texts = harness.state?.messages.map((m) => m.content);
     expect(texts).toContain("live during backfill");
     expect(texts?.[texts.length - 1]).toBe("live during backfill");
+  });
+
+  it("keeps pagination untouched and still flushes buffered events when the backfill hits an empty page", async () => {
+    const harness = createHarness();
+    harness.state = session({
+      oldestLoadedId: 1,
+      hasMore: true,
+      historyStatus: "ready",
+    });
+    const reconciler = new HistoryReconciler<TestSession>(harness.callbacks);
+    let releaseOlder: ((value: unknown) => void) | undefined;
+    const client: ApiClient = {
+      getSessionMessagesPage: vi.fn((_agentId: string, _sessionId: string, params: { limit?: number; before?: number }) => {
+        if (params?.before === undefined) {
+          return Promise.resolve({
+            entries: [{ id: 3, message: { role: "user", content: "recent" } }],
+            hasMore: true,
+            oldestId: 3,
+          });
+        }
+        return new Promise((resolve) => {
+          releaseOlder = resolve;
+        });
+      }),
+    } as unknown as ApiClient;
+
+    reconciler.onOpen();
+    const promise = reconciler.reconcile(client, "a1", "s1");
+    await vi.advanceTimersByTimeAsync(0);
+    reconciler.buffer({ type: "message_update", message: { role: "assistant", content: [{ type: "text", text: "buffered before empty page" }] } } as AgentEvent);
+    releaseOlder?.({ entries: [], hasMore: true, oldestId: null });
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+
+    expect(harness.state?.oldestLoadedId).toBe(3);
+    expect(harness.state?.hasMore).toBe(true);
+    const texts = harness.state?.messages.map((m) => m.content);
+    expect(texts).toContain("buffered before empty page");
+  });
+
+  it("stops the backfill after the page cap", async () => {
+    const harness = createHarness();
+    harness.state = session({
+      oldestLoadedId: 10,
+      hasMore: true,
+      historyStatus: "ready",
+    });
+    const reconciler = new HistoryReconciler<TestSession>(harness.callbacks);
+    const fetch = vi.fn((_agentId: string, _sessionId: string, params: { limit?: number; before?: number }) =>
+      Promise.resolve({
+        entries: [
+          {
+            id: params?.before ?? 60,
+            message: { role: "user", content: "entry" },
+          },
+        ],
+        hasMore: true,
+        oldestId: params?.before ?? 60,
+      }));
+    const client = { getSessionMessagesPage: fetch } as unknown as ApiClient;
+
+    reconciler.onOpen();
+    await reconciler.reconcile(client, "a1", "s1");
+
+    expect(fetch).toHaveBeenCalledTimes(51);
   });
 });

--- a/packages/app/src/features/chat/runtime/history-reconciler.test.ts
+++ b/packages/app/src/features/chat/runtime/history-reconciler.test.ts
@@ -248,4 +248,97 @@ describe("HistoryReconciler", () => {
     const closed = session({ historyStatus: "ready" });
     expect(reconciler.applyClosedState(closed)).toBe(closed);
   });
+
+  it("backfills older pages until the loaded window covers the previous low watermark", async () => {
+    const harness = createHarness();
+    harness.state = session({
+      oldestLoadedId: 2,
+      hasMore: true,
+      historyStatus: "ready",
+    });
+    const reconciler = new HistoryReconciler<TestSession>(harness.callbacks);
+    const calls: Array<{ limit?: number; before?: number }> = [];
+    const client: ApiClient = {
+      getSessionMessagesPage: vi.fn((_agentId: string, _sessionId: string, params: { limit?: number; before?: number }) => {
+        calls.push(params);
+        if (params?.before === undefined) {
+          return Promise.resolve({
+            entries: Array.from({ length: 20 }, (_, i) => ({
+              id: 13 + i,
+              message: { role: "assistant", content: [{ type: "text", text: `m${13 + i}` }] },
+            })),
+            hasMore: true,
+            oldestId: 13,
+          });
+        }
+        return Promise.resolve({
+          entries: [
+            { id: 1, message: { role: "user", content: "old question" } },
+            { id: 2, message: { role: "assistant", content: [{ type: "text", text: "old answer" }] } },
+          ],
+          hasMore: false,
+          oldestId: 1,
+        });
+      }),
+    } as unknown as ApiClient;
+
+    reconciler.onOpen();
+    await reconciler.reconcile(client, "a1", "s1");
+
+    expect(calls).toEqual([
+      { limit: 20 },
+      { limit: 20, before: 13 },
+    ]);
+    expect(harness.state?.oldestLoadedId).toBe(1);
+    expect(harness.state?.hasMore).toBe(false);
+    expect(harness.state?.messages.map((m) => m.content)).toEqual([
+      "old question",
+      "old answer",
+      ...Array.from({ length: 20 }, (_, i) => `m${13 + i}`),
+    ]);
+  });
+
+  it("reduces events buffered during the backfill loop with the older page merge", async () => {
+    const harness = createHarness();
+    harness.state = session({
+      oldestLoadedId: 1,
+      hasMore: true,
+      historyStatus: "ready",
+    });
+    const reconciler = new HistoryReconciler<TestSession>(harness.callbacks);
+    let releaseOlder: ((value: unknown) => void) | undefined;
+    const client: ApiClient = {
+      getSessionMessagesPage: vi.fn((_agentId: string, _sessionId: string, params: { limit?: number; before?: number }) => {
+        if (params?.before === undefined) {
+          return Promise.resolve({
+            entries: Array.from({ length: 20 }, (_, i) => ({
+              id: 13 + i,
+              message: { role: "assistant", content: [{ type: "text", text: `m${13 + i}` }] },
+            })),
+            hasMore: true,
+            oldestId: 13,
+          });
+        }
+        return new Promise((resolve) => {
+          releaseOlder = resolve;
+        });
+      }),
+    } as unknown as ApiClient;
+
+    reconciler.onOpen();
+    const promise = reconciler.reconcile(client, "a1", "s1");
+    await vi.advanceTimersByTimeAsync(0);
+    reconciler.buffer({ type: "message_update", message: { role: "assistant", content: [{ type: "text", text: "live during backfill" }] } } as AgentEvent);
+    releaseOlder?.({
+      entries: [{ id: 1, message: { role: "user", content: "old question" } }],
+      hasMore: false,
+      oldestId: 1,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+
+    const texts = harness.state?.messages.map((m) => m.content);
+    expect(texts).toContain("live during backfill");
+    expect(texts?.[texts.length - 1]).toBe("live during backfill");
+  });
 });

--- a/packages/app/src/features/chat/runtime/history-reconciler.ts
+++ b/packages/app/src/features/chat/runtime/history-reconciler.ts
@@ -86,6 +86,7 @@ export class HistoryReconciler<T extends ChatSessionRuntimeState> {
             };
           });
           await this.coverLoadedWindow(client, agentId, sessionId, lowWater);
+          this.flushBuffered();
           succeeded = true;
           return;
         } catch (err) {
@@ -128,12 +129,17 @@ export class HistoryReconciler<T extends ChatSessionRuntimeState> {
       if (!this.callbacks.isCurrent() || !session) return;
       if (!session.hasMore || session.oldestLoadedId === null) return;
       if (session.oldestLoadedId <= lowWater) return;
-      let result;
+      let pendingResult: Awaited<ReturnType<ApiClient["getSessionMessagesPage"]>> | undefined;
+      let olderMessages;
       try {
-        result = await client.getSessionMessagesPage(agentId, sessionId, {
+        const result = await client.getSessionMessagesPage(agentId, sessionId, {
           limit: 20,
           before: session.oldestLoadedId,
         });
+        if (!this.callbacks.isCurrent()) return;
+        if (result.entries.length === 0) return;
+        olderMessages = parseHistoryMessages(result.entries);
+        pendingResult = result;
       } catch (err) {
         console.warn(
           "[history-reconciler] failed to cover loaded window:",
@@ -142,8 +148,7 @@ export class HistoryReconciler<T extends ChatSessionRuntimeState> {
         return;
       }
       if (!this.callbacks.isCurrent()) return;
-      if (result.entries.length === 0) return;
-      const olderMessages = parseHistoryMessages(result.entries);
+      const result = pendingResult;
       this.callbacks.updateSession((current) => {
         const merged = {
           ...current,

--- a/packages/app/src/features/chat/runtime/history-reconciler.ts
+++ b/packages/app/src/features/chat/runtime/history-reconciler.ts
@@ -6,6 +6,7 @@ import {
 } from "../model/chat-history";
 import { reduceSessionEvents } from "../model/chat-session-reducer";
 import type { ChatSessionRuntimeState } from "./chat-session-runtime";
+import { COVERAGE_MAX_PAGES, resolveHistoryLowWater } from "./history-actions";
 
 const RECONCILE_BACKOFFS = [1000, 2000, 5000];
 
@@ -62,6 +63,9 @@ export class HistoryReconciler<T extends ChatSessionRuntimeState> {
             { limit: 20 },
           );
           if (!this.callbacks.isCurrent()) return;
+          const preMergeSession = this.callbacks.getSession();
+          if (!preMergeSession) return;
+          const lowWater = resolveHistoryLowWater(preMergeSession);
           const historyMessages = parseHistoryMessages(result.entries);
           this.callbacks.updateSession((session) => {
             const reconciled = {
@@ -81,6 +85,7 @@ export class HistoryReconciler<T extends ChatSessionRuntimeState> {
               ),
             };
           });
+          await this.coverLoadedWindow(client, agentId, sessionId, lowWater);
           succeeded = true;
           return;
         } catch (err) {
@@ -108,6 +113,49 @@ export class HistoryReconciler<T extends ChatSessionRuntimeState> {
       if (this.callbacks.isCurrent() && session && (succeeded || this.historyWasReady)) {
         this.callbacks.setStreaming(session.streaming);
       }
+    }
+  }
+
+  private async coverLoadedWindow(
+    client: ApiClient,
+    agentId: string,
+    sessionId: string,
+    lowWater: number | null,
+  ): Promise<void> {
+    if (lowWater === null) return;
+    for (let page = 0; page < COVERAGE_MAX_PAGES; page++) {
+      const session = this.callbacks.getSession();
+      if (!this.callbacks.isCurrent() || !session) return;
+      if (!session.hasMore || session.oldestLoadedId === null) return;
+      if (session.oldestLoadedId <= lowWater) return;
+      let result;
+      try {
+        result = await client.getSessionMessagesPage(agentId, sessionId, {
+          limit: 20,
+          before: session.oldestLoadedId,
+        });
+      } catch (err) {
+        console.warn(
+          "[history-reconciler] failed to cover loaded window:",
+          err,
+        );
+        return;
+      }
+      if (!this.callbacks.isCurrent()) return;
+      if (result.entries.length === 0) return;
+      const olderMessages = parseHistoryMessages(result.entries);
+      this.callbacks.updateSession((current) => {
+        const merged = {
+          ...current,
+          messages: mergeHistoryMessages(current.messages, olderMessages),
+          hasMore: result.hasMore,
+          oldestLoadedId: result.oldestId,
+        };
+        return {
+          ...merged,
+          ...reduceSessionEvents(merged, this.buffered.splice(0), Date.now()),
+        };
+      });
     }
   }
 }

--- a/packages/app/src/features/chat/runtime/streaming-store.test.ts
+++ b/packages/app/src/features/chat/runtime/streaming-store.test.ts
@@ -747,4 +747,77 @@ describe("streaming-store resilience", () => {
       expect(setStreamingSpy).not.toHaveBeenCalled();
     });
   });
+
+  it("clusters already-sent user messages at the recent end when a long run overflows the history page", async () => {
+    const serverEvents: Array<{ id: number; message: unknown }> = [
+      { id: 1, message: { role: "user", content: "old question", timestamp: 1 } },
+      { id: 2, message: { role: "assistant", content: [{ type: "text", text: "old answer" }], timestamp: 2 } },
+    ];
+    const client: ApiClient = {
+      getSessionMessagesPage: vi.fn((_agentId: string, _sessionId: string, params: { limit?: number; before?: number }) => {
+        const eligible = serverEvents.filter((entry) => params?.before === undefined || entry.id < params.before);
+        const selected = eligible.slice(-(params?.limit ?? 20));
+        return Promise.resolve({
+          entries: selected,
+          hasMore: selected.length < eligible.length,
+          oldestId: selected[0]?.id ?? null,
+        });
+      }),
+    } as unknown as ApiClient;
+
+    useStreamingStore.getState().attach(client, "cov1", BASE_URL, "p1", "a1");
+    const socket = mock.instances[mock.instances.length - 1];
+    socket.readyState = OPEN;
+    socket.onopen?.({} as Event);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const sendAndReply = async (userText: string, replyText: string) => {
+      useStreamingStore.getState().sendMessage("cov1", userText);
+      await vi.advanceTimersByTimeAsync(0);
+      socket.onmessage?.({ data: JSON.stringify({ type: "message_start", message: { role: "assistant" } }) } as MessageEvent);
+      socket.onmessage?.({ data: JSON.stringify({ type: "message_update", message: { role: "assistant", content: [{ type: "text", text: replyText }] } }) } as MessageEvent);
+      socket.onmessage?.({ data: JSON.stringify({ type: "run_status", active: false }) } as MessageEvent);
+      await vi.advanceTimersByTimeAsync(0);
+    };
+    await sendAndReply("A", "1");
+    await sendAndReply("B", "2");
+    useStreamingStore.getState().sendMessage("cov1", "C");
+    await vi.advanceTimersByTimeAsync(0);
+    socket.onmessage?.({ data: JSON.stringify({ type: "message_start", message: { role: "assistant" } }) } as MessageEvent);
+    for (let i = 1; i <= 25; i++) {
+      socket.onmessage?.({ data: JSON.stringify({ type: "message_update", message: { role: "assistant", content: [{ type: "text", text: `m${i}` }] } }) } as MessageEvent);
+    }
+    await vi.advanceTimersByTimeAsync(0);
+
+    let nextId = 3;
+    serverEvents.push(
+      { id: nextId++, message: { role: "user", content: "A", timestamp: 3 } },
+      { id: nextId++, message: { role: "assistant", content: [{ type: "text", text: "1" }], timestamp: 4 } },
+      { id: nextId++, message: { role: "user", content: "B", timestamp: 5 } },
+      { id: nextId++, message: { role: "assistant", content: [{ type: "text", text: "2" }], timestamp: 6 } },
+      { id: nextId++, message: { role: "user", content: "C", timestamp: 7 } },
+    );
+    for (let i = 1; i <= 25; i++) {
+      serverEvents.push({ id: nextId++, message: { role: "assistant", content: [{ type: "text", text: `m${i}` }], timestamp: 7 + i } });
+    }
+
+    socket.close();
+    await vi.advanceTimersByTimeAsync(1000);
+    const reopened = mock.instances[mock.instances.length - 1];
+    reopened.readyState = OPEN;
+    reopened.onopen?.({} as Event);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const messages = useStreamingStore.getState().sessions.cov1.messages;
+    expect(messages.map((m) => m.content)).toEqual([
+      "old question",
+      "old answer",
+      "A",
+      "1",
+      "B",
+      "2",
+      "C",
+      ...Array.from({ length: 25 }, (_, i) => `m${i + 1}`),
+    ]);
+  });
 });


### PR DESCRIPTION
## 概要

修复：对话 A,1,B,2,C 后接超长 run（≥ 一页历史 20 条），client 重连（合盖开盖 / 移动端挂起恢复）后已发送的 user 消息集中堆叠到最近处、对应回复消失。

**根因**（调查文档：`docs/dev/investigation/2026-09-02-chat-user-messages-cluster/README.md`）：
1. user 消息发送后永远 `_optimistic`（`user/message` 不经 WS 广播、无 id 回显），直到下一次成功 reconcile 才获得 `_messageId`
2. 超长 run 占满 `limit:20` 最新页 → 页内无任何 user 消息
3. `mergeHistoryMessages` 的 transient 尾部追加假设（"optimistic 比已加载内容新"）失效 → A/B/C 堆到末尾，中间无 id 消息被丢弃

**修复**（设计：`docs/dev/bugfix/2026-09-02-chat-history-page-coverage/design.md`）：reconcile / refreshHistory 在最新页 merge 后按 `before: oldestLoadedId` 逐页回补，直到覆盖重连前已加载低水位。终止条件：覆盖低水位 / hasMore 耗尽 / 单页失败 / 空页（不回写分页）/ 50 页上限。每页 merge 与首次 merge 同构（缓冲 WS 事件原子归约），回补早退路径补 `flushBuffered` 防丢事件。

## 分支依赖

**Stacked on #81**（base 为重构分支）：修复直接落在重构后的 `history-reconciler.ts` / `history-actions.ts`，须在 #81 合并后合并。

## 验证

- 复现用例（验收）：30+ 消息长 run 场景，修复前 `[old…, m6..m25, A, B, C]`（堆叠），修复后完整交错序列 ✅
- `npm test --workspace=packages/app`：1013/1013 全绿（存量用例零修改，纯增量）
- lint 0 error / typecheck 通过

## Review report

**Design review**（sub agent，反馈均已落实）：
- [critical] 循环 merge 未处理缓冲 WS 事件（新丢事件窗口）→ 已修：每页 merge 原子归约缓冲事件
- [important] design 引用文件与 base 分支不符 → 已修：stacked on #81，design 标注分支依赖
- [medium] refreshHistory 循环须逐迭代重读 streaming 防卡页 → 已修
- [minor] 空页不回写分页 / 页数上限 / null-lowWater 全量回补评估 → 均落实

**Code review**（sub agent，commit 4484d0f → 6a1205d）：
- [important] 回补早退路径静默丢弃缓冲事件 → **已修**：成功路径补 `flushBuffered()`，空页用例锁定
- [medium] 终止规则测试未兑现 → **已修**：补空页不回写、50 页上限、refresh streaming 翻转终止三组用例
- [minor] 页级 catch 未包 parseHistoryMessages → **已修**；design 风险表述（trigger refresh 放大）→ **已修**（doc 更新）
- 服务端分页语义下无死循环/跳页（strict `<`、toolResult 超发不破坏单调性）已逐条核verify

**未验证项**：web 移动端挂起恢复全链路为单测级覆盖（未跑 E2E）；H1（run 持久化竞态丢流式回复）为独立已知问题，已记 backlog 另行立项