### PR TITLE
feat: chat 协议 v2 确认帧先行（PR-A：message_settled / intentId / events 端点）

### DIFF
--- a/docs/dev/features/2026-09-03-chat-replica-rewrite/design.md
+++ b/docs/dev/features/2026-09-03-chat-replica-rewrite/design.md
@@ -1,0 +1,186 @@
+# Chat 前端重写：日志副本模型（Log-Replica）+ 分层渲染演进
+
+- 日期：2026-09-03
+- 状态：设计稿（v2 合并稿；sub agent review 16 条已处理：resend 复合限定已落库失败对、ApprovalNoticeBridge/store 字段面/setStreaming 侧带传播补进兼容面、notices 清除补兜底、settle 所有权交接显式化、legacy 快照条目与事件 seq 命名空间隔离、ws-chat.ts 入改动清单等）
+- 来源：合并评审稿 `design/chat-replica-rewrite-q2m8`（日志副本模型，15 条 review 反馈已处理，全部继承）与渲染层演进分析两个正交轴；相对评审稿的修订以【v2】标注，未标注处为全盘采纳。本稿取代评审稿，其分支不再合并（避免同目录冲突）
+- 依赖：#81（runtime 重构）、#82（页覆盖回补 + investigation 文档与 backlog H1 条目）先行合并——本设计删除 #82 大部分产物，属预期演进；文中引用的 investigation 路径与 `coverLoadedWindow` 等符号在 #82 合并后生效
+- 前置调研：`docs/dev/investigation/2026-09-02-chat-user-messages-cluster/README.md`（#82 分支）
+
+## 背景与问题
+
+现行 chat 前端的结构性缺陷分布在两个正交的轴上：
+
+**状态轴（评审稿已诊断）**：主状态是投影（`ChatMessage[]`）而非事件知识。服务端早已 event-sourcing（`SessionEventLog` append-only + `deriveHistoryEntries` 投影），前端只能看到日志的两个有损视图——分页投影（REST）与瞬态事件（WS）——并用启发式缝合：内容全等匹配（`mergeHistoryMessages` 的 `historyUserContents`）、`_optimistic`/`_messageId` 标记、整个合并层。已修复的 user 消息堆叠与 H1 丢流式回复都是该缝合层的结构性缺陷。
+
+**渲染轴（v2 补充诊断）**：`ChatMessage` 是 closed struct，13 个 `_` 前缀 flag 内联投递/错误状态；消息内容在入口被 `extractMessageText` 压成字符串（销毁了 wire 上 part 化的结构，工具调用又靠平行事件重建）；卡片分发 hardcode 三处（reducer 内联构造 / `chat-tool-projection` / `MessageItem` if 链），新增卡片类型 = 4 处 shotgun surgery；`MessageList` 以 index 为 key 且全链无 memo，流式期间每帧全列表重渲染、每条历史消息全文重跑 react-markdown。
+
+**本质模型**：chat = 单一事实源（服务端 append-only 日志）+ 只读副本（客户端三区状态）+ 乐观写（pending intents）+ 纯投影渲染（fold → derive → registry）；「流式」是日志未落盘前缀的实时预览，「重连对账」是副本水位线追赶。渲染层更新呈双峰分布——热路径（最后一条消息的一个 text part，60fps 全量替换，无结构变化）与冷路径（结构变化，人类时间尺度）——正确的抽象应让**失效粒度对齐变化粒度**。
+
+**两阶段策略**：Phase 1 重写状态层（协议 v2 + 副本状态机），UI 冻结面收窄为 props 契约 + DOM 钩子；Phase 2（§Phase 2 路线图）把渲染层从扁平 `ChatMessage[]` 契约迁到 part 化文档 + 注册表。`ChatMessage[]` 因此是**阶段性边界而非终态契约**，Phase 1 冻结期内禁止为其新增 `_` 字段。
+
+## 决策
+
+| # | 决策点 | 结论 |
+|---|---|---|
+| 1 | 抽象 | 前端会话状态 = 三区副本 `SessionReplica = { durable, run, pending, notices }`。`durable` = 已确认事实（**原始条目** `(seq, message)` 有序集 + 窗口水位线，只做 seq 插入/删除，永不按内容合并）；`run` = 进行中 run 的瞬态块（块状态机）；`pending` = 乐观写意图（客户端 intentId，等待确认帧）；`notices` = 客户端本地注记（错误横幅 / withdraw 失败标记，跨重连存活）。渲染 = 单向派生 `render(durable) ++ render(run.blocks) ++ render(pending)`，durable 的派生**在视图层完成 run 作用域聚合**（见 #8） |
+| 2 | 协议 | WS 升级为 v2：新增**确认帧**词汇 `message_settled { seq, message, intentId? }`（覆盖 user/message、assistant/message、tool/result 三类，按 `message.role` 区分）、`turn_withdrawn` 增 `upTo`、`turn_retried { seq, abandonedSeqs }`。瞬态词汇不变，唯 `message_end` 增可选 `seq`（见 #4）。【v2】命名落定 `message_settled`（与块生命周期术语对齐，评审稿开放问题 #2 关闭） |
+| 3 | intentId | 客户端 WS `message` 帧增 `intentId`（客户端生成 ULID）→ `SendMessageMeta.intentId` → 写入 `user/message` event data（additive 可选字段，与 `source`/`triggerName` 同模式，`EVENT_SCHEMA_VERSION` 不升版）→ `deriveHistoryEntries` 投影带出 → 确认帧回显，pending 按其确认。**REST 发送（`startDetachedRun` / ui-sdk 降级路径）不建 pending**，消息经确认帧到达（跨客户端可见性天然覆盖）；REST 契约不加 intentId |
+| 4 | 确认帧发射点与顺序 | 【v2 修订，取代评审稿「瞬态先于 echo」的邻接配对】`AgentRunner.persistMiddleware` 现状即 append 先于 `next(event)`（agent-runner.ts:422-445），改造为：`appendMessageEvent` 返回带 seq 的 `SessionEvent`，瞬态 `message_end` 携带该 seq 下发（`next({ ...event, seq })`；persistMiddleware 是 pipeline 末位，capability middlewares 仍见原始 pi 事件），紧随其后发射 `message_settled`（同一 publish 链路，WS 保序）。客户端**对确认帧幂等 fold**：`message_end{seq}` 与 `message_settled{seq}` 是同一事实的两种帧型，先到者入 durable、后到者 no-op。`user/message` 在 `sendMessage` appendBatch 后、pipeline 创建前经 onEvent 直发 `message_settled`（无对应瞬态事件） |
+| 5 | withdraw / retry 确认帧 | 改造：`AgentRunner.withdrawLastTurn` 返回 `{ seq, upTo }`（现返回 user seq；`upTo` = `turn/withdrawn` 自身事件 seq，撤回区间 `[seq, upTo)` 与 fold.ts `collectAbandonedSeqs` 语义一致），`SessionManager` 透传，hub 广播 `{ type: "turn_withdrawn", seq, upTo }`。`turn_retried` 在 `retryLastTurn` appendBatch 后经 onEvent 发射。withdraw 在 run 中被拒绝（不入 `runEvents`），重连客户端经 tier ② 追赶 |
+| 6 | 断线续传（三层） | ① hub `runEvents` replay（短缺口；确认帧随 buffer 记录重放）；② `GET .../sessions/:id/events?since=&limit=`（确认帧词汇，cap 200 + hasMore 续拉），端点经 hub channel `await ready` 后读，保证 restore（含 `repairLog` 追加的修复事件）先于读取完成，消除修复事件丢失窗口；③ 分页快照（冷启动 / 大缺口）**范围替换**：只替换 `[snapshot.oldestSeq, ∞)` 区间，保留已加载的更早前缀（seq 有序插入天然支持），不破坏向上滚动的已加载历史与滚动位置。【v2 补充】快照后若存在已载前缀且 `snapshot.oldestSeq > highSeq + 1`（中间留洞），先 tier ② 补 `[highSeq+1, snapshot.oldestSeq)`，失败则丢弃前缀（诚实降级，不留隐形洞） |
+| 7 | 水位线不变量 | `durable.highSeq` 单调不减。【v2 修订】失效判定**只适用于前向来源**（live 确认帧 / tier ② / tier ③）：出现 `seq ≤ highSeq` 且 durable 中不存在的条目 → 水位线失效 → 全量快照重同步；已存在 seq 的重复帧 = 幂等 no-op。`loadMore` 反向分页条目天然 `seq < highSeq`，按设计插入水位线以下，不触发。该规则统一覆盖 legacy 会话迁移后 seq 从 0 重启（events 端点对未迁移会话返回 `410` + 原因，客户端转快照模式、highSeq 置空直到出现事件化数据）与任何异常乱序。【v2 补充】快照模式下 legacy 条目（REST 消息 id）与事件 seq 无同源关系，共享 `(seq, message)` 有序集会撞车：快照模式会话**首次收到事件化数据（live 确认帧或 tier ②）时全量丢弃快照条目**再按事件追赶，highSeq 自首个事件建立 |
+| 8 | durable 折叠 | durable 只存原始条目并按 seq 插入/删除（`turn_withdrawn` echo 删 `[seq, upTo)`，`turn_retried` echo 删 `abandonedSeqs`）——纯且平凡。**tool/result 对 assistant `_toolCalls` 的增强（toolResultMap / 卡片）与 run 边界文件变更聚合（`aggregateFileChanges`）不进 durable，移到视图派生**：对可见窗口按 run 边界分 memo 重算（复用 `chat-history.ts` 既有函数，从「页级」改为「窗口 run 级」调用） |
+| 9 | run 尾模型 | 块状态机：`RunBlock = draft \| tool(+card) \| question \| approval \| error`，生命周期 `streaming → settled(seq) \| failed \| aborted`。**复用** `chat-session-reducer` 的投影逻辑（tool 卡/control 卡/错误分类原样保留），从「平铺数组 patch」改为「run 作用域块归约」。【v2 修订】块 settle 匹配 = **seq 相等**（瞬态 `message_end{seq}` 即确认帧，块在瞬态到达时即刻 settle，settle 延迟与 echo 解耦），评审稿的「run 内按序 + role 匹配 + 内容回退」删除，开放问题 #1（依赖 pi message id）随之关闭。**settle = 所有权交接**：块 settle 即出 `run.blocks`、条目由 durable 承接渲染，`run.blocks` 只含未 settle 块，三区渲染拼接无重复。abort 保真：中止的 draft 块 settle 为 `aborted`（内容保留显示），重连后随 run 区丢弃——与现状 reconcile 行为一致，非回归；aborted partial 是否产生持久化事件以契约测试锁定现行为 |
+| 10 | notices | 瞬态 `error` 事件（无持久化对应物：conflict / model 未配置 / 纯错误气泡）与 withdraw 失败进入 `notices: { kind: "error" \| "withdrawFailed", bornAtSeq, message, code? }`，跨重连存活。【v2 修订】清除规则不依赖 runId（瞬态 error 帧现无 run 标识，加 runId 属协议蔓延）：notices 在 durable 收到 `bornAtSeq` 之后的持久化 error turn（`stopReason === "error"` 的 assistant 条目）或覆盖区间的删除帧时清除；**兜底**：同 session 后续任意 user message settle 成功即清除同类 error notice（覆盖「错误无持久化对应物、修复后滞留」的窗口）。派生视图据此渲染错误横幅并抑制对应轮 retry——`flagWithdrawError`/`_withdrawError` 语义保留，落点从消息标记改为注记 |
+| 11 | resend 语义 | `planRetry` 的 resend 变体改为 **withdraw + send 复合**，且**仅当失败对已落库**（durable 中存在该 user 轮及其 error 条目）：先 withdraw（服务端 `turn/withdrawn` 落库隐藏失败对）再发新消息；withdraw 被拒（前置校验失败）时回退纯 send——失败对保留在 durable（诚实历史），不回退今日「本地隐藏、reconcile 复活」的矛盾行为。**pending intent 失败（发送未成功、无持久化对应物，现 `_sendFailed` 场景）的重试 = 纯 send**（rebuild intent），禁止触发 withdraw——否则服务端校验通过、静默撤回上一个健康 turn。`retry-plan` 收敛时删除 `_sendFailed` 分支，该场景移交 intents 层 |
+| 12 | 兼容面（消费方逐一迁移） | `useChatSession` 公共 action 面保留（`sendMessage/retry/withdrawLastTurn/abort/reconnect/respondApproval/respondQuestion/loadMore`）；`refreshHistory` 降级为内部 `resync()`（= tier ② 拉取），**`TriggerEventBridge` 改调 resync**（attached 会话本已实时收确认帧，resync 只作兜底）；resync 失败置 `historyError`、`retryHistory` 转调 resync——`ConnectionBanner` 的 `historyError`/`onRetryHistory` props 契约不变。**`ApprovalNoticeBridge` / `collectPendingApprovals`**：审批卡现位于 run 块，需提供「全缓存会话（含未 attach、run 仍 active）派生视图」选择器供其扫描 pending 审批/提问，行为保留。**store 字段面**：绕过 hook 的裸读取（`hasMore`/`loadingMore`、`scrollPosition`、`streaming`、`messages`）在 replica-store 的 session 记录上保留等价扁平字段或选择器，PR-B 内逐一对齐而非边实现边发明契约。**`useProjectDataStore.setStreaming` 侧带传播**（现 6 处调用点）在新 store 收敛为单一传播点重接，不因选择器化而静默丢失。`ui-sdk/handlers/send-message.ts` 的 REST 降级路径不变（无 pending，见 #3）；`web-resume-probe` / `useChatScroll`（scrollPosition 留 session 记录）/ `chat/index.tsx` loadMore 不变 |
+| 13 | 协议兼容 | 不做版本握手。确认帧为新增事件类型 + additive 字段；v1 客户端 parser 对未知事件 try/catch 跳过（现行为），v2 server + v1 client = v1 行为。桌面与 web 同源发布，偏差仅缓存 PWA（告警噪音接受） |
+| 14 | 状态机纯化 | `reduce(state, frame) → state` / `plan(state, command) → frames` 均纯函数。**frame 词汇含内部生命周期帧**（`connected/disconnected/fatalClosed/replayCompleted`——现 onclose 清 `_streaming`、缓冲 gating 等传输层状态迁移全部入帧）；核心测试不再需要 MockWebSocket |
+| 15 | 作用域 | 重写 runtime/model/store 层；UI 组件层冻结面 = **props 契约 + `data-chat-*` 主题钩子**。【v2 修订】React 内部机制不在冻结面内——`MessageList` key 由 index 改为派生层提供的稳定 key（`seq` / `intentId` / 块 id），直接消灭重挂载债（折叠态/滚动锚定不再丢失），而非引用 backlog。传输层（心跳/探活/重连退避、TTL 会话缓存、attach 生命周期）与 rAF 批处理原样保留。`ChatMessage[]` 为 Phase 2 阶段性边界：冻结期内禁止新增 `_` 字段，派生辅助数据（稳定 key）走独立通道（见 §app 实现第 12 条） |
+
+## 契约
+
+### WS server → client（新增/扩展）
+
+```jsonc
+// 确认帧：已落库事实。与 message_end{seq} 幂等等效，客户端按 seq 去重
+{ "type": "message_settled", "seq": 42, "message": { /* AgentMessage */ }, "intentId": "01J…" }  // intentId 仅 user/message 携带
+{ "type": "message_end", "message": { /* … */ }, "seq": 42 }  // seq 可选；assistant/toolResult 携带其落库 seq
+{ "type": "turn_retried", "seq": 50, "abandonedSeqs": [45] }
+{ "type": "turn_withdrawn", "seq": 40, "upTo": 44 }  // upTo = turn_withdrawn 自身 seq，撤回区间 [seq, upTo)
+```
+
+### WS client → server（扩展）
+
+```jsonc
+{ "type": "message", "content": "…", "attachments": [], "intentId": "01J…" }  // intentId 可选（ULID）
+```
+
+### REST（新增）
+
+```
+GET /api/projects/:projectId/agents/:agentId/sessions/:id/events?since=<seq>&limit=200
+→ 200 { events: Array<message_settled | turn_withdrawn | turn_retried>, hasMore: boolean }
+     （确认帧词汇同 WS；经 hub channel await ready 后从 log 投影，跳过非消息/非 turn 标记事件）
+→ 410 { reason: "legacy-unmigrated" }（未迁移会话；客户端转快照模式）
+```
+
+## 各层实现
+
+### contracts
+
+1. `websocket.ts`：`chatServerEvent` union 增 `message_settled` / `turn_retried`，`turn_withdrawn` 增可选 `upTo`，`message_end` 增可选 `seq`；`chatClientMessage` message 增可选 `intentId`。payload 保持 `Type.Unsafe`（server 透明转发原则不变）
+2. `sessions.ts`：`sessionEventsResponse`（含 410 语义）
+
+### core
+
+3. `session/events.ts`：`SendMessageMeta` 与 `user/message` data 增 `intentId?: string`
+4. `session/agent-runner.ts`：`appendMessageEvent` 返回带 seq 的 `SessionEvent`；`persistMiddleware`（pipeline 末位）对 assistant/toolResult 的 `message_end` 以 `next({ ...event, seq })` 下发、随后经 onEvent 发 `message_settled`；`sendMessage` 在 appendBatch 后、pipeline 创建前经 onEvent 直发 user `message_settled`；`withdrawLastTurn` 返回 `{ seq, upTo }`；`retryLastTurn` appendBatch 后经 onEvent 发 `turn_retried`
+5. `session/fold.ts`：`projectMessageEvent` 带出 `intentId`（`DerivedMessageEntry` 增可选字段）
+6. `session-manager.ts`：withdraw 返回值透传
+7. `project-manager.ts`：`getSessionEventsSince(agentId, sessionId, since, limit)`（未迁移 → 显式标记供 route 返回 410）
+
+### server
+
+8. `chat-session-hub.ts`：withdraw 广播带 `upTo`；提供 `readEventsSince`（经 channel await ready / 必要时触发 restore 后读）；`ChatSessionAttachment.sendMessage` 签名增 intentId 透传
+9. `ws-chat.ts`：客户端 `message` 帧 `intentId` 校验与透传；出站帧经升级后的 `parseChatServerEvent` 校验（contracts 先行是硬前置）
+10. `routes/sessions.ts`：events 端点（契约绑定 + 410）
+
+### app（重写层）
+
+```
+features/chat/
+  replica/
+    session-replica.ts   # 纯状态机：reduce(state, frame) / plan(state, command)
+    durable.ts           # (seq, message) 有序集 + 水位线不变量（#7）
+    derive.ts            # 视图派生：run 边界 tool 增强 + 文件聚合 + notices 合成 + 稳定 key
+    run-tail.ts          # run 块归约（自 chat-session-reducer 改造）
+    intents.ts           # pending 三态（sending/failed/acked）
+    notices.ts           # 本地注记
+    sync.ts              # 三层追赶编排（successor of history-reconciler）
+  runtime/
+    chat-session-runtime.ts  # 纯传输壳（协议 v2；生命周期发内部帧）
+    chat-runtime-registry.ts
+  replica-store.ts       # 薄 store：sessions + 生命周期 + 选择器（useChatSession 面兼容）；rAF 批处理保留
+  model/                 # 保留：chat-history（解析函数复用进 derive）、chat-tool-projection、classify-error、
+                         #       turn-groups、approval-notice、retry-plan（resend 改复合后收敛）、withdrawable
+                         # 删除：mergeHistoryMessages、settlePendingWithdraw、#82 回补循环
+```
+
+11. 初始消息：attach 前的 initialMessage = 排队 pending intent；`takeInitialMessage`/`initialMessageSent` 消失
+12. derive 输出：keyed 条目 `Array<{ key: string; message: ChatMessage }>`（key = `seq:` / `intent:` / `block:` 前缀 + id），`MessageList` 与 `TriggerTurnGroup` 分组 key（现 `message._messageId ?? index`）统一改吃该 key 通道。选择器面：`messages: ChatMessage[]`（keyed 投影，`useChatScroll` 等旧消费方不变）与 keyed 选择器并行；key 通道独立于 `ChatMessage` 结构体，Phase 2 迁移时原样沿用
+13. 命令：`sendMessage` → intentId → pending + WS 帧；失败/超时/error → intent failed（SendFailedBar 无感）；`withdraw`/`retry`（含 #11 复合）/`abort`/`respond*` → plan 产出帧
+14. 选择器：`messages` = derive 三区拼接；`streaming` = run.active ∥ pending.sending；`connectionStatus` 不变
+
+## Phase 2 路线图：渲染层 part 化（独立 PR，实施另立 design）
+
+动机：Phase 1 修复状态轴后，渲染轴四债仍在（closed struct、三处 hardcode 分发、无 memo、全文重 parse），且 `derive.ts` 的建立恰好为渲染层迁移提供了单一接缝。
+
+1. **文档模型**：derive 输出从 `ChatMessage[]` 迁至 part 化 `ChatDoc`：`Turn { id, delivery?, messages } → Message { id, role, parts } → Part`；`Part = text { rev } | tool { rev, toolName, args, status, card? }`，id = `seq` / `toolCallId`，`rev` 随更新自增。wire 上 `AssistantMessage.content` 本就是 part 数组，Phase 1 的 durable 原始条目天然保留该结构——Phase 2 只是不再在派生时销毁它
+2. **渲染注册表**：`ToolProjection { match(toolName), project(事件/结果) → card?, Component }` 单点注册，取代三处 hardcode；新增卡片类型 = 一个注册项
+3. **失效粒度对齐双峰分布**：`MessageItem` memo + 稳定 key + part 级引用复用（derive 对未变部分返回原引用），流式期间每帧失效集合 ⊆ {最后一条消息的最后一个 text part}；该性能不变量写进测试
+4. **流式 markdown 增量解析**：完成前缀按 `\n\n` 边界切 stable block（按内容相等 memo）+ 尾部 live block，仅 live block 每帧重 parse
+5. **envelope**：`delivery ∈ pending | failed | sent | withdrawn` 由 pending/notices 区投影，取代 `_optimistic/_sendFailed/_error` 系 flag 的取证式推断
+
+Phase 1 为其预留的接缝：derive 单一出口、稳定 key 通道、`ChatMessage[]` 冻结不加字段、durable 保留原始 part 结构。
+
+## 删除清单（收益对账）
+
+| 删除 | 理由 |
+|---|---|
+| `mergeHistoryMessages` + 内容全等匹配 | seq + intentId 取代 |
+| #82 页覆盖回补循环（`coverLoadedWindow` / `refreshWithCoverage`） | durable 按 seq 更新，无覆盖假设 |
+| `settlePendingWithdraw` / `flagWithdrawError` / `pendingWithdraw` | `turn_withdrawn {seq, upTo}` 原子处理；失败语义移 notices |
+| `_optimistic` 悬挂与 reconcile 赌约 | pending 三态 |
+| echo↔块内容回退匹配（评审稿 #9）【v2】 | seq 相等精确匹配 |
+| H1 已知问题（backlog 条目） | 确认帧 + tier ② 结构性消灭丢回复窗口 |
+| `historyStatus` 双态大部分语义 | sync 编排内化，对外仅 loading |
+| MessageList index key 重挂载（backlog 条目）【v2】 | 稳定 key（seq）落地 |
+
+保留：传输 runtime 全套、TTL 会话缓存、attach 生命周期、UI 组件层与主题钩子（props/DOM 契约）、model/ 纯函数多数、rAF 批处理。
+
+## 测试
+
+- **replica 状态机（核心，纯函数帧序列）**：确认帧幂等（`message_end{seq}` 与 `message_settled{seq}` 任意顺序/重复到达）、intent 确认与失败、**pending 失败重试 = 纯 send 不触发 withdraw**（#11 回归防护）、withdraw/retry 区间删除、块生命周期（draft / tool 卡 / control 卡 / aborted 保真）、**settle 所有权交接**（块出 run 区、durable 承接，无重复渲染）、水位线违反（前向来源）→ 全量重同步、`loadMore` 反向插入不触发、**legacy 快照条目首次事件化数据到达时全量丢弃**、notices 生存期与清除（含 user settle 成功兜底）、内部生命周期帧、replayCompleted gating
+- **settle 穿越不变量【v2】**：同一帧序列下，run 块渲染输出 ≡ durable 派生渲染输出（golden test，tool 卡/control 卡/文件聚合在两条路径上的字段逐一相等——防双路径漂移）
+- core：确认帧发射顺序（瞬态 `message_end{seq}` → `message_settled`，user 在 pipeline 前）、intentId 落库与 `deriveHistoryEntries` 带出、withdraw `{seq, upTo}` 区间语义、aborted partial 持久化行为锁定——**PM 门面契约测试（红线：server/desktop 各至少一条不 mock 被测方法）**
+- server：确认帧广播至全体订阅者（含 detachedRun）、runEvents replay 含确认帧、events 端点契约（since 边界 / cap / hasMore / 410 legacy / channel-ready 后含 repairLog 事件）
+- app：sync 三层选择与降级（含 #6 洞边界）；既有行为套件（withdraw / retry 两变体 / reconnect / resume-probe / probe 超时）以帧序列重表达；#82 的 A/B/C 堆叠场景与 H1 场景转回归用例；**`collectPendingApprovals` 经「全缓存会话派生视图」选择器的行为保留测试**（后台 session 审批 toast）
+- UI 组件层零改动 → 现有组件测试原样通过作为兼容性证明（key 变更除外，key 不属行为契约）
+
+## 风险与边界
+
+- **run 块与 durable 派生双路径漂移**：靠函数复用（chat-history 解析函数两路共用）+ settle 穿越 golden test 锁定
+- **compaction 断线窗口**【v2 新识别】：断线期间发生 compaction 时客户端旧条目滞留（现 REST 历史 `deriveHistoryEntries` 同样不体现 digest，非回归）；「compacted 帧进 tier ② 词汇」列 backlog
+- **单帧体积**：`message_settled` 携带完整 message，与现 `message_end` 相同，无放大；`message_update` 快照语义不变
+- **帧序依赖**：WS 有序保证内 seq 配对无歧义；跨连接由 tier ② 兜底
+- **legacy 会话首启**：410 → 快照模式，水位线空置直至事件化数据出现；迁移后 seq 重启由 #7 不变量兜底
+- **旧 PWA 告警噪音**：接受（同源发布，窗口短）
+- **重写量**：run-tail 自 chat-session-reducer 平移而非重设计，现有套件为行为规格
+
+## 开放问题
+
+1. ~~pi `AgentMessage` 是否有稳定 id~~【v2 关闭】：瞬态 `message_end` 携带 seq，配对精确化，不再依赖 pi id
+2. ~~`message_persisted` vs `message_settled` 命名~~【v2 落定】：`message_settled`
+3. events cap 200 是否足够：超长 run 多轮续拉已有 hasMore 兜底；实现时按实测调整首拉 cap
+4. Phase 2 立项时点：PR-B 合并后按渲染债优先级排期（本文 §Phase 2 为路线图，实施另立 design）
+
+## E2E
+
+影响 chat 全链路：`chat-streaming-resilience` / `chat-withdraw` / `chat-retry` / `floating-chat` 全量 + 新增「多客户端确认帧可见性」（桌面实时见移动端 user 消息）。合并前 `npm run verify:e2e`。
+
+## PR 拆分【v2 修订：单 PR 全量重写 → 三 PR 序列】
+
+1. **PR-A 协议先行**（contracts + core + server）：确认帧词汇、intentId、events 端点、hub 广播。dark launch——v1 客户端忽略新帧 = v1 行为，现有 e2e 套件全量跑作为不回归证明；PM 门面契约测试在此 PR 落地
+2. **PR-B app 副本切换**（replica 状态机 + store 重写 + merge 层删除 + 稳定 key）：消费方逐项迁移（#12 兼容面），#82 回归场景转帧序列用例
+3. **PR-C 渲染层**（Phase 2，另立 design）：part 化 derive 输出 + 注册表 + memo + 流式 markdown 增量
+
+每步独立可验证、可独立回滚；PR-A 合并后即使 PR-B 延迟，协议侧无半成品状态。
+
+## 文档同步（doc-sync 清单）
+
+- `docs/official/architecture/chat.md`：Renderer 节重写为三区副本模型 + 确认帧协议 + 三层追赶
+- `docs/official/project-structure.md`：replica/ 目录与删除文件
+- `docs/official/data-conventions.md`：`user/message` event data 增 `intentId`（additive 不升版）
+- `docs/dev/backlog.md`：删除 H1 条目（结构性消灭）与 MessageList key 条目（稳定 key 落地）；新增「compacted 帧进 tier ② 词汇」
+- theme skills 豁免核实（DOM 钩子不变）

--- a/docs/official/architecture/chat.md
+++ b/docs/official/architecture/chat.md
@@ -26,10 +26,12 @@ Composer.send
 
 ## Wire 协议（`contracts/websocket.ts`）
 
-- **client → server**：`message`（content + attachments 路径引用）、`abort`、`ping`、`retry`、`withdraw`、`resolve_control_request`（kind approval：approved / reason；kind question：answer）
+- **client → server**：`message`（content + attachments 路径引用 + 可选 `intentId` ULID，用于乐观写确认回执）、`abort`、`ping`、`retry`、`withdraw`、`resolve_control_request`（kind approval：approved / reason；kind question：answer）
 - **server → client**：
-  - pi 生命周期族：`agent_start` / `agent_end` / `turn_start` / `turn_end` / `message_start` / `message_update` / `message_end` / `tool_execution_start` / `tool_execution_update` / `tool_execution_end`
-  - session 级：`run_status`（active）、`control_request` / `control_resolved`、`turn_withdrawn`（seq）、`error`（message + code）、`pong`
+  - pi 生命周期族：`agent_start` / `agent_end` / `turn_start` / `turn_end` / `message_start` / `message_update` / `message_end`（可选 `seq`：assistant/toolResult 携带其落库 seq，与瞬态事件同帧序下发）/ `tool_execution_start` / `tool_execution_update` / `tool_execution_end`
+  - **确认帧族**（已落库事实，客户端按 seq 幂等 fold；`message_end{seq}` 与 `message_settled{seq}` 等效）：`message_settled`（seq + message + 可选 intentId）、`turn_withdrawn`（seq + upTo，撤回区间 `[seq, upTo)`）、`turn_retried`（seq + abandonedSeqs）
+  - session 级：`run_status`（active）、`control_request` / `control_resolved`、`error`（message + code）、`pong`
+  - v1 客户端对未知帧 parser 抛错、由 runtime try/catch 跳过——新增帧类型无需版本握手
 - **error code**（`classify-run-error.ts`）：`MODEL_NOT_CONFIGURED`、`AUTH_ERROR`、`PERMANENT`、`TRANSIENT`。规则：
   - 401/403 → AUTH；429/5xx/网络错误 → TRANSIENT
   - 其余 4xx 及 `ConflictError` / `ValidationError` → PERMANENT
@@ -46,15 +48,16 @@ Composer.send
 - **HTTP 静默发送**：`POST .../sessions/:id/messages`，目标会话未 attach WS 时 UI SDK 走此路径（`open:false` 只控制不跳转导航）：
   - `startDetachedRun` 只递增 attachment 计数保持 channel 存活、不注册订阅者——调用方只拿 `{ok:true}`，run 失败经 error 事件到达 WS 订阅者
   - 与 WS 共享 run 序列化（running 时 409）
+- **事件增量端点**：`GET .../sessions/:id/events?since=&limit=`（cap 200 + hasMore 续拉）——hub channel `await ready`（restore 含 repairLog 修复）后从 log 投影确认帧词汇；未迁移 legacy 会话预检即拒（`MigrationRequiredError` → 410 `{reason: "legacy-unmigrated"}`），不触发迁移
 
 ## Core：一次 sendMessage（`agent-runner.ts`）
 
 1. guard 链：`ensureNotBusy`（in-flight 抛 ValidationError）→ 消费 pendingReload → `ensureModel` → `ensureWritable` → beforeTurn hook → 组装附件消息。所有权在 `ensureNotBusy` 通过时同步取得，覆盖至 afterTurn 结束；preflight 任一阶段抛错都会释放，不会写入 phantom turn 或卡死 busy 状态
 2. **先持久化**：`appendBatch([user/message, turn/start])` 成功后才 `agent.prompt`
 3. 事件经 EventPipeline（log → capability middlewares → 附件 sanitizer → persistMiddleware）流向 hub；control 事件旁路——`controlBus.swapEventSink` 直达 sink 不过中间件
-4. 落库映射：`message_end` → `assistant/message` / `tool/result`；`agent_end` → `turn/end`（reason 取自最后 assistant 的 stopReason）
-5. `retryLastTurn`：要求末条为失败 assistant；追加 `turn/retried`（abandonedSeqs）+ `turn/start`，`agent.continue()`
-6. `withdrawLastTurn`：定位最后 `user/message`，已被 abandoned/compaction 覆盖则拒绝；追加 `turn/withdrawn`
+4. 落库映射：`message_end` → `assistant/message` / `tool/result`；`agent_end` → `turn/end`（reason 取自最后 assistant 的 stopReason）。**确认帧发射**：assistant/toolResult 的瞬态 `message_end` 携带落库 seq 下发，紧随其后经 onEvent 发 `message_settled`（同一 publish 链路，WS 保序）；`user/message` 在 appendBatch 后、pipeline 创建前直发 `message_settled`（含 `intentId` 回执）
+5. `retryLastTurn`：要求末条为失败 assistant；追加 `turn/retried`（abandonedSeqs）+ `turn/start` 后经 onEvent 发 `turn_retried` 确认帧，再 `agent.continue()`
+6. `withdrawLastTurn`：定位最后 `user/message`，已被 abandoned/compaction 覆盖则拒绝；追加 `turn/withdrawn` 并返回 `{ seq, upTo }`（撤回区间 `[seq, upTo)`），hub 据此广播
 
 ## Renderer：runtime / store / reducer 三层
 

--- a/docs/official/data-conventions.md
+++ b/docs/official/data-conventions.md
@@ -151,7 +151,7 @@ frontmatter 字段：
   - `title` 是可选用户可编辑标题——重命名只更新 title 不动 `updated_at`，列表按 `updated_at DESC, id DESC` 排序，保持「最近活动」语义
 - `events` 表（append-only，主键 `(session_id, seq)`）：信封为 `{ type, seq, time, data, schema_version }`。当前事件词汇表：
   - `turn/start`、`turn/end`（reason: completed / aborted / error）
-  - `user/message`（data 可选 `source: "triggered"` + `triggerName`，trigger 发送标记；absent = 手动发送）、`assistant/message`、`tool/result`
+  - `user/message`（data 可选 `source: "triggered"` + `triggerName`，trigger 发送标记，absent = 手动发送；可选 `intentId`，客户端乐观写回执标记，经确认帧回显）、`assistant/message`、`tool/result`
   - `compaction/applied`（anchorSeq、digestContent、digestSource、excludedSeqs）
   - `turn/retried`（abandonedSeqs）、`turn/withdrawn`（seq）
 

--- a/packages/app/src/features/chat/model/agent-event-parse.ts
+++ b/packages/app/src/features/chat/model/agent-event-parse.ts
@@ -170,6 +170,8 @@ export function parseAgentEvent(event: ChatServerEvent): AgentEvent {
       return { type: "message_update", message: parseAgentMessage(event.message) };
     case "message_end":
       return { type: "message_end", message: parseAgentMessage(event.message) };
+    default:
+      throw new Error(`unsupported chat server event: ${(event as { type: string }).type}`);
   }
 }
 

--- a/packages/contracts/src/__tests__/chat-websocket-contracts.test.ts
+++ b/packages/contracts/src/__tests__/chat-websocket-contracts.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   parseChatClientMessage,
   parseChatServerEvent,
+  parseContract,
+  schemas,
 } from "../index.js";
 
 describe("chat websocket control contract", () => {
@@ -210,5 +212,99 @@ describe("chat websocket control contract", () => {
     expect(() =>
       parseChatServerEvent({ type: "turn_withdrawn", seq: "3" }),
     ).toThrow(/Invalid payload/);
+  });
+
+  it("accepts turn_withdrawn with optional upTo", () => {
+    const event = { type: "turn_withdrawn", seq: 3, upTo: 6 };
+    expect(parseChatServerEvent(event)).toEqual(event);
+    expect(parseChatServerEvent({ type: "turn_withdrawn", seq: 3 })).toEqual({
+      type: "turn_withdrawn",
+      seq: 3,
+    });
+  });
+
+  it("accepts message_settled with and without intentId", () => {
+    const withIntent = {
+      type: "message_settled",
+      seq: 42,
+      message: { role: "user", content: "hi" },
+      intentId: "01JTEST",
+    };
+    expect(parseChatServerEvent(withIntent)).toEqual(withIntent);
+    const withoutIntent = {
+      type: "message_settled",
+      seq: 43,
+      message: { role: "assistant", content: [] },
+    };
+    expect(parseChatServerEvent(withoutIntent)).toEqual(withoutIntent);
+  });
+
+  it("rejects message_settled without seq or message", () => {
+    expect(() =>
+      parseChatServerEvent({ type: "message_settled", message: { role: "user", content: "hi" } }),
+    ).toThrow(/Invalid payload/);
+    expect(() => parseChatServerEvent({ type: "message_settled", seq: 42 })).toThrow(
+      /Invalid payload/,
+    );
+    expect(() => parseChatServerEvent({ type: "message_settled", seq: "42", message: {} })).toThrow(
+      /Invalid payload/,
+    );
+  });
+
+  it("accepts message_end with optional seq", () => {
+    const event = {
+      type: "message_end",
+      message: { role: "assistant", content: [] },
+      seq: 42,
+    };
+    expect(parseChatServerEvent(event)).toEqual(event);
+    expect(
+      parseChatServerEvent({ type: "message_end", message: { role: "assistant", content: [] } }),
+    ).toEqual({ type: "message_end", message: { role: "assistant", content: [] } });
+    expect(() => parseChatServerEvent({ type: "message_end", message: {}, seq: "42" })).toThrow(
+      /Invalid payload/,
+    );
+  });
+
+  it("accepts turn_retried and rejects malformed variants", () => {
+    const event = { type: "turn_retried", seq: 50, abandonedSeqs: [45, 46] };
+    expect(parseChatServerEvent(event)).toEqual(event);
+    expect(() => parseChatServerEvent({ type: "turn_retried", seq: 50 })).toThrow(
+      /Invalid payload/,
+    );
+    expect(() =>
+      parseChatServerEvent({ type: "turn_retried", seq: 50, abandonedSeqs: [true] }),
+    ).toThrow(/Invalid payload/);
+  });
+
+  it("accepts client message with optional intentId and rejects malformed intentId", () => {
+    expect(
+      parseChatClientMessage({ type: "message", content: "hi", intentId: "01JWS" }),
+    ).toEqual({ type: "message", content: "hi", intentId: "01JWS" });
+    expect(parseChatClientMessage({ type: "message", content: "hi" })).toEqual({
+      type: "message",
+      content: "hi",
+    });
+    expect(() =>
+      parseChatClientMessage({ type: "message", content: "hi", intentId: 42 }),
+    ).toThrow(/Invalid payload/);
+  });
+
+  it("settledFrame schema accepts the three frame kinds and rejects others", () => {
+    const { settledFrame } = schemas;
+    expect(
+      parseContract(settledFrame, { type: "message_settled", seq: 1, message: {} }),
+    ).toEqual({ type: "message_settled", seq: 1, message: {} });
+    expect(parseContract(settledFrame, { type: "turn_withdrawn", seq: 1, upTo: 3 })).toEqual({
+      type: "turn_withdrawn",
+      seq: 1,
+      upTo: 3,
+    });
+    expect(parseContract(settledFrame, { type: "turn_retried", seq: 5, abandonedSeqs: [] })).toEqual(
+      { type: "turn_retried", seq: 5, abandonedSeqs: [] },
+    );
+    expect(() => parseContract(settledFrame, { type: "message_end", seq: 1 })).toThrow(
+      /Invalid payload/,
+    );
   });
 });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -56,6 +56,7 @@ export type {
   SessionRenameRequest,
   SessionMessagesResponse,
   SessionMessagesPageResponse,
+  SessionEventsResponse,
   SessionStatusResponse,
 } from "./sessions.js";
 

--- a/packages/contracts/src/sessions.ts
+++ b/packages/contracts/src/sessions.ts
@@ -1,4 +1,5 @@
 import { Type, type Static } from "@sinclair/typebox";
+import { settledFrame } from "./websocket.js";
 
 const sessionInfo = Type.Object({
   id: Type.String(),
@@ -48,6 +49,10 @@ export const schemas = {
     hasMore: Type.Boolean(),
     oldestId: Type.Union([Type.Number(), Type.Null()]),
   }),
+  sessionEventsResponse: Type.Object({
+    events: Type.Array(settledFrame),
+    hasMore: Type.Boolean(),
+  }),
   sessionStatus: Type.Object({
     currentTokens: Type.Number(),
     contextWindowLimit: Type.Union([Type.Number(), Type.Null()]),
@@ -65,4 +70,5 @@ export type SendMessageRequest = Static<typeof schemas.sendMessageRequest>;
 export type SendMessageOkResponse = Static<typeof schemas.sendMessageOkResponse>;
 export type SessionMessagesResponse = Static<typeof schemas.sessionMessagesResponse>;
 export type SessionMessagesPageResponse = Static<typeof schemas.sessionMessagesPageResponse>;
+export type SessionEventsResponse = Static<typeof schemas.sessionEventsResponse>;
 export type SessionStatusResponse = Static<typeof schemas.sessionStatus>;

--- a/packages/contracts/src/websocket.ts
+++ b/packages/contracts/src/websocket.ts
@@ -41,6 +41,31 @@ const toolResultMessages = Type.Unsafe<ToolResultMessage[]>(
 );
 const toolArgs = Type.Unsafe<Record<string, unknown>>(Type.Unknown());
 
+const messageSettledFrame = Type.Object({
+  type: Type.Literal("message_settled"),
+  seq: Type.Integer(),
+  message: agentMessage,
+  intentId: Type.Optional(Type.String()),
+});
+
+const turnWithdrawnFrame = Type.Object({
+  type: Type.Literal("turn_withdrawn"),
+  seq: Type.Integer(),
+  upTo: Type.Optional(Type.Integer()),
+});
+
+const turnRetriedFrame = Type.Object({
+  type: Type.Literal("turn_retried"),
+  seq: Type.Integer(),
+  abandonedSeqs: Type.Array(Type.Integer()),
+});
+
+export const settledFrame = Type.Union([
+  messageSettledFrame,
+  turnWithdrawnFrame,
+  turnRetriedFrame,
+]);
+
 const chatServerEvent = Type.Union([
   Type.Object({ type: Type.Literal("agent_start") }),
   Type.Object({
@@ -62,7 +87,11 @@ const chatServerEvent = Type.Union([
     message: agentMessage,
     assistantMessageEvent: Type.Optional(Type.Unknown()),
   }),
-  Type.Object({ type: Type.Literal("message_end"), message: agentMessage }),
+  Type.Object({
+    type: Type.Literal("message_end"),
+    message: agentMessage,
+    seq: Type.Optional(Type.Integer()),
+  }),
   Type.Object({
     type: Type.Literal("tool_execution_start"),
     toolCallId: Type.String(),
@@ -120,7 +149,10 @@ const chatServerEvent = Type.Union([
   Type.Object({
     type: Type.Literal("turn_withdrawn"),
     seq: Type.Integer(),
+    upTo: Type.Optional(Type.Integer()),
   }),
+  messageSettledFrame,
+  turnRetriedFrame,
   Type.Object({
     type: Type.Literal("error"),
     message: Type.String(),
@@ -143,6 +175,7 @@ export const schemas = {
           }),
         ),
       ),
+      intentId: Type.Optional(Type.String()),
     }),
     Type.Object({ type: Type.Literal("abort") }),
     Type.Object({ type: Type.Literal("ping") }),

--- a/packages/contracts/src/websocket.ts
+++ b/packages/contracts/src/websocket.ts
@@ -196,10 +196,12 @@ export const schemas = {
     }),
   ]),
   chatServerEvent,
+  settledFrame,
 } as const;
 
 export type ChatClientMessage = Static<typeof schemas.chatClientMessage>;
 export type ChatServerEvent = Static<typeof chatServerEvent>;
+export type SettledFrameContract = Static<typeof settledFrame>;
 
 export function parseChatClientMessage(payload: unknown): ChatClientMessage {
   return parseContract(schemas.chatClientMessage, payload);

--- a/packages/core/src/__tests__/session/agent-runner.test.ts
+++ b/packages/core/src/__tests__/session/agent-runner.test.ts
@@ -771,7 +771,7 @@ Agent with time perception.`,
 
     const anchor = await runner.withdrawLastTurn();
 
-    expect(anchor).toBe(2);
+    expect(anchor).toEqual({ seq: 2, upTo: 4 });
     const withdrawnEvents = eventsOf(runner).filter((e: any) => e.type === "turn/withdrawn");
     expect(withdrawnEvents).toHaveLength(1);
     expect(withdrawnEvents[0].data).toEqual({ seq: 2 });
@@ -794,7 +794,7 @@ Agent with time perception.`,
 
     const anchor = await runner.withdrawLastTurn();
 
-    expect(anchor).toBe(0);
+    expect(anchor).toEqual({ seq: 0, upTo: 2 });
     expect(agent.state.messages).toEqual([]);
     expect(deriveMessages(agentStore.sessions.readEvents(sessionId))).toEqual([]);
   });
@@ -879,7 +879,7 @@ Agent with time perception.`,
 
     const anchor = await runner.withdrawLastTurn();
 
-    expect(anchor).toBe(3);
+    expect(anchor).toEqual({ seq: 3, upTo: 5 });
     const messages = agentOf(runner).state.messages;
     expect(messages.length).toBe(1);
     expect((messages[0] as any).content).toContain("digest of q1/a1");

--- a/packages/core/src/__tests__/session/session-manager.test.ts
+++ b/packages/core/src/__tests__/session/session-manager.test.ts
@@ -519,7 +519,7 @@ describe("SessionManager lifecycle", () => {
 
     const anchor = await runtime.sessionRuntime.withdrawLastTurn(sessionId);
 
-    expect(anchor).toBe(0);
+    expect(anchor).toEqual({ seq: 0, upTo: 2 });
     expect(agentStore.sessions.readEvents(sessionId).at(-1)).toMatchObject({
       type: "turn/withdrawn",
       data: { seq: 0 },

--- a/packages/core/src/__tests__/session/settled-frames.test.ts
+++ b/packages/core/src/__tests__/session/settled-frames.test.ts
@@ -283,6 +283,42 @@ describe("AgentRunner settled frames", () => {
     expect(transientEnd.seq).toBe(toolSeq);
   });
 
+  it("locks current behavior: an aborted assistant message_end still persists and settles", async () => {
+    const { runner, sessionId } = await createRunner();
+    const seen: any[] = [];
+    const abortedPartial = {
+      role: "assistant",
+      content: [{ type: "text", text: "partial before abort" }],
+      stopReason: "aborted",
+      timestamp: Date.now(),
+    };
+    stubAgentLoopWith(runner, (emit) => {
+      emit({ type: "message_start", message: abortedPartial });
+      emit({ type: "message_update", message: abortedPartial });
+      emit({ type: "message_end", message: abortedPartial });
+      emit({ type: "agent_end", messages: [abortedPartial] });
+    });
+
+    await runner.sendMessage("hello", [], (e) => seen.push(e));
+
+    const persisted = eventsOf(runner)
+      .filter((e: any) => e.type === "assistant/message")
+      .map((e: any) => e.data.message);
+    expect(persisted).toEqual([abortedPartial]);
+    expect(seen).toContainEqual({
+      type: "message_settled",
+      seq: eventsOf(runner).find((e: any) => e.type === "assistant/message")?.seq,
+      message: abortedPartial,
+    });
+    const turnEnd = eventsOf(runner).find((e: any) => e.type === "turn/end");
+    expect(turnEnd.data.reason).toBe("aborted");
+
+    const store = ((deps.projectStore as any).getAgent(agentId) as any).sessions;
+    expect(deriveHistoryEntries(store.readEvents(sessionId)).map((e) => e.message)).toContainEqual(
+      abortedPartial,
+    );
+  });
+
   it("emits turn_retried with the appended event seq before transient events", async () => {
     const { runner } = await createRunner();
     const failed = {

--- a/packages/core/src/__tests__/session/settled-frames.test.ts
+++ b/packages/core/src/__tests__/session/settled-frames.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs";
+import { createSilentLogger } from "../../logger.js";
+
+const { getChatStreamFnMock, resolveModelByIdMock } = vi.hoisted(() => ({
+  getChatStreamFnMock: vi.fn(() => vi.fn()),
+  resolveModelByIdMock: vi.fn((modelId: string) => {
+    const slashIdx = modelId.indexOf("/");
+    return slashIdx >= 0
+      ? { id: modelId.slice(slashIdx + 1), provider: modelId.slice(0, slashIdx) }
+      : { id: modelId, provider: modelId };
+  }),
+}));
+
+const stubCatalog = {
+  getChatStreamFn: getChatStreamFnMock,
+  resolveModelById: resolveModelByIdMock,
+} as never;
+
+import { createProject } from "../../factory.js";
+import { AgentRunner } from "../../session/agent-runner.js";
+import { SessionEventLog } from "../../session/event-log.js";
+import {
+  deriveHistoryEntries,
+  projectSettledFrames,
+} from "../../session/fold.js";
+import type { SessionEvent } from "../../session/events.js";
+import { RunConfigHolder, type RuntimeDeps } from "../../session/runtime.js";
+import { createModelResolver } from "../../session/model-resolver.js";
+import { builtinToolCapabilities } from "../../capabilities/builtin.js";
+import { createStoreRegistry } from "../../kernel/ports.js";
+
+const TEST_AGENT_PROFILE = `---
+name: Test Agent
+tools:
+  - read_file
+---
+
+Test agent for sessions.`;
+
+interface RuntimeInternals {
+  projectManager: { projectStore: { agents: Map<string, unknown> } };
+  triggerManager: { stopAll: () => void };
+  timerService: { stop: () => void };
+}
+
+function agentOf(runner: AgentRunner): any {
+  return runner.agentRef;
+}
+
+function eventsOf(runner: AgentRunner): any[] {
+  return (runner as any).eventLog.events;
+}
+
+function ev(
+  type: SessionEvent["type"],
+  seq: number,
+  data: unknown,
+): SessionEvent {
+  return { type, seq, time: seq, data } as SessionEvent;
+}
+
+describe("projectSettledFrames", () => {
+  const events: SessionEvent[] = [
+    ev("turn/start", 0, {}),
+    ev("user/message", 1, { message: { role: "user", content: "q", timestamp: 1 }, intentId: "01J" }),
+    ev("assistant/message", 2, { message: { role: "assistant", content: [], stopReason: "stop", timestamp: 2 } }),
+    ev("tool/result", 3, { message: { role: "toolResult", toolCallId: "t1", toolName: "read_file", content: [], timestamp: 3 } }),
+    ev("turn/end", 4, { reason: "completed" }),
+    ev("turn/withdrawn", 5, { seq: 1 }),
+    ev("turn/retried", 6, { abandonedSeqs: [2] }),
+    ev("compaction/applied", 7, { anchorSeq: 0, digestContent: "d", excludedSeqs: [] }),
+  ];
+
+  it("maps message and turn events to settled frames and skips markers", () => {
+    const { frames, hasMore } = projectSettledFrames(events, -1, 100);
+    expect(hasMore).toBe(false);
+    expect(frames).toEqual([
+      { type: "message_settled", seq: 1, message: { role: "user", content: "q", timestamp: 1 }, intentId: "01J" },
+      { type: "message_settled", seq: 2, message: { role: "assistant", content: [], stopReason: "stop", timestamp: 2 } },
+      { type: "message_settled", seq: 3, message: { role: "toolResult", toolCallId: "t1", toolName: "read_file", content: [], timestamp: 3 } },
+      { type: "turn_withdrawn", seq: 1, upTo: 5 },
+      { type: "turn_retried", seq: 6, abandonedSeqs: [2] },
+    ]);
+  });
+
+  it("only returns frames whose event seq is greater than since", () => {
+    const { frames } = projectSettledFrames(events, 2, 100);
+    expect(frames).toEqual([
+      { type: "message_settled", seq: 3, message: { role: "toolResult", toolCallId: "t1", toolName: "read_file", content: [], timestamp: 3 } },
+      { type: "turn_withdrawn", seq: 1, upTo: 5 },
+      { type: "turn_retried", seq: 6, abandonedSeqs: [2] },
+    ]);
+  });
+
+  it("caps at limit and reports hasMore", () => {
+    const { frames, hasMore } = projectSettledFrames(events, -1, 2);
+    expect(frames).toHaveLength(2);
+    expect(hasMore).toBe(true);
+  });
+
+  it("returns empty and no hasMore when nothing follows since", () => {
+    const { frames, hasMore } = projectSettledFrames(events, 7, 100);
+    expect(frames).toEqual([]);
+    expect(hasMore).toBe(false);
+  });
+
+  it("omits intentId when the user message carries none", () => {
+    const noIntent: SessionEvent[] = [
+      ev("user/message", 0, { message: { role: "user", content: "q", timestamp: 1 } }),
+    ];
+    const { frames } = projectSettledFrames(noIntent, -1, 100);
+    expect(frames).toEqual([
+      { type: "message_settled", seq: 0, message: { role: "user", content: "q", timestamp: 1 } },
+    ]);
+  });
+});
+
+describe("AgentRunner settled frames", () => {
+  let tmpDir: string;
+  let runtime: RuntimeInternals & Awaited<ReturnType<typeof createProject>>;
+  let deps: RuntimeDeps;
+  let agentId: string;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "wb-settled-"));
+    getChatStreamFnMock.mockClear();
+    resolveModelByIdMock.mockClear();
+    runtime = (await createProject(tmpDir, {
+      projectName: "Test",
+      logger: createSilentLogger(),
+    })) as RuntimeInternals & Awaited<ReturnType<typeof createProject>>;
+    const projectStore = runtime.projectManager.projectStore as any;
+    const testAgent = await projectStore.createAgent("test-agent", TEST_AGENT_PROFILE);
+    agentId = testAgent.getProfile().id;
+    runtime.timerService.stop();
+    deps = {
+      projectStore,
+      projectRoot: projectStore.getRootPath(),
+      fileWriteMutex: (runtime as any).sessionRuntime.deps.fileWriteMutex,
+      logger: createSilentLogger(),
+      runConfig: new RunConfigHolder({ defaultModel: "openai/gpt-4o" }),
+      modelResolver: createModelResolver(stubCatalog),
+      modelCatalog: stubCatalog,
+      capabilities: builtinToolCapabilities(),
+      stores: createStoreRegistry(),
+      attachmentProcessors: [],
+    };
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function createRunner(): Promise<{ runner: AgentRunner; sessionId: string }> {
+    const agentStore = (deps.projectStore as any).getAgent(agentId) as any;
+    const sessionId = agentStore.sessions.createSession();
+    const eventLog = SessionEventLog.open(agentStore.sessions, sessionId);
+    const runner = await AgentRunner.init(deps, agentId, sessionId, { eventLog });
+    return { runner, sessionId };
+  }
+
+  function stubAgentLoopWith(runner: AgentRunner, emit: (listener: (event: any) => void) => void): void {
+    const agent = agentOf(runner);
+    let capturedListener: ((event: any) => void) | undefined;
+    agent.subscribe = vi.fn((listener: any) => {
+      capturedListener = listener;
+      return () => {};
+    }) as never;
+    agent.prompt = vi.fn().mockImplementation(async () => {
+      emit((event) => capturedListener?.(event));
+    }) as never;
+    agent.continue = vi.fn().mockResolvedValue(undefined) as never;
+  }
+
+  it("emits user message_settled with intentId before transient events and persists intentId", async () => {
+    const { runner, sessionId } = await createRunner();
+    const seen: any[] = [];
+    stubAgentLoopWith(runner, () => {});
+
+    await runner.sendMessage("hello", [], (e) => seen.push(e), { intentId: "01JTEST" });
+
+    const userSettled = seen.filter((e) => e.type === "message_settled");
+    expect(userSettled).toEqual([
+      {
+        type: "message_settled",
+        seq: 0,
+        message: { role: "user", content: [{ type: "text", text: "hello" }], timestamp: expect.any(Number) },
+        intentId: "01JTEST",
+      },
+    ]);
+    expect(seen[0].type).toBe("message_settled");
+
+    const userEvent = eventsOf(runner).find((e: any) => e.type === "user/message");
+    expect(userEvent.data.intentId).toBe("01JTEST");
+    const derived = deriveHistoryEntries(
+      ((deps.projectStore as any).getAgent(agentId) as any).sessions.readEvents(sessionId),
+    );
+    expect(derived[0].intentId).toBe("01JTEST");
+  });
+
+  it("stamps persisted seq on assistant message_end and follows it with message_settled", async () => {
+    const { runner } = await createRunner();
+    const seen: any[] = [];
+    const assistantMsg = {
+      role: "assistant",
+      content: [{ type: "text", text: "hi" }],
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+    stubAgentLoopWith(runner, (emit) => {
+      emit({ type: "message_start", message: assistantMsg });
+      emit({ type: "message_update", message: assistantMsg });
+      emit({ type: "message_end", message: assistantMsg });
+      emit({ type: "agent_end", messages: [assistantMsg] });
+    });
+
+    await runner.sendMessage("hello", [], (e) => seen.push(e));
+
+    const transientEnd = seen.find(
+      (e: any) => e.type === "message_end" && e.message?.role === "assistant",
+    );
+    const persistedSeq = eventsOf(runner).find(
+      (e: any) => e.type === "assistant/message",
+    )?.seq;
+    expect(persistedSeq).toBeDefined();
+    expect(transientEnd.seq).toBe(persistedSeq);
+
+    const settled = seen.filter((e: any) => e.type === "message_settled");
+    expect(settled).toEqual([
+      { type: "message_settled", seq: expect.any(Number), message: expect.any(Object) },
+      { type: "message_settled", seq: persistedSeq, message: assistantMsg },
+    ]);
+
+    const transientEndIndex = seen.indexOf(transientEnd);
+    expect(seen[transientEndIndex + 1]).toBe(settled[1]);
+  });
+
+  it("leaves the user transient message_end unstamped", async () => {
+    const { runner } = await createRunner();
+    const seen: any[] = [];
+    const userMsg = { role: "user", content: [{ type: "text", text: "hello" }], timestamp: Date.now() };
+    stubAgentLoopWith(runner, (emit) => {
+      emit({ type: "message_start", message: userMsg });
+      emit({ type: "message_end", message: userMsg });
+      emit({ type: "agent_end", messages: [] });
+    });
+
+    await runner.sendMessage("hello", [], (e) => seen.push(e));
+
+    const userTransientEnd = seen.find(
+      (e: any) => e.type === "message_end" && e.message?.role === "user",
+    );
+    expect(userTransientEnd).toBeDefined();
+    expect(userTransientEnd.seq).toBeUndefined();
+  });
+
+  it("settles toolResult message_end with the tool/result seq", async () => {
+    const { runner } = await createRunner();
+    const seen: any[] = [];
+    const toolResult = {
+      role: "toolResult",
+      toolCallId: "t1",
+      toolName: "read_file",
+      content: [{ type: "text", text: "data" }],
+      timestamp: Date.now(),
+    };
+    stubAgentLoopWith(runner, (emit) => {
+      emit({ type: "message_end", message: toolResult });
+      emit({ type: "agent_end", messages: [] });
+    });
+
+    await runner.sendMessage("hello", [], (e) => seen.push(e));
+
+    const toolSeq = eventsOf(runner).find((e: any) => e.type === "tool/result")?.seq;
+    expect(toolSeq).toBeDefined();
+    expect(seen).toContainEqual({ type: "message_settled", seq: toolSeq, message: toolResult });
+    const transientEnd = seen.find(
+      (e: any) => e.type === "message_end" && e.message?.role === "toolResult",
+    );
+    expect(transientEnd.seq).toBe(toolSeq);
+  });
+
+  it("emits turn_retried with the appended event seq before transient events", async () => {
+    const { runner } = await createRunner();
+    const failed = {
+      role: "assistant",
+      content: [{ type: "text", text: "boom" }],
+      stopReason: "error",
+      errorMessage: "provider down",
+      timestamp: Date.now(),
+    };
+    const firstAgent = agentOf(runner);
+    stubAgentLoopWith(runner, (emit) => {
+      firstAgent.state.messages.push(failed);
+      emit({ type: "message_start", message: failed });
+      emit({ type: "message_end", message: failed });
+      emit({ type: "agent_end", messages: [failed] });
+    });
+    await runner.sendMessage("hello", [], () => {});
+
+    const seen: any[] = [];
+    const retriedMsg = {
+      role: "assistant",
+      content: [{ type: "text", text: "retry ok" }],
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+    stubAgentLoopWith(runner, (emit) => {
+      emit({ type: "message_start", message: retriedMsg });
+      emit({ type: "message_end", message: retriedMsg });
+      emit({ type: "agent_end", messages: [retriedMsg] });
+    });
+    await runner.retryLastTurn((e) => seen.push(e));
+
+    const retriedEvent = eventsOf(runner).find((e: any) => e.type === "turn/retried");
+    expect(retriedEvent.data.abandonedSeqs).toHaveLength(1);
+    expect(seen[0]).toEqual({
+      type: "turn_retried",
+      seq: retriedEvent.seq,
+      abandonedSeqs: retriedEvent.data.abandonedSeqs,
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,11 +18,13 @@ export {
   AccessDeniedError,
   ConflictError,
   ModelNotConfiguredError,
+  MigrationRequiredError,
 } from "./errors.js";
 export type { ProjectRuntime } from "./project-runtime.js";
 export type { ProjectManager } from "./project-manager.js";
 export type { SessionManager } from "./session/session-manager.js";
 export type { SessionControlEvent } from "./session/types.js";
+export type { SettledFrame } from "./session/events.js";
 export type { TriggerManager } from "./trigger/trigger-manager.js";
 export type { TriggerEventPayload } from "./trigger/trigger-manager.js";
 export type { TimerService } from "./trigger/timer-service.js";

--- a/packages/core/src/session/agent-runner.ts
+++ b/packages/core/src/session/agent-runner.ts
@@ -17,7 +17,7 @@ import {
 import { composeTurnHooks, type TurnHooks } from "../kernel/turn-hooks.js";
 import { collectAbandonedSeqs, deriveMessages, repairLog } from "./fold.js";
 import { SessionEventLog } from "./event-log.js";
-import type { SessionEvent, SendMessageMeta } from "./events.js";
+import type { SessionEvent, SendMessageMeta, SettledFrame } from "./events.js";
 import { readCurrentTokens } from "../context/token-estimate.js";
 import {
   buildAgent,
@@ -27,7 +27,9 @@ import {
   streamDecoratorsFor,
 } from "./agent-assembly.js";
 
-export type RunnerEventHandler = (event: AgentEvent | SessionControlEvent) => void;
+export type RunnerEventHandler = (
+  event: AgentEvent | SessionControlEvent | SettledFrame,
+) => void;
 
 export class AgentRunner {
   private eventLog: SessionEventLog | null = null;
@@ -146,24 +148,31 @@ export class AgentRunner {
         ? (stripUserAttachments(userMessage as never, attachments) as typeof userMessage)
         : userMessage;
 
-      this.eventLog!.appendBatch([
+      const batch = this.eventLog!.appendBatch([
         {
           type: "user/message",
           data: {
             message: sanitizedUserMessage as never,
             ...(meta?.source !== undefined ? { source: meta.source } : {}),
             ...(meta?.triggerName !== undefined ? { triggerName: meta.triggerName } : {}),
+            ...(meta?.intentId !== undefined ? { intentId: meta.intentId } : {}),
           },
         },
         { type: "turn/start", data: {} },
       ]);
+      onEvent({
+        type: "message_settled",
+        seq: batch[0].seq,
+        message: sanitizedUserMessage as never,
+        ...(meta?.intentId !== undefined ? { intentId: meta.intentId } : {}),
+      });
 
       const dispatch = createEventPipeline(
         [
           logEventMiddleware(sessionLogger),
           ...this.capabilityMiddlewares,
           ...(sanitizer ? [sanitizer.middleware] : []),
-          this.persistMiddleware(),
+          this.persistMiddleware(onEvent),
         ],
         onEvent,
       );
@@ -212,10 +221,15 @@ export class AgentRunner {
       }
 
       this.ensureModel();
-      this.eventLog!.appendBatch([
+      const retryBatch = this.eventLog!.appendBatch([
         { type: "turn/retried", data: { abandonedSeqs: [lastEvent.seq] } },
         { type: "turn/start", data: {} },
       ]);
+      onEvent({
+        type: "turn_retried",
+        seq: retryBatch[0].seq,
+        abandonedSeqs: [lastEvent.seq],
+      });
       this.syncBufferFromLog();
 
       const sessionLogger = this.deps.logger.child({ sessionId: this.sessionId });
@@ -223,7 +237,7 @@ export class AgentRunner {
         [
           logEventMiddleware(sessionLogger),
           ...this.capabilityMiddlewares,
-          this.persistMiddleware(),
+          this.persistMiddleware(onEvent),
         ],
         onEvent,
       );
@@ -241,7 +255,7 @@ export class AgentRunner {
     }
   }
 
-  async withdrawLastTurn(): Promise<number> {
+  async withdrawLastTurn(): Promise<{ seq: number; upTo: number }> {
     this.ensureNotBusy();
     const events = this.eventLog!.events;
     const lastUserEvent = [...events]
@@ -260,9 +274,9 @@ export class AgentRunner {
         `Session "${this.sessionId}" last turn is already compacted into a digest and cannot be withdrawn`,
       );
     }
-    this.eventLog!.append("turn/withdrawn", { seq: lastUserEvent.seq });
+    const withdrawn = this.eventLog!.append("turn/withdrawn", { seq: lastUserEvent.seq });
     this.syncBufferFromLog();
-    return lastUserEvent.seq;
+    return { seq: lastUserEvent.seq, upTo: withdrawn.seq };
   }
 
   private ensureNotBusy(): void {
@@ -419,11 +433,20 @@ export class AgentRunner {
     }
   }
 
-  private persistMiddleware(): EventMiddleware<AgentEvent> {
+  private persistMiddleware(onEvent: RunnerEventHandler): EventMiddleware<AgentEvent> {
     return (event, next) => {
       if (this.eventLog) {
         if (event.type === "message_end") {
-          this.appendMessageEvent(event.message);
+          const persisted = this.appendMessageEvent(event.message);
+          if (persisted) {
+            next({ ...event, seq: persisted.seq } as typeof event);
+            onEvent({
+              type: "message_settled",
+              seq: persisted.seq,
+              message: event.message as never,
+            });
+            return;
+          }
         } else if (event.type === "agent_end") {
           const lastMessage = [...event.messages]
             .reverse()
@@ -444,13 +467,15 @@ export class AgentRunner {
     };
   }
 
-  private appendMessageEvent(message: unknown): void {
+  private appendMessageEvent(message: unknown): SessionEvent | undefined {
     const role = (message as { role?: string }).role;
     if (role === "assistant") {
-      this.eventLog!.append("assistant/message", { message: message as never });
-    } else if (role === "toolResult") {
-      this.eventLog!.append("tool/result", { message: message as never });
+      return this.eventLog!.append("assistant/message", { message: message as never });
     }
+    if (role === "toolResult") {
+      return this.eventLog!.append("tool/result", { message: message as never });
+    }
+    return undefined;
   }
 
   private syncBufferFromLog(): void {

--- a/packages/core/src/session/events.ts
+++ b/packages/core/src/session/events.ts
@@ -6,12 +6,13 @@ export type TurnEndReason = "completed" | "aborted" | "error";
 export interface SendMessageMeta {
   source?: "triggered";
   triggerName?: string;
+  intentId?: string;
 }
 
 export interface SessionEventMap {
   "turn/start": Record<string, never>;
   "turn/end": { reason: TurnEndReason };
-  "user/message": { message: AgentMessage; source?: "triggered"; triggerName?: string };
+  "user/message": { message: AgentMessage; source?: "triggered"; triggerName?: string; intentId?: string };
   "assistant/message": { message: AssistantMessage };
   "tool/result": { message: ToolResultMessage };
   "compaction/applied": {
@@ -23,6 +24,11 @@ export interface SessionEventMap {
   "turn/retried": { abandonedSeqs: number[] };
   "turn/withdrawn": { seq: number };
 }
+
+export type SettledFrame =
+  | { type: "message_settled"; seq: number; message: AgentMessage; intentId?: string }
+  | { type: "turn_withdrawn"; seq: number; upTo: number }
+  | { type: "turn_retried"; seq: number; abandonedSeqs: number[] };
 
 export type SessionEventType = keyof SessionEventMap;
 

--- a/packages/core/src/session/fold.ts
+++ b/packages/core/src/session/fold.ts
@@ -1,13 +1,14 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ToolResultMessage } from "@earendil-works/pi-ai";
 import { wrapDigestContent } from "../context/compaction.js";
-import { MESSAGE_EVENT_TYPES, type SessionEvent } from "./events.js";
+import { MESSAGE_EVENT_TYPES, type SessionEvent, type SettledFrame } from "./events.js";
 
 export interface DerivedMessageEntry {
   seq: number;
   message: AgentMessage;
   source?: "triggered";
   triggerName?: string;
+  intentId?: string;
 }
 
 interface RestartState {
@@ -68,13 +69,66 @@ function projectMessageEvent(event: SessionEvent): DerivedMessageEntry {
     message: AgentMessage;
     source?: "triggered";
     triggerName?: string;
+    intentId?: string;
   };
   return {
     seq: event.seq,
     message: data.message,
     ...(data.source !== undefined ? { source: data.source } : {}),
     ...(data.triggerName !== undefined ? { triggerName: data.triggerName } : {}),
+    ...(data.intentId !== undefined ? { intentId: data.intentId } : {}),
   };
+}
+
+export function projectSettledFrames(
+  events: readonly SessionEvent[],
+  since: number,
+  limit: number,
+): { frames: SettledFrame[]; hasMore: boolean } {
+  const frames: SettledFrame[] = [];
+  let hasMore = false;
+  for (const event of events) {
+    if (event.seq <= since) continue;
+    const frame = settledFrameOf(event);
+    if (!frame) continue;
+    if (frames.length === limit) {
+      hasMore = true;
+      break;
+    }
+    frames.push(frame);
+  }
+  return { frames, hasMore };
+}
+
+function settledFrameOf(event: SessionEvent): SettledFrame | undefined {
+  switch (event.type) {
+    case "user/message": {
+      const intentId = (event.data as { intentId?: string }).intentId;
+      return {
+        type: "message_settled",
+        seq: event.seq,
+        message: event.data.message,
+        ...(intentId !== undefined ? { intentId } : {}),
+      };
+    }
+    case "assistant/message":
+    case "tool/result":
+      return {
+        type: "message_settled",
+        seq: event.seq,
+        message: event.data.message,
+      };
+    case "turn/withdrawn":
+      return { type: "turn_withdrawn", seq: event.data.seq, upTo: event.seq };
+    case "turn/retried":
+      return {
+        type: "turn_retried",
+        seq: event.seq,
+        abandonedSeqs: event.data.abandonedSeqs,
+      };
+    default:
+      return undefined;
+  }
 }
 
 function scanRestarts(events: readonly SessionEvent[]): RestartState {

--- a/packages/core/src/session/session-manager.ts
+++ b/packages/core/src/session/session-manager.ts
@@ -147,7 +147,8 @@ export class SessionManager {
     limit: number,
   ): { frames: SettledFrame[]; hasMore: boolean } {
     this.requireEventizedSession(agentId, sessionId);
-    const agentStore = this.deps.projectStore.getAgent(agentId)!;
+    const agentStore = this.deps.projectStore.getAgent(agentId);
+    if (!agentStore) return { frames: [], hasMore: false };
     return projectSettledFrames(
       agentStore.sessions.readEvents(sessionId),
       since,

--- a/packages/core/src/session/session-manager.ts
+++ b/packages/core/src/session/session-manager.ts
@@ -1,10 +1,10 @@
 import type { AgentChangePayload } from "../store/project.js";
 import type { Logger } from "../logger.js";
-import { NotFoundError } from "../errors.js";
+import { MigrationRequiredError, NotFoundError } from "../errors.js";
 import { AgentRunner, type RunnerEventHandler } from "./agent-runner.js";
 import { SessionEventLog } from "./event-log.js";
-import type { SendMessageMeta } from "./events.js";
-import { deriveMessages } from "./fold.js";
+import type { SendMessageMeta, SettledFrame } from "./events.js";
+import { deriveMessages, projectSettledFrames } from "./fold.js";
 import { computeSessionStatus, type SessionStatus } from "./status.js";
 import type { TurnContextSnapshot } from "./types.js";
 import type { Attachment } from "../attachments/index.js";
@@ -90,7 +90,9 @@ export class SessionManager {
     return session.retryLastTurn(onEvent);
   }
 
-  async withdrawLastTurn(sessionId: string): Promise<number> {
+  async withdrawLastTurn(
+    sessionId: string,
+  ): Promise<{ seq: number; upTo: number }> {
     const session = this.sessions.get(sessionId);
     if (!session) throw new NotFoundError(`No active session "${sessionId}"`);
     return session.withdrawLastTurn();
@@ -122,6 +124,34 @@ export class SessionManager {
       agentStore.getProfile(),
       this.deps.modelCatalog.resolveModelById.bind(this.deps.modelCatalog),
       this.runConfigHolder.current().defaultModel,
+    );
+  }
+
+  requireEventizedSession(agentId: string, sessionId: string): void {
+    const agentStore = this.deps.projectStore.getAgent(agentId);
+    if (!agentStore) throw new NotFoundError(`Agent "${agentId}" not found`);
+    if (!agentStore.sessions.getSession(sessionId)) {
+      throw new NotFoundError(`Session "${sessionId}" not found`);
+    }
+    if (agentStore.sessions.sessionNeedsMigration(sessionId)) {
+      throw new MigrationRequiredError(
+        `Session "${sessionId}" uses the legacy message format and must be migrated first`,
+      );
+    }
+  }
+
+  getSessionEventsSince(
+    agentId: string,
+    sessionId: string,
+    since: number,
+    limit: number,
+  ): { frames: SettledFrame[]; hasMore: boolean } {
+    this.requireEventizedSession(agentId, sessionId);
+    const agentStore = this.deps.projectStore.getAgent(agentId)!;
+    return projectSettledFrames(
+      agentStore.sessions.readEvents(sessionId),
+      since,
+      limit,
     );
   }
 

--- a/packages/server/src/__tests__/chat-session-hub.test.ts
+++ b/packages/server/src/__tests__/chat-session-hub.test.ts
@@ -277,14 +277,19 @@ describe("ChatSessionHub", () => {
     attachment.close();
   });
 
-  it("broadcasts settled frames and replays them from the run buffer on re-attach", async () => {
+  it("broadcasts settled frames to every subscriber and replays them from the run buffer on re-attach", async () => {
     const mock = createRuntime();
     const hub = new ChatSessionHub(logger);
     const firstEvents: any[] = [];
+    const secondEvents: any[] = [];
     const first = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
       firstEvents.push(event),
     );
+    const second = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+      secondEvents.push(event),
+    );
     await first.ready;
+    await second.ready;
 
     const run = first.sendMessage("hi", [], "01JINTENT");
     await vi.waitFor(() => expect(mock.runtime.sendMessage).toHaveBeenCalled());
@@ -295,27 +300,26 @@ describe("ChatSessionHub", () => {
       seq: 2,
     });
     mock.emit({ type: "message_settled", seq: 2, message: { role: "assistant", content: [{ type: "text", text: "ok" }] } });
-    first.close();
 
-    expect(mock.runtime.sendMessage).toHaveBeenCalledWith(
-      "s1",
-      "hi",
-      [],
-      expect.any(Function),
-      { intentId: "01JINTENT" },
-    );
     expect(firstEvents).toContainEqual({
       type: "message_settled",
       seq: 2,
       message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
     });
+    expect(secondEvents).toContainEqual({
+      type: "message_settled",
+      seq: 2,
+      message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
+    });
+
+    first.close();
+    second.close();
 
     const replayed: any[] = [];
-    const second = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+    const third = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
       replayed.push(event),
     );
-    await second.ready;
-    expect(replayed.map((event) => event.type)).toContain("message_settled");
+    await third.ready;
     expect(replayed).toContainEqual({
       type: "message_settled",
       seq: 2,
@@ -325,7 +329,33 @@ describe("ChatSessionHub", () => {
     mock.emit({ type: "agent_end", messages: [] });
     mock.finish();
     await run;
-    second.close();
+    third.close();
+  });
+
+  it("delivers settled frames from a detached run to attached subscribers", async () => {
+    const mock = createRuntime();
+    mock.runtime.sendMessage.mockImplementation(
+      (_sessionId: string, _content: string, _attachments: unknown, onEvent: (event: any) => void) => {
+        onEvent({ type: "message_settled", seq: 0, message: { role: "user", content: "hi" } });
+        return Promise.resolve();
+      },
+    );
+    const hub = new ChatSessionHub(logger);
+    const events: any[] = [];
+    const attachment = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+      events.push(event),
+    );
+    await attachment.ready;
+    events.length = 0;
+
+    await hub.startDetachedRun("p1", mock.runtime as never, "a1", "s1", "hi");
+
+    expect(events).toContainEqual({
+      type: "message_settled",
+      seq: 0,
+      message: { role: "user", content: "hi" },
+    });
+    attachment.close();
   });
 
   it("startDetachedRun rethrows restore failures", async () => {

--- a/packages/server/src/__tests__/chat-session-hub.test.ts
+++ b/packages/server/src/__tests__/chat-session-hub.test.ts
@@ -22,7 +22,7 @@ function createRuntime() {
         });
       },
     ),
-    withdrawLastTurn: vi.fn().mockResolvedValue(4),
+    withdrawLastTurn: vi.fn().mockResolvedValue({ seq: 4, upTo: 6 }),
     abortSession: vi.fn(),
     resolveControlRequest: vi.fn(),
     destroySession: vi.fn(),
@@ -155,7 +155,7 @@ describe("ChatSessionHub", () => {
     attachment.close();
   });
 
-  it("withdrawLastTurn publishes turn_withdrawn with the anchor seq", async () => {
+  it("withdrawLastTurn publishes turn_withdrawn with the anchor seq and boundary", async () => {
     const mock = createRuntime();
     const hub = new ChatSessionHub(logger);
     const events: any[] = [];
@@ -168,7 +168,7 @@ describe("ChatSessionHub", () => {
     await attachment.withdrawLastTurn();
 
     expect(mock.runtime.withdrawLastTurn).toHaveBeenCalledWith("s1");
-    expect(events).toEqual([{ type: "turn_withdrawn", seq: 4 }]);
+    expect(events).toEqual([{ type: "turn_withdrawn", seq: 4, upTo: 6 }]);
     attachment.close();
   });
 
@@ -275,6 +275,57 @@ describe("ChatSessionHub", () => {
     );
     expect(logger.error).toHaveBeenCalled();
     attachment.close();
+  });
+
+  it("broadcasts settled frames and replays them from the run buffer on re-attach", async () => {
+    const mock = createRuntime();
+    const hub = new ChatSessionHub(logger);
+    const firstEvents: any[] = [];
+    const first = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+      firstEvents.push(event),
+    );
+    await first.ready;
+
+    const run = first.sendMessage("hi", [], "01JINTENT");
+    await vi.waitFor(() => expect(mock.runtime.sendMessage).toHaveBeenCalled());
+    mock.emit({ type: "message_start", message: { role: "assistant", content: [] } });
+    mock.emit({
+      type: "message_end",
+      message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      seq: 2,
+    });
+    mock.emit({ type: "message_settled", seq: 2, message: { role: "assistant", content: [{ type: "text", text: "ok" }] } });
+    first.close();
+
+    expect(mock.runtime.sendMessage).toHaveBeenCalledWith(
+      "s1",
+      "hi",
+      [],
+      expect.any(Function),
+      { intentId: "01JINTENT" },
+    );
+    expect(firstEvents).toContainEqual({
+      type: "message_settled",
+      seq: 2,
+      message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
+    });
+
+    const replayed: any[] = [];
+    const second = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+      replayed.push(event),
+    );
+    await second.ready;
+    expect(replayed.map((event) => event.type)).toContain("message_settled");
+    expect(replayed).toContainEqual({
+      type: "message_settled",
+      seq: 2,
+      message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
+    });
+
+    mock.emit({ type: "agent_end", messages: [] });
+    mock.finish();
+    await run;
+    second.close();
   });
 
   it("startDetachedRun rethrows restore failures", async () => {

--- a/packages/server/src/__tests__/session-events-contract.test.ts
+++ b/packages/server/src/__tests__/session-events-contract.test.ts
@@ -1,0 +1,194 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Fastify, { type FastifyInstance, type FastifyRequest } from "fastify";
+import Database from "better-sqlite3";
+import { createProject, type ProjectRuntime, type Logger } from "@spherse/core";
+import { registerSessionRoutes } from "../routes/sessions.js";
+import { ChatSessionHub } from "../chat-session-hub.js";
+import { registerCoreErrorHandler } from "../errors.js";
+import type { ProjectRegistry } from "../registry.js";
+
+const silentLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  trace: () => {},
+  fatal: () => {},
+  child: () => silentLogger,
+};
+
+const TEST_AGENT_PROFILE = `---
+name: Test Agent
+tools:
+  - read_file
+---
+
+Test agent for sessions.`;
+
+declare module "fastify" {
+  interface FastifyRequest {
+    projectCtx?: {
+      projectManager: import("@spherse/core").ProjectManager;
+      sessionRuntime: import("@spherse/core").SessionManager;
+    };
+  }
+}
+
+describe("session events contract: real SessionManager through real route + hub", () => {
+  let tmpDir: string;
+  let runtime: ProjectRuntime;
+  let app: FastifyInstance;
+  let agentId: string;
+  let agentSlug: string;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "spherse-events-contract-"));
+    runtime = await createProject(tmpDir, { projectName: "Contract", logger: silentLogger });
+    const projectStore = runtime.projectManager.projectStore;
+    const testAgent = await projectStore.createAgent("test-agent", TEST_AGENT_PROFILE);
+    agentId = testAgent.getProfile().id;
+    agentSlug = testAgent.getProfile().slug;
+
+    app = Fastify();
+    app.addHook("preHandler", async (req: FastifyRequest) => {
+      req.projectCtx = {
+        projectManager: runtime.projectManager,
+        sessionRuntime: runtime.sessionRuntime,
+      };
+    });
+    registerCoreErrorHandler(app);
+    registerSessionRoutes(app, {} as ProjectRegistry, new ChatSessionHub(silentLogger as never));
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    runtime.timerService.stop();
+    await runtime.shutdown();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function agentStore(): any {
+    return runtime.projectManager.projectStore.getAgent(agentId) as any;
+  }
+
+  function seedSession(events: Array<{ type: string; data: unknown }>): string {
+    const sessionId = agentStore().sessions.createSession();
+    agentStore().sessions.appendEvents(
+      sessionId,
+      events.map((event, index) => ({
+        type: event.type,
+        seq: index,
+        time: index + 1,
+        data: event.data,
+      })),
+      1,
+    );
+    return sessionId;
+  }
+
+  it("projects message and turn events, skips markers, and honors since/limit/hasMore", async () => {
+    const sessionId = seedSession([
+      { type: "user/message", data: { message: { role: "user", content: "q1", timestamp: 1 }, intentId: "01JA" } },
+      { type: "turn/start", data: {} },
+      { type: "assistant/message", data: { message: { role: "assistant", content: [{ type: "text", text: "a1" }], stopReason: "stop", timestamp: 2 } } },
+      { type: "turn/end", data: { reason: "completed" } },
+      { type: "user/message", data: { message: { role: "user", content: "q2", timestamp: 3 } } },
+      { type: "turn/start", data: {} },
+      { type: "assistant/message", data: { message: { role: "assistant", content: [{ type: "text", text: "a2" }], stopReason: "stop", timestamp: 4 } } },
+      { type: "turn/end", data: { reason: "completed" } },
+      { type: "turn/withdrawn", data: { seq: 4 } },
+    ]);
+
+    const all = await app.inject({
+      method: "GET",
+      url: `/api/projects/p1/agents/${agentId}/sessions/${sessionId}/events`,
+    });
+    expect(all.statusCode).toBe(200);
+    expect((all.json() as { events: unknown[] }).events.map((frame) => (frame as { type: string; seq?: number }).type)).toEqual([
+      "message_settled",
+      "message_settled",
+      "message_settled",
+      "message_settled",
+      "turn_withdrawn",
+    ]);
+    expect((all.json() as { events: any[] }).events[0]).toMatchObject({ seq: 0, intentId: "01JA" });
+    expect((all.json() as { events: any[] }).events[4]).toEqual({ type: "turn_withdrawn", seq: 4, upTo: 8 });
+
+    const paged = await app.inject({
+      method: "GET",
+      url: `/api/projects/p1/agents/${agentId}/sessions/${sessionId}/events?since=0&limit=2`,
+    });
+    const pagedJson = paged.json() as { events: any[]; hasMore: boolean };
+    expect(pagedJson.events.map((f) => f.seq)).toEqual([2, 4]);
+    expect(pagedJson.hasMore).toBe(true);
+
+    const tail = await app.inject({
+      method: "GET",
+      url: `/api/projects/p1/agents/${agentId}/sessions/${sessionId}/events?since=8`,
+    });
+    expect(tail.statusCode).toBe(200);
+    const tailJson = tail.json() as { events: unknown[]; hasMore: boolean };
+    expect(tailJson.events).toEqual([]);
+    expect(tailJson.hasMore).toBe(false);
+  });
+
+  it("includes repair events appended by restore (channel-ready before read)", async () => {
+    const sessionId = seedSession([
+      { type: "user/message", data: { message: { role: "user", content: "q", timestamp: 1 } } },
+      { type: "turn/start", data: {} },
+      {
+        type: "assistant/message",
+        data: {
+          message: {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "t1", name: "read_file", arguments: {} }],
+            stopReason: "stop",
+            timestamp: 2,
+          },
+        },
+      },
+    ]);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/projects/p1/agents/${agentId}/sessions/${sessionId}/events`,
+    });
+    expect(res.statusCode).toBe(200);
+    const frames = (res.json() as { events: any[] }).events;
+    const repaired = frames.find(
+      (frame) => frame.type === "message_settled" && frame.message?.role === "toolResult",
+    );
+    expect(repaired).toBeDefined();
+    expect(repaired.message.toolCallId).toBe("t1");
+    expect(repaired.message.isError).toBe(true);
+  });
+
+  it("returns 410 for a legacy unmigrated session without migrating it", async () => {
+    const sessionId = agentStore().sessions.createSession();
+    const db = new Database(path.join(tmpDir, ".spherse", "agents", agentSlug, "sessions.db"));
+    db.prepare(
+      "INSERT INTO messages (session_id, role, content, timestamp, prev_message_id, message_content_schema_version) VALUES (?, ?, ?, ?, NULL, 1)",
+    ).run(sessionId, "user", JSON.stringify({ role: "user", content: "legacy", timestamp: 1 }), Date.now());
+    db.close();
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/projects/p1/agents/${agentId}/sessions/${sessionId}/events`,
+    });
+    expect(res.statusCode).toBe(410);
+    expect(res.json()).toEqual({ reason: "legacy-unmigrated" });
+    expect(agentStore().sessions.sessionNeedsMigration(sessionId)).toBe(true);
+  });
+
+  it("returns 404 for a missing session", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/projects/p1/agents/${agentId}/sessions/no-such-session/events`,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/packages/server/src/__tests__/session-events-contract.test.ts
+++ b/packages/server/src/__tests__/session-events-contract.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -19,6 +19,21 @@ const silentLogger: Logger = {
   fatal: () => {},
   child: () => silentLogger,
 };
+
+const { getChatStreamFnMock, resolveModelByIdMock } = vi.hoisted(() => ({
+  getChatStreamFnMock: vi.fn(() => vi.fn()),
+  resolveModelByIdMock: vi.fn((modelId: string) => {
+    const slashIdx = modelId.indexOf("/");
+    return slashIdx >= 0
+      ? { id: modelId.slice(slashIdx + 1), provider: modelId.slice(0, slashIdx) }
+      : { id: modelId, provider: modelId };
+  }),
+}));
+
+const stubCatalog = {
+  getChatStreamFn: getChatStreamFnMock,
+  resolveModelById: resolveModelByIdMock,
+} as never;
 
 const TEST_AGENT_PROFILE = `---
 name: Test Agent
@@ -41,17 +56,24 @@ describe("session events contract: real SessionManager through real route + hub"
   let tmpDir: string;
   let runtime: ProjectRuntime;
   let app: FastifyInstance;
+  let hub: ChatSessionHub;
   let agentId: string;
   let agentSlug: string;
 
   beforeAll(async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "spherse-events-contract-"));
-    runtime = await createProject(tmpDir, { projectName: "Contract", logger: silentLogger });
+    runtime = await createProject(tmpDir, {
+      projectName: "Contract",
+      logger: silentLogger,
+      modelCatalog: stubCatalog,
+      defaultModel: "openai/gpt-4o",
+    });
     const projectStore = runtime.projectManager.projectStore;
     const testAgent = await projectStore.createAgent("test-agent", TEST_AGENT_PROFILE);
     agentId = testAgent.getProfile().id;
     agentSlug = testAgent.getProfile().slug;
 
+    hub = new ChatSessionHub(silentLogger as never);
     app = Fastify();
     app.addHook("preHandler", async (req: FastifyRequest) => {
       req.projectCtx = {
@@ -60,7 +82,7 @@ describe("session events contract: real SessionManager through real route + hub"
       };
     });
     registerCoreErrorHandler(app);
-    registerSessionRoutes(app, {} as ProjectRegistry, new ChatSessionHub(silentLogger as never));
+    registerSessionRoutes(app, {} as ProjectRegistry, hub);
     await app.ready();
   });
 
@@ -190,5 +212,91 @@ describe("session events contract: real SessionManager through real route + hub"
       url: `/api/projects/p1/agents/${agentId}/sessions/no-such-session/events`,
     });
     expect(res.statusCode).toBe(404);
+  });
+
+  it("clamps limit to 200 and reports hasMore", async () => {
+    const sessionId = seedSession(
+      Array.from({ length: 205 }, (_, i) => ({
+        type: "user/message",
+        data: { message: { role: "user", content: `q${i}`, timestamp: i + 1 } },
+      })),
+    );
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/projects/p1/agents/${agentId}/sessions/${sessionId}/events?limit=500`,
+    });
+    const json = res.json() as { events: unknown[]; hasMore: boolean };
+    expect(json.events).toHaveLength(200);
+    expect(json.hasMore).toBe(true);
+  });
+
+  it("real write facade: sendMessage intentId → settled frames → withdraw broadcast, through real SessionManager", async () => {
+    const finalAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "ok" }],
+      stopReason: "stop",
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      timestamp: Date.now(),
+    };
+    getChatStreamFnMock.mockImplementation(
+      () =>
+        (async () => ({
+          async *[Symbol.asyncIterator]() {},
+          result: async () => finalAssistant,
+        })) as never,
+    );
+
+    const sessionId = agentStore().sessions.createSession();
+    const events: any[] = [];
+    const attachment = hub.attach(
+      "p1",
+      runtime.sessionRuntime,
+      agentId,
+      sessionId,
+      (event) => events.push(event),
+    );
+    expect(await attachment.ready).toBe(true);
+
+    await attachment.sendMessage("hello", [], "01JFACADE");
+
+    const userSettled = events.find(
+      (event) => event.type === "message_settled" && event.message?.role === "user",
+    );
+    expect(userSettled).toMatchObject({ seq: 0, intentId: "01JFACADE" });
+    const assistantSettled = events.filter(
+      (event) => event.type === "message_settled" && event.message?.role === "assistant",
+    );
+    expect(assistantSettled).toHaveLength(1);
+    expect(assistantSettled[0].seq).toBe(2);
+    const transientEnd = events.find(
+      (event) => event.type === "message_end" && event.message?.role === "assistant",
+    );
+    expect(transientEnd.seq).toBe(2);
+    expect(events.indexOf(transientEnd)).toBeLessThan(events.indexOf(assistantSettled[0]));
+
+    await attachment.withdrawLastTurn();
+    expect(events.at(-1)).toEqual({ type: "turn_withdrawn", seq: 0, upTo: 4 });
+
+    const endpoint = await app.inject({
+      method: "GET",
+      url: `/api/projects/p1/agents/${agentId}/sessions/${sessionId}/events`,
+    });
+    const frames = (endpoint.json() as { events: any[] }).events;
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "message_settled",
+      "message_settled",
+      "turn_withdrawn",
+    ]);
+    expect(frames[2]).toEqual({ type: "turn_withdrawn", seq: 0, upTo: 4 });
+
+    attachment.close();
+    getChatStreamFnMock.mockImplementation(() => vi.fn() as never);
   });
 });

--- a/packages/server/src/__tests__/ws-chat.test.ts
+++ b/packages/server/src/__tests__/ws-chat.test.ts
@@ -53,7 +53,7 @@ function createMockRegistry() {
   const sessionRuntime = {
     restoreSession: vi.fn().mockResolvedValue(undefined),
     sendMessage: vi.fn().mockResolvedValue(undefined),
-    withdrawLastTurn: vi.fn().mockResolvedValue(2),
+    withdrawLastTurn: vi.fn().mockResolvedValue({ seq: 2, upTo: 4 }),
     abortSession: vi.fn(),
     resolveControlRequest: vi.fn(),
     destroySession: vi.fn(),
@@ -99,7 +99,7 @@ describe("ws-chat /ws/projects/:p/chat/:a/:s handler", () => {
     socket.simulateMessage(Buffer.from(JSON.stringify({ type: "withdraw" })));
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(sessionRuntime.withdrawLastTurn).toHaveBeenCalledWith("s1");
-    expect(sentObjects(socket)).toContainEqual({ type: "turn_withdrawn", seq: 2 });
+    expect(sentObjects(socket)).toContainEqual({ type: "turn_withdrawn", seq: 2, upTo: 4 });
   });
 
   it("sends error event when withdrawLastTurn rejects", async () => {
@@ -244,5 +244,31 @@ describe("ws-chat /ws/projects/:p/chat/:a/:s handler", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(sentObjects(socket)).toContainEqual({ type: "error", message: "oops", code: "TRANSIENT" });
     expect(socket.close).not.toHaveBeenCalled();
+  });
+
+  it("passes intentId from the message frame through to sendMessage meta", async () => {
+    socket.simulateMessage(
+      Buffer.from(JSON.stringify({ type: "message", content: "hi", intentId: "01JWS" })),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sessionRuntime.sendMessage).toHaveBeenCalledWith(
+      "s1",
+      "hi",
+      [],
+      expect.any(Function),
+      { intentId: "01JWS" },
+    );
+  });
+
+  it("sends message without meta when the frame carries no intentId", async () => {
+    socket.simulateMessage(Buffer.from(JSON.stringify({ type: "message", content: "hi" })));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sessionRuntime.sendMessage).toHaveBeenCalledWith(
+      "s1",
+      "hi",
+      [],
+      expect.any(Function),
+      undefined,
+    );
   });
 });

--- a/packages/server/src/chat-session-hub.ts
+++ b/packages/server/src/chat-session-hub.ts
@@ -1,4 +1,4 @@
-import { ConflictError, type Attachment, type SessionManager } from "@spherse/core";
+import { ConflictError, type Attachment, type SessionManager, type SettledFrame } from "@spherse/core";
 import type { FastifyBaseLogger } from "fastify";
 import { classifyRunError } from "./classify-run-error.js";
 
@@ -25,7 +25,7 @@ interface ChatChannel {
 
 export interface ChatSessionAttachment {
   ready: Promise<boolean>;
-  sendMessage(content: string, attachments?: Attachment[]): Promise<void>;
+  sendMessage(content: string, attachments?: Attachment[], intentId?: string): Promise<void>;
   retryLastTurn(): Promise<void>;
   withdrawLastTurn(): Promise<void>;
   abort(): void;
@@ -74,7 +74,7 @@ export class ChatSessionHub {
 
     return {
       ready,
-      sendMessage: async (content, attachments) => {
+      sendMessage: async (content, attachments, intentId) => {
         if (!(await ready) || !active) return;
         await this.startRun(channel, (onEvent) =>
           channel.runtime.sendMessage(
@@ -82,6 +82,7 @@ export class ChatSessionHub {
             content,
             attachments ?? [],
             onEvent,
+            intentId !== undefined ? { intentId } : undefined,
           ),
         );
       },
@@ -96,8 +97,8 @@ export class ChatSessionHub {
         if (channel.running) {
           throw new ConflictError(`Session "${channel.sessionId}" is already running`);
         }
-        const seq = await channel.runtime.withdrawLastTurn(channel.sessionId);
-        this.publish(channel, { type: "turn_withdrawn", seq });
+        const { seq, upTo } = await channel.runtime.withdrawLastTurn(channel.sessionId);
+        this.publish(channel, { type: "turn_withdrawn", seq, upTo });
       },
       abort: () => {
         if (active) channel.runtime.abortSession(channel.sessionId);
@@ -155,6 +156,20 @@ export class ChatSessionHub {
         channel.attachments -= 1;
         this.cleanupIfIdle(channel);
       });
+  }
+
+  async readEventsSince(
+    projectId: string,
+    runtime: SessionManager,
+    agentId: string,
+    sessionId: string,
+    since: number,
+    limit: number,
+  ): Promise<{ frames: SettledFrame[]; hasMore: boolean }> {
+    runtime.requireEventizedSession(agentId, sessionId);
+    const channel = this.getOrCreateChannel(projectId, runtime, agentId, sessionId);
+    await channel.ready;
+    return runtime.getSessionEventsSince(agentId, sessionId, since, limit);
   }
 
   private getOrCreateChannel(

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -1,3 +1,12 @@
+import type { FastifyInstance } from "fastify";
+import {
+  AccessDeniedError,
+  ConflictError,
+  MigrationRequiredError,
+  NotFoundError,
+  ValidationError,
+} from "@spherse/core";
+
 export class HttpError extends Error {
   constructor(
     public readonly statusCode: number,
@@ -27,4 +36,32 @@ export function conflict(message: string): HttpError {
 
 export function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+export function registerCoreErrorHandler(fastify: FastifyInstance): void {
+  fastify.setErrorHandler((err, req, reply) => {
+    if (err instanceof HttpError) {
+      return reply.code(err.statusCode).send(err.body ?? { error: err.message });
+    }
+    if (err instanceof NotFoundError) {
+      return reply.code(404).send({ error: err.message });
+    }
+    if (err instanceof ValidationError) {
+      return reply.code(400).send({ error: err.message });
+    }
+    if (err instanceof AccessDeniedError) {
+      return reply.code(403).send({ error: err.message });
+    }
+    if (err instanceof ConflictError) {
+      return reply.code(409).send({ error: err.message });
+    }
+    if (err instanceof MigrationRequiredError) {
+      return reply.code(410).send({ reason: "legacy-unmigrated" });
+    }
+    if (err instanceof Error && "validation" in err && err.validation) {
+      return reply.code(400).send({ error: err.message });
+    }
+    req.log.error({ err }, "unhandled request error");
+    reply.code(500).send({ error: errorMessage(err) });
+  });
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,15 +3,9 @@ import type { AddressInfo } from "node:net";
 import websocket from "@fastify/websocket";
 import multipart from "@fastify/multipart";
 import type { Logger, SamplingParams, ThinkingLevel, ModelCatalog } from "@spherse/core";
-import {
-  NotFoundError,
-  ValidationError,
-  AccessDeniedError,
-  ConflictError,
-} from "@spherse/core";
 import { ProjectRegistry } from "./registry.js";
 import { createServerLogger, createPrettyStream } from "./logger.js";
-import { HttpError, errorMessage } from "./errors.js";
+import { registerCoreErrorHandler } from "./errors.js";
 import { registerAuthHook, type AuthOptions } from "./auth.js";
 import { registerAuthGatedCors } from "./cors.js";
 import { registerHostGuard } from "./host-guard.js";
@@ -79,28 +73,7 @@ export async function createMultiProjectServer(
 
   fastify.get("/health", { schema: { response: { 200: { type: "object", properties: { ok: { type: "boolean" } } } } } }, async () => ({ ok: true }));
 
-  fastify.setErrorHandler((err, req, reply) => {
-    if (err instanceof HttpError) {
-      return reply.code(err.statusCode).send(err.body ?? { error: err.message });
-    }
-    if (err instanceof NotFoundError) {
-      return reply.code(404).send({ error: err.message });
-    }
-    if (err instanceof ValidationError) {
-      return reply.code(400).send({ error: err.message });
-    }
-    if (err instanceof AccessDeniedError) {
-      return reply.code(403).send({ error: err.message });
-    }
-    if (err instanceof ConflictError) {
-      return reply.code(409).send({ error: err.message });
-    }
-    if (err instanceof Error && "validation" in err && err.validation) {
-      return reply.code(400).send({ error: err.message });
-    }
-    req.log.error({ err }, "unhandled request error");
-    reply.code(500).send({ error: errorMessage(err) });
-  });
+  registerCoreErrorHandler(fastify);
 
   fastify.setNotFoundHandler((req, reply) => {
     reply.code(404).send({ error: "Route not found" });

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -102,6 +102,34 @@ export function registerSessionRoutes(
     },
   );
 
+  fastify.get<{
+    Params: { projectId: string; agentId: string; id: string };
+    Querystring: { since?: string; limit?: string };
+  }>(
+    "/api/projects/:projectId/agents/:agentId/sessions/:id/events",
+    {
+      schema: { response: { 200: schemas.sessionEventsResponse } },
+    },
+    async (req) => {
+      const parsedSince = req.query.since !== undefined ? parseInt(req.query.since, 10) : -1;
+      const since = Number.isNaN(parsedSince) || parsedSince < -1 ? -1 : parsedSince;
+      const parsedLimit = parseInt(req.query.limit ?? "200", 10);
+      const limit = Math.min(200, Math.max(1, Number.isNaN(parsedLimit) ? 200 : parsedLimit));
+      const result = await hub.readEventsSince(
+        req.params.projectId,
+        req.projectCtx!.sessionRuntime,
+        req.params.agentId,
+        req.params.id,
+        since,
+        limit,
+      );
+      return parseContract(schemas.sessionEventsResponse, {
+        events: result.frames,
+        hasMore: result.hasMore,
+      });
+    },
+  );
+
   fastify.post<{
     Params: { projectId: string; agentId: string; id: string };
     Body: { content: string };

--- a/packages/server/src/ws-chat.ts
+++ b/packages/server/src/ws-chat.ts
@@ -70,7 +70,7 @@ export function handleChatWebSocket(
 
         if (msg.type === "message") {
           try {
-            await attachment.sendMessage(msg.content, msg.attachments ?? []);
+            await attachment.sendMessage(msg.content, msg.attachments ?? [], msg.intentId);
           } catch (err) {
             if (closed) return;
             fastify.log.error({ err, sessionId }, "chat ws message error");


### PR DESCRIPTION
## 背景

[`docs/dev/features/2026-09-03-chat-replica-rewrite/design.md`](../blob/feat/chat-settled-frames-protocol/docs/dev/features/2026-09-03-chat-replica-rewrite/design.md)（chat 前端日志副本模型 v2 合并稿）。本 PR 为三段序列的 **PR-A 协议先行**，dark launch：v2 server + v1 client = v1 行为，PR-B（app 副本切换）之前协议侧无半成品状态。

## 内容

- **contracts**：确认帧词汇 `message_settled`（seq + message + 可选 intentId）、`turn_retried`（seq + abandonedSeqs）、`turn_withdrawn.upTo`、`message_end` 可选 `seq`；client `message` 帧可选 `intentId`；`sessionEventsResponse`
- **core**：
  - `persistMiddleware`：assistant/toolResult 瞬态 `message_end` 携带落库 seq 下发、紧随 `message_settled`（pipeline 同步，帧序有保证）；`user/message` 在 pipeline 前直发含 intentId 回执
  - `withdrawLastTurn` 返回 `{seq, upTo}`（区间与 `collectAbandonedSeqs` 同源）；`retryLastTurn` 发 `turn_retried`
  - `projectSettledFrames`（since/limit/hasMore 投影）；`deriveHistoryEntries` 带出 intentId
- **server**：hub withdraw 广播带 upTo、`readEventsSince`（410 预检不触发迁移 → channel await ready 含 repairLog 修复 → store 读）、events 端点（cap 200 + hasMore）、`MigrationRequiredError` → 410、ws-chat intentId 透传
- **app**：仅 parser 对未知帧 default throw（v1「忽略未知帧」语义的最小实现，行为不变，由 runtime try/catch 兜住）
- **docs**：`data-conventions.md`（intentId）、`architecture/chat.md`（wire 词汇、确认帧发射点、events 端点）

## 验证

- `npm run verify` 全绿（lint / build / typecheck / 全部单测 / i18n）
- **全量 e2e 77 passed**（dark launch 不回归证明）
- 真门面契约测试：stub catalog 注入真 core，走真 sendMessage（intentId → settled 帧序）+ withdraw（{seq, upTo} 广播）+ events 端点全链

Review report 见评论区。