### PR TITLE
feat: chat wire 协议 v2——seq 上行链路、游标重放与 hub 结构化（chat 重构 PR1/6）

### DIFF
--- a/docs/dev/backlog.md
+++ b/docs/dev/backlog.md
@@ -41,6 +41,7 @@
 - [ ] **server 契约缺口修复（4 处）**：① `POST /attachments` 响应无 schema——renderer 在 `api.ts` 本地另定义 `attachmentUploadResponse` 手工校验，契约应上收到 contracts；② `DELETE /attachments` body 无 schema 无 parseContract；③ `images/export` body schema 内联手写，未进 contracts；④ agent 级 `GET .../agents/:agentId/sessions` 整路由无 schema（无 limit 分支返回裸 `listSessions()`）。四处均违反 server README「所有 JSON route 绑定机制 1（Fastify schema option）」规则；修复时补 contract 或在 README 豁免清单显式登记取舍。
 - [ ] **安全语义对齐（三项决策 + 落地）**：① `.spherse` 未分类文件（`spherseOther`）LLM 可读——`LLM_READ` 白名单包含该类别且有测试钉住（`access-policy.test.ts`），与「避免内部数据泄漏」的最初意图相悖，需决策收紧为不可读或接受现状并改测试意图注释；② `memory_save`/`memory_recall` 直连 MemoryStore 完全不经 access policy——用户 deny `.spherse` 后 memory 持久化照常工作，与文档曾声称的「安全优先语义」不符，需决策是否让 memory 工具走 policy 或显式豁免；③ `manage_project_config` 的 `update_welcome_page` 是写操作且 UI 归入高级工具组，但 core 层未包 `withApproval`（与 run_command/manage_agent/manage_trigger 的「高级写操作经审批」模式不一致），yolo 警示文案也未提及它——需决策补审批或在文档/文案中显式声明豁免取舍。
 - [ ] **跨层接缝契约清单对账**：SessionPort 5 方法（create/restore/sendMessage/abortSession/sessionExists）在 server/desktop 包的契约覆盖缺口逐条对账（trigger 路径、ws-chat 路径），按 AGENTS.md 契约规矩补齐。
+- [ ] **chat WS 出站背压**：`ChatChannel.publish` 同步 `socket.send`，慢客户端（手机 PWA 走公网 tunnel）的 ws 发送缓冲无上限增长（`message_update` 为累积快照，帧大且高频），无人看 `bufferedAmount`。方向：ws-chat 的 send 闭包按 `bufferedAmount` 分级——软阈值（~1MB）丢弃流式 update 帧（累积快照语义下丢中间帧无损，下一条即全量）、硬上限（~16MB）close 断开，客户端经游标重放 + 快照无损恢复。参见 `docs/dev/features/2026-09-05-chat-refactor/design.md`（hub 缺陷分析节）。
 
 ## 条件触发（设计决策）
 

--- a/docs/dev/decisions/0011-chat-wire-cursor-replay.md
+++ b/docs/dev/decisions/0011-chat-wire-cursor-replay.md
@@ -1,0 +1,25 @@
+# ADR-0011：chat wire 协议携带 seq，重连恢复以游标重放取代 HTTP 对账
+
+- 状态：accepted
+- 日期：2026-09-05
+- 影响：`@spherse/contracts`（websocket.ts 协议 v2）、`packages/server`（hub/channel/projector）、`packages/core`（SessionStore.readEventsAfter、SessionManager 门面）；renderer 侧随 chat 重构 PR3/PR4 切换
+
+## 背景
+
+持久层已是事件溯源（events 表主键 `(session_id, seq)` 连续），但 wire 协议不携带任何身份——客户端消息身份只能靠 HTTP 拉 history 建立、乐观消息靠内容匹配去重、重连恢复靠「重刷最近 20 条 + mergeHistoryMessages 合并」（transient 过滤会丢流式中气泡），且发送无 ack。
+
+## 决策
+
+- **seq 上 wire**：`user_message` echo（含 `clientId` ack）、`message_end.seq`（经落库实例引用配对）、`agent_end.seq`、`turn_retried`；流式 stitch 身份用 hub 生成的 `messageId`（pi message payload 运行时无 id 字段，不能作为身份）
+- **重放词汇 = 原始持久化事件**：connect 带 `?since=`（≥ -1）时重放 `seq > since` 的原始 SessionEvent（非投影 entries）——撤回/重试的删除语义天然表达，且免 fold 成本（`readEventsAfter` SQL 下推 O(page)）
+- **游标是客户端 per-connection 状态**：服务端不存 session 级游标，多客户端同看一个 session（多对一连接模型）各自进度互不干扰
+- close code 族扩为 4400/4401/4402（fatal 集合），非法客户端消息从软失败 error 改为 close(4400)
+
+## 后果
+
+- 正：消息身份贯穿 live/replay/冷启动三路；重连增量恢复；快照与重放的冗余可审计（见 design doc §1.8，收缩与 control 落库随 PR4/PR5）
+- 负：hub 对三个外部不变量新增依赖（persist-before-callback 引用配对、pi 顺序流模型、门面同步性），已由 `ChatWireProjector` 模块化收敛 + 真 runtime 契约测试钉住；旧 renderer 对新事件静默丢弃（过渡态，PR3 移除）
+
+## 原始记录
+
+- `docs/dev/features/2026-09-05-chat-refactor/design.md`（完整设计与 PR 切分）

--- a/docs/dev/features/2026-09-05-chat-refactor/design.md
+++ b/docs/dev/features/2026-09-05-chat-refactor/design.md
@@ -117,6 +117,14 @@ connect URL 增加可选 query 参数 `since`（数字，**取值域 ≥ -1**：
 | 旧 app + 新 server | 旧 app 忽略新事件类型（parse 失败静默丢弃）；新增字段 TypeBox 默认放行 additionalProperties，无破坏 |
 | 新 app + 旧 server | 无 `session_ready` → 回退 legacy 对账（现有代码路径保留至版本门槛提升） |
 
+### 1.8 快照收缩（与 PR4 联动，服务端不可单方面先行）
+
+快照（`runEvents`）与游标重放的分工审计：已完成消息（`message_end` ⟺ 已落库）在快照里是**纯冗余**——游标重放必然覆盖；快照不可替代的内容只有 in-flight 状态：未关闭消息窗口的 start + 最后一条 update（累积快照语义）、进行中的 tool_execution、**pending control_request（完全不落库，快照是唯一恢复路径）**。
+
+收缩后快照 = O(in-flight)：pi 顺序流保证同时最多一个开放消息窗口，上界恒小；`recordRunEvent` 的压缩逻辑已是该形状的一半，补「已完成消息丢弃 + 字节预算」即可。静默期（thinking/慢工具）重连的 partial 文本由快照保留的「最后一条 update」覆盖，不依赖下一条 delta。
+
+前置条件：客户端 reducer 须支持「无完整前史的快照」与「update 懒建气泡」（messageId 机制支持），故归入 PR4 前后端同改，PR1-PR3 期间维持全量快照。
+
 ## §2 服务端改造
 
 ### 2.1 seq 上 wire 的内部通道

--- a/docs/dev/features/2026-09-05-chat-refactor/design.md
+++ b/docs/dev/features/2026-09-05-chat-refactor/design.md
@@ -123,7 +123,7 @@ connect URL 增加可选 query 参数 `since`（数字，**取值域 ≥ -1**：
 
 优先复用 `SessionEventLog` 现成的订阅机制：`appendBatch` 落库后已同步 notify 订阅者（`event-log.ts:50-58,66-71`），且覆盖面比扩展 onEvent 更全（`withdrawLastTurn`、afterTurn hooks、repairLog 追加都走 append 而无 onEvent）。
 
-persist→wire 的翻译/富化收敛在 **`ChatWireProjector`**（`server/chat-wire-projector.ts`，结构化类型、零框架依赖的纯状态机）：消费 log 事件产出 echo/`turn_retried` 广播、维护 `pendingClientId`/引用→seq 配对/run 级 messageId 序列/`lastTurnEndSeq`，并对 pi wire 事件做富化。hub 只保留 channel/run 生命周期、快照压缩与 fanout——协议翻译的外部不变量（persist-before-callback 引用配对、pi 顺序流模型）从 hub 的跨方法共享可变状态收敛为 projector 的模块内局部状态，projector 可独立单测（无 runtime mock）。
+persist→wire 的翻译/富化收敛在 **`ChatWireProjector`**（`server/chat-wire-projector.ts`，结构化类型、零框架依赖的纯状态机）：消费 log 事件产出 echo/`turn_retried` 广播、维护 `pendingClientId`/引用→seq 配对/run 级 messageId 序列/`lastTurnEndSeq`，并对 pi wire 事件做富化。**单 session 生命周期收敛在 `ChatChannel`**（`server/chat-channel.ts`，每 session 一实例）：restore→ready、日志订阅、attach（连接级生命周期为 attach 闭包，不单独抽象）、run 序列化、快照压缩、握手重放、fanout、空闲自清理，持有 projector。`ChatSessionHub` 退化为注册表（`Map<key, ChatChannel>` + getOrCreate + 身份守卫删除回调）——协议翻译的外部不变量（persist-before-callback 引用配对、pi 顺序流模型）从 hub 的跨方法共享可变状态收敛为 projector 的模块内局部状态，projector 可独立单测（无 runtime mock）。
 
 clientId 传递：WS 层 `attachment.sendMessage(content, attachments, clientId?)` → hub 侧拼 echo（实现时二选一：SendMessageMeta 扩展或回调回传，契约测试钉住「echo.seq == user/message seq」）。compaction/repair 事件经此通道到达但不上 wire（无 UI 效果）。
 

--- a/docs/dev/features/2026-09-05-chat-refactor/design.md
+++ b/docs/dev/features/2026-09-05-chat-refactor/design.md
@@ -121,10 +121,9 @@ connect URL 增加可选 query 参数 `since`（数字，**取值域 ≥ -1**：
 
 ### 2.1 seq 上 wire 的内部通道
 
-优先复用 `SessionEventLog` 现成的订阅机制：`appendBatch` 落库后已同步 notify 订阅者（`event-log.ts:50-58,66-71`），且覆盖面比扩展 onEvent 更全（`withdrawLastTurn`、afterTurn hooks、repairLog 追加都走 append 而无 onEvent）。通道选型：hub 经 SessionManager 订阅目标 session 的事件日志，收到带 seq 的 `SessionEvent` 后做两件事：
+优先复用 `SessionEventLog` 现成的订阅机制：`appendBatch` 落库后已同步 notify 订阅者（`event-log.ts:50-58,66-71`），且覆盖面比扩展 onEvent 更全（`withdrawLastTurn`、afterTurn hooks、repairLog 追加都走 append 而无 onEvent）。
 
-- wire 事件富化：`message_end.seq`、`agent_end.seq`（与 pi wire 事件的配对在 hub 内按消息 id 完成）
-- 持久事件翻译广播：`user/message` → `user_message` echo（带 clientId、meta）；`turn/retried` → `turn_retried` 广播
+persist→wire 的翻译/富化收敛在 **`ChatWireProjector`**（`server/chat-wire-projector.ts`，结构化类型、零框架依赖的纯状态机）：消费 log 事件产出 echo/`turn_retried` 广播、维护 `pendingClientId`/引用→seq 配对/run 级 messageId 序列/`lastTurnEndSeq`，并对 pi wire 事件做富化。hub 只保留 channel/run 生命周期、快照压缩与 fanout——协议翻译的外部不变量（persist-before-callback 引用配对、pi 顺序流模型）从 hub 的跨方法共享可变状态收敛为 projector 的模块内局部状态，projector 可独立单测（无 runtime mock）。
 
 clientId 传递：WS 层 `attachment.sendMessage(content, attachments, clientId?)` → hub 侧拼 echo（实现时二选一：SendMessageMeta 扩展或回调回传，契约测试钉住「echo.seq == user/message seq」）。compaction/repair 事件经此通道到达但不上 wire（无 UI 效果）。
 

--- a/docs/dev/features/2026-09-05-chat-refactor/design.md
+++ b/docs/dev/features/2026-09-05-chat-refactor/design.md
@@ -43,6 +43,7 @@ chat（每 session 一条，`chat-session-runtime.ts`）与 bus（全局一条�
 | 4 | 前端四层 | L1 通用 WS 抽象（chat/bus 共用）→ L2 per-session 域状态 store（统管消息/连接投影/分页/游标，ws 生命周期为其 action）→ L3 身份化 reducer + 视图模型 → L4 纯渲染 |
 | 5 | trigger 收口 + 服务端性能纳入本次 | 实现分 PR，同一 design doc |
 | 6 | 快照机制保留 | 进行中 run 的流式部分无持久化形态，attach 时的压缩快照（`runEvents`）与游标重放并存、按身份去重 |
+| 7 | control 事件落库 | `control/requested`/`control/resolved` 进 SessionEventMap（append → emit，persist-before-callback 同款）；wire 事件附 seq 并纳入游标推进集合；`rejectAll`(abort) 补发 `resolved {aborted}` 修多端缺口；pending 投影 = requested 未配对 resolved 且无 `turn/end` 隔断（repair 合成的 turn/end 自动排除崩溃悬空）。快照收缩见 §1.8 |
 
 ## §1 Wire 协议 v2（`contracts/websocket.ts`）
 
@@ -117,13 +118,15 @@ connect URL 增加可选 query 参数 `since`（数字，**取值域 ≥ -1**：
 | 旧 app + 新 server | 旧 app 忽略新事件类型（parse 失败静默丢弃）；新增字段 TypeBox 默认放行 additionalProperties，无破坏 |
 | 新 app + 旧 server | 无 `session_ready` → 回退 legacy 对账（现有代码路径保留至版本门槛提升） |
 
-### 1.8 快照收缩（与 PR4 联动，服务端不可单方面先行）
+### 1.8 快照收缩与 control 落库（PR4/PR5 联动，服务端不可单方面先行）
 
-快照（`runEvents`）与游标重放的分工审计：已完成消息（`message_end` ⟺ 已落库）在快照里是**纯冗余**——游标重放必然覆盖；快照不可替代的内容只有 in-flight 状态：未关闭消息窗口的 start + 最后一条 update（累积快照语义）、进行中的 tool_execution、**pending control_request（完全不落库，快照是唯一恢复路径）**。
+快照（`runEvents`）与游标重放的分工审计：**已完成消息（`message_end` ⟺ 已落库）在快照里是纯冗余**——游标重放必然覆盖；流式中的 partial 消息与执行中工具也不依赖快照——累积快照语义下，重连后**下一条 live 事件即全量补偿**；快照保留 in-flight 的 start + 最后一条 update 只是把「静默期（LLM 卡顿/长工具）重连的空窗」从几十秒缩到零，是 UX 补偿而非正确性需求。
 
-收缩后快照 = O(in-flight)：pi 顺序流保证同时最多一个开放消息窗口，上界恒小；`recordRunEvent` 的压缩逻辑已是该形状的一半，补「已完成消息丢弃 + 字节预算」即可。静默期（thinking/慢工具）重连的 partial 文本由快照保留的「最后一条 update」覆盖，不依赖下一条 delta。
+**唯一正确性需求是 pending control_request**（不落库、一次性广播、不会再发）——由决策 #7 落库解决。关键不变量：pending 期间 run 阻塞在 gate 上、无后续落库，`control/requested` 必然紧邻 log 尾部，因此冷启动（游标 = HTTP 首页最后 message 的 seq）与重连的游标重放**必然覆盖**它。
 
-前置条件：客户端 reducer 须支持「无完整前史的快照」与「update 懒建气泡」（messageId 机制支持），故归入 PR4 前后端同改，PR1-PR3 期间维持全量快照。
+收缩后快照 = O(in-flight)：开放消息窗口的 start + 最后一条 update + 执行中 tool_execution；control 事件落库后快照中保留双通道副本（reducer 按 requestId 幂等），稳定后可删。快照另加字节/条目预算兜底。
+
+前置条件：客户端 reducer 须支持「无完整前史的快照」与「update 懒建气泡」（messageId 机制支持）+ `applyPersistedEvent` 消费 control 事件，故归入 PR4 前后端同改；core 词汇表与落库点在 PR5 先行。
 
 ## §2 服务端改造
 

--- a/docs/dev/features/2026-09-05-chat-refactor/design.md
+++ b/docs/dev/features/2026-09-05-chat-refactor/design.md
@@ -1,0 +1,253 @@
+# Chat 协议与前端架构重构（协议先行）
+
+- 日期：2026-09-05
+- 分支：`feat/chat-refactor`（多个 PR）
+- 状态：设计已与用户对齐；sub agent review 完成（1C/5I/5M/3m，反馈已全部处理并入正文），待实施
+- 前置：`docs/dev/features/2026-08-21-session-event-log/`（events 表 + 连续 seq + fold 已合入；其 §9 明确留下「WS 直播流协议不改」的缺口，本 feature 补上）
+- 范围：`@spherse/contracts` + `@spherse/server`（协议、hub、trigger 收口、性能）+ `@spherse/app`（四层重划分）
+
+## 背景与动机
+
+chat 前端分层骨架已存在（runtime 连接类 / streaming-store / model 纯函数 / 组件），本次重构解决的是两个根问题及其衍生病灶：
+
+### 根问题 1：wire 协议里消息没有身份
+
+持久层已是标准事件溯源（events 表主键 `(session_id, seq)` 连续单调，`core/store/session.ts`），但 WS 协议未利用：
+
+- 服务端推送的流式事件不带 seq/id（`contracts/websocket.ts`，仅 `turn_withdrawn` 有 seq）
+- 客户端消息身份 `_messageId` 只能靠 HTTP 拉 history 建立；乐观 user 消息靠**内容字符串匹配**去重（`app/features/chat/model/chat-history.ts:49`）
+- 重连恢复 = 重刷最近 20 条 history + `mergeHistoryMessages` 合并 + 缓冲事件重放（`chat-session-runtime.ts:100-158`）；合并时无 id 的流式中气泡被丢弃，若缓冲为空，断线前积累的流式文本从 UI 消失（`chat-history.ts:54`）
+- 发送无 ack：断线窗口内消息成败未知；hub `attachment.sendMessage` 未 ready 时静默丢弃（`chat-session-hub.ts:77`）
+- `MessageList` 用 `key={index}`，loadMore 前插时 React 复用错位（`MessageList.tsx:69`）——transient 消息无稳定 id 是根因
+
+### 根问题 2：WS 连接管理两套重复实现
+
+chat（每 session 一条，`chat-session-runtime.ts`）与 bus（全局一条，`bus-store.ts`）各自实现心跳（30s/60s）、退避表 `[1,2,5,10,30]s`、resume probe（5s），细节分叉：chat 有 fatal 4401 + 重连 10 次上限、bus 无限重连；chat 用 `awaitingPongSince`、bus 用 `lastPongAt`。
+
+### 次级问题（多为根问题下游）
+
+- `streaming-store` 525 行职责过载（连接装配/引用计数 TTL/乐观发送/重试撤回审批/分页/rAF 批处理）；`streaming` 状态双写到 `project-data-store` 6 处手动同步；三条 history HTTP 路径（loadMore/refreshHistory/reconcile）无互斥
+- reducer 依赖「数组最后一条 assistant」定位（`chat-session-reducer.ts:82` 起），`turn_start`/`turn_end` 被解析但忽略——最后一条是历史气泡时新 run 首 tool call 误入
+- trigger run 绕过 hub（`core/factory.ts:103-110` SessionPort 直连 SessionManager）：浏览中的 WS 客户端收不到 trigger run 的流式事件与 run_status，channel.running 与真实状态脱节
+- history 分页每次全量 readEvents + 全量 fold + 内存切片（`core/project-manager.ts:202-210`），O(全 log)
+- 每条出站 WS 事件跑一遍 TypeBox 校验（`ws-chat.ts:31`），流式高频下是纯开销
+- close code 只有 4401，`MigrationRequiredError` 等不可恢复错误走 1000 导致客户端白重连
+
+## 已确认的关键决策
+
+| # | 决策 | 内容 |
+|---|---|---|
+| 1 | 协议先行 | 先定 contracts（seq/echo/since 重放/close code），再动前端；避免 reducer 合并语义写两遍 |
+| 2 | 重放词汇 = 原始持久化事件 | connect 带 `since`，服务端重放 `seq > since` 的**原始 SessionEvent**（非投影 entries）——撤回/重试的「删除」语义天然表达，无 fold 成本 |
+| 3 | 游标 = 客户端 per-connection 状态 | 保留多客户端同看一个 session 的多对一模型；服务端不存 session 级游标 |
+| 4 | 前端四层 | L1 通用 WS 抽象（chat/bus 共用）→ L2 per-session 域状态 store（统管消息/连接投影/分页/游标，ws 生命周期为其 action）→ L3 身份化 reducer + 视图模型 → L4 纯渲染 |
+| 5 | trigger 收口 + 服务端性能纳入本次 | 实现分 PR，同一 design doc |
+| 6 | 快照机制保留 | 进行中 run 的流式部分无持久化形态，attach 时的压缩快照（`runEvents`）与游标重放并存、按身份去重 |
+
+## §1 Wire 协议 v2（`contracts/websocket.ts`）
+
+### 1.1 连接握手与重放流程
+
+connect URL 增加可选 query 参数 `since`（数字，客户端已应用的最高 seq）。attach 成功（restore ready）后服务端按序发送：
+
+```
+1. session_ready   { lastSeq, replay: true }     ← 能力握手 + 服务端当前最高 seq
+2. replay_events   { events: SessionEvent[] }     ← 仅当 since 存在：seq > since 升序，分批（每批 ≤200）
+3. replay_done     {}                             ← 重放结束标记
+4. （现有流程）当前 run 压缩快照 + run_status
+5. 进入正常订阅
+```
+
+关键实现约束（hub）：
+
+- 重放数据源用 channel.runtime 持有的**内存事件日志尾部**同步切片（经 SessionManager 门面读取，见 §2.2），切完在同一 tick 内加入 subscribers——避免「读期间新事件既不在重放里又未订阅到」的缝隙（Node 单线程 + better-sqlite3 同步读，天然原子）；**replay 分批为纯同步循环，不 yield 事件循环**（若需异步背压则改为「先订阅、后重放、按 seq 幂等去重」的顺序无关方案，二选一，实现时定死并加契约测试）
+- 回退判定：新 server 协议保证 `session_ready` 恒为 attach 后首个事件——新客户端以「收到的首个事件不是 `session_ready`」判定旧 server，走 legacy 对账路径（web PWA 连旧桌面 server 的兼容层，退出条件见 §7）；不用超时判定，避免 restore 慢导致误回退
+- 旧客户端收到新事件类型：其内置 contracts 的 closed union parse 失败 → 现有 runtime 静默丢弃，无破坏（`chat-session-runtime.ts` onmessage try/catch）
+
+### 1.2 服务端 → 客户端事件变更
+
+| 事件 | 变更 | 说明 |
+|---|---|---|
+| `user_message`（新增） | `{ seq, message, clientId?, source?, triggerName? }` | **user 消息回显/ack**。hub 在 `user/message` 落库后广播给全部订阅者；发送方按 `clientId` 结算乐观消息，其他客户端按 seq 插入。`source`/`triggerName` 透传 `SendMessageMeta`（`core/session/events.ts:6-9`，已存在）。HTTP 静默发送路径（`startDetachedRun`）无 clientId，echo 照发、仅推进其他端游标，行为自洽 |
+| `message_end` | 增加 `seq?: number` | = 对应持久化事件（`assistant/message` 或 `tool/result`）的 seq；流式气泡获得持久身份 |
+| `agent_end` | 增加 `seq?: number` | = `turn/end` 的 seq |
+| `turn_retried`（新增） | `{ seq, abandonedSeqs: number[] }` | retry 的多端同步：今天只有发送方本地知道重试弃置，其他端靠 HTTP 对账补 |
+| `session_ready` / `replay_events` / `replay_done`（新增） | 见 1.1 | |
+| `replay_events.events[]` | 原始 SessionEvent 信封（type/seq/time/data） | 复用 `@spherse/core` `SessionEventMap` 词汇，contracts 侧 schema 镜像导出 |
+
+不变的部分：pi 流式事件族（`message_start/update`、`tool_execution_*`）payload 透传不动；流式消息的 stitch 身份用 payload 自带的 pi message `id`（`log-agent-event.ts:31` 已在用），`message_end` 到达后绑定 `id → seq`。
+
+### 1.3 客户端 → 服务端事件变更
+
+`message` 增加 `clientId?: string`（客户端生成的 uuid，**可选**——旧客户端发送不带 clientId 时 `parseChatClientMessage` 必须放行，server 对缺失 clientId 的消息不做结算、echo 照发；若做成必填会直接打断「旧 app + 新 server」组合的发消息路径）。用于 `user_message` 回显结算。
+
+### 1.4 游标语义
+
+- 游标 = 客户端本地已应用事件的最高 seq；更新一律 `cursor = max(cursor, seq)`，**永不回退**——`turn_withdrawn` 的 wire seq 是被撤回 user 消息的 seq（小于当前游标，因被撤的 assistant `message_end.seq` 更大），只用于截断不用于推进回退
+- live 推进集合：`user_message`、`message_end`、`agent_end`、`turn_retried`、`turn_withdrawn`（每条 wire 事件携带的 seq）
+- 重放推进：`replay_events` 中每条事件（含 no-op 的 `turn/start`、`compaction/applied`）都推进
+- `turn/start`、`compaction/applied` 不上 wire（live 场景无 UI 效果；重放场景已覆盖；冷启动走 HTTP 投影）——游标因此可能出现空洞，无害：重放按 `seq > since` 读取是幂等超集
+- TTL 清理消息时**保留游标**，重 attach 走增量重放；页面刷新游标丢失 = 冷启动全量，可接受
+
+### 1.5 重放与快照的重叠去重（reducer 不变量）
+
+重放（持久事件，按 seq）与快照（pi wire 事件，按 message id）存在交集。规则：
+
+1. 持久事件按 seq 幂等：本地已有该 seq → skip
+2. wire 事件按 message id stitch；`message_start` 到达时该 id 已绑定 seq（重放已给过）→ skip
+3. `message_end` 的 seq 已知但 id 未知（重放在先）→ 以持久事件为准，跳过 wire 侧内容
+4. 以上不变量用 reducer 性质测试锁住（§9）
+
+### 1.6 close code 族
+
+```
+4400  PROTOCOL_ERROR        非法客户端消息（替代现在的 error 事件后 1000）
+4401  SESSION_UNRECOVERABLE （现有）
+4402  MIGRATION_REQUIRED    restore 抛 MigrationRequiredError
+```
+
+客户端 fatal 集合 = {4400, 4401, 4402}，收到即停止重连——4400 必须入 fatal：客户端自身 bug 产生非法消息时若当瞬时错误处理，会陷入「connect → send → 4400 → reconnect」死循环（现状是 error 事件软失败 + 连接保持，改 close 后语义必须配套收紧）。瞬时错误维持 1000 关闭触发重连。
+
+### 1.7 版本兼容矩阵
+
+| 组合 | 行为 |
+|---|---|
+| 新 app + 新 server | 完整 v2：游标重放、echo、ack |
+| 旧 app + 新 server | 旧 app 忽略新事件类型（parse 失败静默丢弃）；新增字段 TypeBox 默认放行 additionalProperties，无破坏 |
+| 新 app + 旧 server | 无 `session_ready` → 回退 legacy 对账（现有代码路径保留至版本门槛提升） |
+
+## §2 服务端改造
+
+### 2.1 seq 上 wire 的内部通道
+
+优先复用 `SessionEventLog` 现成的订阅机制：`appendBatch` 落库后已同步 notify 订阅者（`event-log.ts:50-58,66-71`），且覆盖面比扩展 onEvent 更全（`withdrawLastTurn`、afterTurn hooks、repairLog 追加都走 append 而无 onEvent）。通道选型：hub 经 SessionManager 订阅目标 session 的事件日志，收到带 seq 的 `SessionEvent` 后做两件事：
+
+- wire 事件富化：`message_end.seq`、`agent_end.seq`（与 pi wire 事件的配对在 hub 内按消息 id 完成）
+- 持久事件翻译广播：`user/message` → `user_message` echo（带 clientId、meta）；`turn/retried` → `turn_retried` 广播
+
+clientId 传递：WS 层 `attachment.sendMessage(content, attachments, clientId?)` → hub 侧拼 echo（实现时二选一：SendMessageMeta 扩展或回调回传，契约测试钉住「echo.seq == user/message seq」）。compaction/repair 事件经此通道到达但不上 wire（无 UI 效果）。
+
+### 2.2 ranged read 与 SessionManager 门面
+
+`SessionStore` 增加 `readEventsAfter(sessionId, sinceSeq, limit)`：SQL 下推 `WHERE session_id=? AND seq>? ORDER BY seq LIMIT ?`，主键天然索引，O(limit)。
+
+hub 持有的是 `SessionManager` 而非 store，且其 sessions map 为 private、server 侧不持有 SessionStore 引用——已在 `SessionManager` 上补**门面方法**：`readSessionEventsAfter(agentId, sessionId, sinceSeq, limit)`（优先内存日志尾部，未激活 session 回落 store 查询）、`getSessionLastSeq(agentId, sessionId)`（返回 -1 表示空）与 `subscribeSessionEvents(sessionId, listener)`。这是 §1.1「同 tick 切片 + 订阅」论述成立的前置条件，纳入 §9 契约测试。重放不做 fold——原始事件直出，这是「重放词汇 = 原始事件」决策的性能红利。
+
+### 2.3 trigger run 收口
+
+现状：trigger capability 经 `factory.ts:103-110` 的 sessionPort 直连 SessionManager，绕过 hub。改造需要 core 与 server 两侧配合（仅 server 侧不可行——capabilities 函数执行时 sessionRuntime 尚未创建（`factory.ts:81-84` vs `:101`）、TriggerManager 构造后 port 不可替换、`SessionPort.sendMessage` 无 agentId 参数（hub 建 channel 必需）、hub 无带 meta 的公共 startRun 变体）：
+
+- core：`assembleProject` 增加可选 `wrapSessionPort?: (port: SessionPort) => SessionPort` 钩子，在 sessionRuntime 创建后、capabilities init 前应用；`SessionPort.sendMessage` 调用上下文补 agentId（签名或 meta 扩展，二选一）
+- server：包装实现将 trigger 的 sendMessage 改走 hub 公共 API `startRunWithMeta(channel, meta, executor)`；hub 时序无问题（hub 在 server index 创建，早于按需 assembleProject）
+- 行为对齐：trigger 撞上运行中 session 的冲突语义不变（今天 `ensureNotBusy` 抛 ValidationError → trigger failed；收口后 hub `startRun` 抛 ConflictError → 同样 failed，错误路径统一）
+- 按仓库契约测试红线，server/desktop 对新 SessionPort 门面各补一条不 mock 被测方法的真实边界测试
+- trigger 完成通知仍走 bus trigger 频道（TriggerEventBridge 的 query 失效职责不变，删掉的只是 refreshHistory 部分，见 §7）
+
+### 2.4 分页性能（增量 fold 缓存）
+
+`getRecentSessionHistory`（`project-manager.ts:181`）的 events 路径从「全量读 + 全量 fold + 切片」改为 **fold-on-write 缓存**：缓存挂在 project-manager 的会话历史读取处（按 sessionId 键控、事件数作版本号失效、LRU 上限），**不挂在 SessionManager 内存日志上**——未激活 session（未 create/restore，无内存日志）的分页读也要覆盖，否则列表/预览路径的 O(全 log) 依旧。正确性用性质测试锁住：「任意事件序列后，缓存投影 == 全量重 fold」。legacy 路径不动。
+
+### 2.5 出站校验降级
+
+`ws-chat.ts:31` 的 `parseChatServerEvent` 出站校验移到测试（server 契约测试对每类事件 pin schema），生产路径直发；保留 `SPHERSE_VALIDATE_WS=1` 环境变量开关供调试。
+
+## §3 前端 L1：通用 WS 抽象（`app/src/lib/ws/`）
+
+`WsConnection` 类，配置化策略，chat 与 bus 共用：
+
+```ts
+interface WsConnectionConfig {
+  url: () => string;                       // 每次连接时求值（token 可能刷新）
+  heartbeat: { pingIntervalMs; pongTimeoutMs };
+  backoffMs: number[];                     // chat/bus 同表 [1,2,5,10,30]s
+  maxRetries: number;                      // chat: 10, bus: Infinity
+  fatalCloseCodes: Set<number>;            // chat: {4401,4402}, bus: 空
+  probeTimeoutMs: number;                  // resume probe 用
+}
+```
+
+- 显式状态机：`connecting → open → (waiting-backoff → connecting)* → failed | fatal | closed`——`waiting-backoff` 独立成态，修复 ConnectionBanner 把退避等待与连接尝试混为一谈的问题
+- API：`send(data)`、`close()`、`probe()`、`onMessage`、`onStateChange`；心跳采用 chat 侧现语义（`awaitingPongSince` 精确等待，bus 向其对齐）
+- 纯 TS 类不进 React/zustand；bus-store 保留 zustand 壳（resumedAt、频道订阅状态），连接委托给 WsConnection，对外 API 不变——5 个 bus 桥（ContentQueryBridge 等）零改动
+
+## §4 前端 L2：chat session 域 store
+
+新 store（`features/chat/runtime/` 下，命名实现时定，倾向 `chat-session-store`）取代 `streaming-store` + `chat-runtime-registry` + `ChatSessionRuntime` 三件套：
+
+- **状态**：`sessions: Record<sessionId, ChatSessionState>`，每项含 `connectionStatus`（L1 状态机投影）、`historyStatus`、`messages`（视图态 ChatMessage）、`streaming`、分页 `{hasMore, oldestLoadedId, loading}`、`cursor`、`scrollPosition`
+- **连接**：每 session 一个 `WsConnection` 实例（url 带 since），attach/detach 引用计数与 TTL 沿用现语义；TTL 清消息、保游标；`ChatSessionRuntime` 类溶解——连接策略进 L1，**重连 reconcile 被游标重放整体取代（删除）**；legacy 回退是另一段独立逻辑（「首事件非 session_ready → HTTP 首页拉取 + 合并」的冷对账），落在新 store 内保留并用结构测试钉住存在性；send/abort/retry/withdraw 收敛为 store action
+- **action**：`send`（乐观插入 + clientId + echo 结算）、`abort`、`retry`、`withdraw`、`resolveControl`、`loadMore`、UI SDK 的 `sendMessage` 复用同一 action（HTTP fallback 保留在 action 内，消灭第三条发送路径）
+- **派生**：`streamingSessionIds` 改为 selector 导出，`project-data-store` 删除 streaming 字段（只留 initialMessage），消灭 6 处手动同步
+- **事件批处理**：保留 rAF 批量归约，补 `setTimeout` 兜底修后台 tab 冻结
+- 新 store 必须加入 `project-lifecycle.ts` 的 `clearProject` 级联清单（`project-lifecycle.structure.test.ts` 会强制）
+- 命名清理：现 `ChatRuntimeProvider`（runtime-context.tsx，只是 `{sessionId, agentId}` context）更名（如 `ChatAgentContext`），让出 Runtime 词汇
+
+## §5 前端 L3：身份化 reducer + 视图模型
+
+- **双入口归约**：`applyWireEvent`（pi 流式事件，按 message id stitch）+ `applyPersistedEvent`（原始 SessionEvent，按 seq 幂等）——撤回/重试的截断走两条明确路径：wire 侧 `turn_withdrawn` 按「删至该 user seq」、persisted 侧按 `[data.seq, event.seq)` 区间（`fold.ts:95-105`）；`turn/retried` 按 abandonedSeqs 移除——替代 `mergeHistoryMessages` 的 transient 过滤 + 内容匹配合并
+- **turn 感知**：`turn_start`/`agent_end`（= turn/end）维护 run 边界，消息按 turn 归组，废除 `prev[length-1]` 定位——修掉「新 run 首 tool call 误入历史气泡」
+- **冷启动合并**：HTTP 首页 entries 与本地 live 态按 seq/id 合并（现 `_messageId` 机制保留，范围缩小到冷启动 + loadMore）
+- **视图模型下沉**：`groupTurns`、superseded 计算（现渲染期 `MessageList.tsx:37-42`）移到 model 层纯函数输出，渲染层只消费；key 全部用稳定身份（seq / message id / clientId）
+
+## §6 前端 L4：渲染层修复
+
+- `MessageList` key 稳定化（依赖 L3 身份）
+- ConnectionBanner 消费 L1 状态机（`waiting-backoff` 独立文案）
+- `HtmlCard` 取数解耦：previewUrl fetch 从组件抽到注入 loader / query
+- 组件不再 `useStreamingStore.getState()` 反向调 action，统一经 hook
+- 其余小项：Composer mimeType 跟随压缩输出、`findProjectSession` N+1 探测收敛（可与本重构解耦，顺手修）
+
+## §7 拆除项
+
+| 拆除 | 条件 |
+|---|---|
+| `ChatSessionRuntime` + registry + **重连 reconcile** | PR3（游标重放上线；legacy **冷对账**路径保留在新 store，见 §1.7/§4） |
+| `mergeHistoryMessages` transient 过滤 / 内容匹配合并 | PR4（新 reducer） |
+| `TriggerEventBridge` 的 refreshHistory 调用 | PR5（trigger 收口后 live 事件可达；session 列表 query 失效保留） |
+| `project-data-store.streamingSessionIds` | PR3（改 selector） |
+| legacy 冷对账路径（新 app + 旧 server） | 保留至 web 版本兼容门槛提升（`lib/version-compat.ts` minVersion 覆盖 v2 server），单列小 PR 删除 |
+
+## §8 PR 切分
+
+| PR | 内容 | 依赖 |
+|---|---|---|
+| PR1 | contracts v2 + server：echo/seq 富化、since 重放、SessionManager 门面 + readEventsAfter、close code 族、出站校验降级 + 契约测试 | 无 |
+| PR2 | app L1：`WsConnection` + bus-store 迁移（行为对齐测试） | 无（可与 PR1 并行） |
+| PR3 | app L2：session store + 游标重放接入，删重连 reconcile，streaming 派生化 | PR1、PR2 |
+| PR4 | app L3+L4：身份化 reducer、视图模型、渲染修复 | PR3 |
+| PR5 | core+server：trigger 收口（wrapSessionPort 钩子 + port 签名 + hub startRunWithMeta）+ 分页 fold 缓存；删 TriggerEventBridge 的 refreshHistory | PR1 |
+| PR6 | 文档同步 + legacy 冷对账路径清理评估（视版本门槛） | 全部 |
+
+每个 PR 独立可合：PR1/2 无行为耦合，PR3 是最大风险点（连接与数据流同时换），PR4 纯前端可回滚。**PR3 必须在 PR5 合入后才可合**：删 refreshHistory 依赖 trigger 收口在先，否则 attach 中的 session 在 trigger run 期间失去唯一补偿通道（PR5 的 refreshHistory 拆除条目随收口一并落地）。
+
+## §9 测试策略
+
+| 层 | 测试 |
+|---|---|
+| core | `readEventsAfter` 边界（since=0/中间/超尾部）；SessionManager 门面（内存优先/store 回落一致性）；fold 缓存性质测试（随机事件序列 → 缓存投影 == 全量重 fold） |
+| contracts/server | 契约测试：重放顺序（session_ready → replay → replay_done → 快照 → run_status）、echo.seq == user/message seq、message_end.seq 配对、close code 映射、门面契约测试（hub 经门面读到的尾部 == 落库事件）；按仓库红线，server/desktop 对 SessionPort 门面各保留一条不 mock 被测方法的真实边界测试 |
+| app L1 | 状态机单测（退避序列、fatal 停止、probe、pong 超时）；bus 迁移行为对齐测试（订阅重放、resumedAt 语义不变） |
+| app L3 | reducer 性质测试：随机 (live wire + replay + history) 交错流 → 不变量（无重复 seq、id↔seq 绑定一致、重放合并结果 == 全量重建、按 seq 截断正确） |
+| app L2 | store 测试：引用计数/TTL 保游标、乐观消息 echo 结算、断线窗口 send 失败标记、多 session 隔离 |
+| E2E | 断线重连重放（含「断线期间 run 已结束」场景）、双端同看一个 session、trigger run 可见性；合并前 `npm run verify:e2e` |
+
+## 明确不做（本次）
+
+- streaming chunk 落盘（快照机制已覆盖进行中 run）
+- bus WS 与 chat WS 合并为单连接多路复用
+- HTTP history 端点改游标重放协议（冷启动/loadMore 维持 entries 分页）
+- 出站事件的完整 payload schema 化（contracts 精确化另行立项，见 session-event-log「明确不做」）
+- 全量 history 端点删除（遗留面，另行清理）
+- WS 鉴权从 query token 迁移（独立安全问题）
+
+## 风险与对策
+
+| 风险 | 对策 |
+|---|---|
+| 重放与快照重叠去重出错（重复气泡/丢内容） | §1.5 不变量 + reducer 性质测试；PR3 灰度期内保留 HTTP 刷新按钮兜底 |
+| hub 改动破坏多订阅者广播 | hub 单测覆盖多 subscriber echo/重放互不干扰 |
+| bus 迁移波及 5 个桥 | L1 对外 API 与 bus-store 壳不变；E2E bus 场景回归 |
+| trigger 收口改变错误时序 | 收口前后 trigger 失败路径行为对齐测试（ConflictError ↔ ensureNotBusy） |
+| 新 app + 旧 server 回退路径腐化 | legacy 对账路径用结构测试钉住存在性，版本门槛提升后立即删 |
+| TTL 保留游标导致陈旧 session 重放放大 | 游标为纯数字，内存可忽略；重放量 O(增量) 由 readEventsAfter 保证 |
+| streaming 双写删除引发 UI 回归 | PR3 内 selector 替换 + SessionRow spinner 单测 |

--- a/docs/dev/features/2026-09-05-chat-refactor/design.md
+++ b/docs/dev/features/2026-09-05-chat-refactor/design.md
@@ -48,7 +48,7 @@ chat（每 session 一条，`chat-session-runtime.ts`）与 bus（全局一条�
 
 ### 1.1 连接握手与重放流程
 
-connect URL 增加可选 query 参数 `since`（数字，客户端已应用的最高 seq）。attach 成功（restore ready）后服务端按序发送：
+connect URL 增加可选 query 参数 `since`（数字，**取值域 ≥ -1**：`-1` 表示从头全量重放，与 `getSessionLastSeq` 的空日志哨兵值一致；非整数或 < -1 忽略、视为未携带）。attach 成功（restore ready）后服务端按序发送：
 
 ```
 1. session_ready   { lastSeq, replay: true }     ← 能力握手 + 服务端当前最高 seq
@@ -69,13 +69,13 @@ connect URL 增加可选 query 参数 `since`（数字，客户端已应用的�
 | 事件 | 变更 | 说明 |
 |---|---|---|
 | `user_message`（新增） | `{ seq, message, clientId?, source?, triggerName? }` | **user 消息回显/ack**。hub 在 `user/message` 落库后广播给全部订阅者；发送方按 `clientId` 结算乐观消息，其他客户端按 seq 插入。`source`/`triggerName` 透传 `SendMessageMeta`（`core/session/events.ts:6-9`，已存在）。HTTP 静默发送路径（`startDetachedRun`）无 clientId，echo 照发、仅推进其他端游标，行为自洽 |
-| `message_end` | 增加 `seq?: number` | = 对应持久化事件（`assistant/message` 或 `tool/result`）的 seq；流式气泡获得持久身份 |
+| `message_end` | 增加 `seq?: number` 与 `messageId?: string` | seq = 对应持久化事件（`assistant/message` 或 `tool/result`）的 seq；流式气泡获得持久身份。配对机制见下方「不变的部分」 |
 | `agent_end` | 增加 `seq?: number` | = `turn/end` 的 seq |
 | `turn_retried`（新增） | `{ seq, abandonedSeqs: number[] }` | retry 的多端同步：今天只有发送方本地知道重试弃置，其他端靠 HTTP 对账补 |
 | `session_ready` / `replay_events` / `replay_done`（新增） | 见 1.1 | |
 | `replay_events.events[]` | 原始 SessionEvent 信封（type/seq/time/data） | 复用 `@spherse/core` `SessionEventMap` 词汇，contracts 侧 schema 镜像导出 |
 
-不变的部分：pi 流式事件族（`message_start/update`、`tool_execution_*`）payload 透传不动；流式消息的 stitch 身份用 payload 自带的 pi message `id`（`log-agent-event.ts:31` 已在用），`message_end` 到达后绑定 `id → seq`。
+不变的部分：pi 流式事件族（`message_start/update`、`tool_execution_*`）payload 透传不动。**流式消息的 wire 身份是 hub 生成的 `messageId`**（run 级自增 `m1/m2/...`，由 hub 注入 `message_start/update/end`）：pi message payload 运行时**没有 id 字段**（`pi-ai` 构造 assistant message 不赋 id，类型亦未声明，已实证 `anthropic-messages.js` stream 构造），不能作为 stitch 身份。`message_end.seq` 的配对机制是**实例引用相等**：`persistMiddleware` 落库时传入的 message 实例与 wire `message_end` 的 payload 是同一引用（appendBatch 不 clone），hub 以 run 级 WeakMap 引用→seq 配对——该行为由 server 真 runtime 契约测试钉住。
 
 ### 1.3 客户端 → 服务端事件变更
 
@@ -91,12 +91,13 @@ connect URL 增加可选 query 参数 `since`（数字，客户端已应用的�
 
 ### 1.5 重放与快照的重叠去重（reducer 不变量）
 
-重放（持久事件，按 seq）与快照（pi wire 事件，按 message id）存在交集。规则：
+重放（持久事件，按 seq）与快照（pi wire 事件，按 hub 生成的 messageId）存在交集。规则：
 
 1. 持久事件按 seq 幂等：本地已有该 seq → skip
-2. wire 事件按 message id stitch；`message_start` 到达时该 id 已绑定 seq（重放已给过）→ skip
-3. `message_end` 的 seq 已知但 id 未知（重放在先）→ 以持久事件为准，跳过 wire 侧内容
-4. 以上不变量用 reducer 性质测试锁住（§9）
+2. wire 事件按 messageId stitch；`message_start` 到达时该 messageId 已绑定 seq（重放已给过）→ skip
+3. `message_end` 的 seq 已知但 messageId 未见过（重放在先）→ 以持久事件为准，跳过 wire 侧内容
+4. live 期间 `message_end` 同时携带 messageId 与 seq，客户端据此建立 messageId→seq 绑定，供重连快照去重
+5. 以上不变量用 reducer 性质测试锁住（§9）
 
 ### 1.6 close code 族
 
@@ -245,6 +246,8 @@ interface WsConnectionConfig {
 | 风险 | 对策 |
 |---|---|
 | 重放与快照重叠去重出错（重复气泡/丢内容） | §1.5 不变量 + reducer 性质测试；PR3 灰度期内保留 HTTP 刷新按钮兜底 |
+| `message_end.seq` 引用配对依赖 persistMiddleware 不 clone 落库实例 | 真 runtime 契约测试钉住引用一致性；pi/core 升级若引入 clone，富化退化为无 seq（有守卫、不崩），契约测试立即失败暴露 |
+| pi message 无 id、messageId 由 hub 生成 | messageId 只在 wire 层使用、run 级作用域，不落库、不进 core；重连快照保留 messageId（runEvents 存富化后事件） |
 | hub 改动破坏多订阅者广播 | hub 单测覆盖多 subscriber echo/重放互不干扰 |
 | bus 迁移波及 5 个桥 | L1 对外 API 与 bus-store 壳不变；E2E bus 场景回归 |
 | trigger 收口改变错误时序 | 收口前后 trigger 失败路径行为对齐测试（ConflictError ↔ ensureNotBusy） |

--- a/docs/dev/features/2026-09-05-chat-refactor/plan.md
+++ b/docs/dev/features/2026-09-05-chat-refactor/plan.md
@@ -7,7 +7,7 @@
 - [x] contracts：`session_ready` / `replay_events` / `replay_done` / `user_message` / `turn_retried` schema；`message_end.seq` / `agent_end.seq` 可选字段；`message.clientId`（**可选**，旧客户端发送不带 clientId 必须放行）；close code 4400/4402；`SessionEvent` 信封 schema 镜像导出
 - [x] core：`SessionStore.readEventsAfter(sessionId, sinceSeq, limit)` SQL 下推 + 单测
 - [x] core：`SessionManager` 门面 `readSessionEventsAfter` / `getSessionLastSeq`（内存日志优先、store 回落）+ 契约测试
-- [x] server hub：经 `SessionEventLog.subscribe` 订阅落库事件（`event-log.ts:50-58` 现成机制）——`user/message` → `user_message` echo（clientId + source/triggerName）；`turn/retried` → `turn_retried` 广播；`message_end`/`agent_end` seq 富化
+- [x] server hub：经 `SessionEventLog.subscribe` 订阅落库事件（`event-log.ts:50-58` 现成机制）——`user/message` → `user_message` echo（clientId + source/triggerName）；`turn/retried` → `turn_retried` 广播；`message_end`/`agent_end` seq 富化；翻译/富化收敛在 `ChatWireProjector` 纯状态机（独立单测，hub 只留 channel/run 生命周期与 fanout）
 - [x] server hub：attach 握手流程（session_ready → since 重放 → replay_done → 快照 → run_status），门面同步切片 + 同 tick 订阅；分批纯同步循环不 yield 事件循环
 - [x] server ws-chat：close code 映射（4400/4402）；出站 TypeBox 校验移到测试、保留 `SPHERSE_VALIDATE_WS` 开关
 - [x] 契约测试：重放顺序、echo.seq 配对、message_end.seq 配对、close code、多 subscriber 互不干扰

--- a/docs/dev/features/2026-09-05-chat-refactor/plan.md
+++ b/docs/dev/features/2026-09-05-chat-refactor/plan.md
@@ -36,6 +36,7 @@
 
 - [ ] `applyWireEvent`（message id stitch + turn 感知，废除尾部定位）+ `applyPersistedEvent`（seq 幂等、按 seq 截断/移除）
 - [ ] 冷启动 entries 合并缩小化；删 `mergeHistoryMessages` transient 过滤/内容匹配
+- [ ] reducer 支持「无完整前史的快照」与 update 懒建气泡；服务端同步落地快照收缩为 O(in-flight)（丢已完成消息 + 字节预算，见 design §1.8）
 - [ ] 视图模型下沉：groupTurns / superseded 进 model 层；MessageList key 稳定化
 - [ ] ConnectionBanner 消费新状态机（waiting-backoff 独立文案）
 - [ ] HtmlCard 取数解耦（loader 注入）；组件去除 `getState()` 反向调用

--- a/docs/dev/features/2026-09-05-chat-refactor/plan.md
+++ b/docs/dev/features/2026-09-05-chat-refactor/plan.md
@@ -1,0 +1,63 @@
+# Chat 重构实施计划
+
+对应 [design.md](./design.md)。每个 PR 独立实现、独立 review、独立合入；勾选随实施更新。
+
+## PR1 协议 v2（contracts + server）
+
+- [x] contracts：`session_ready` / `replay_events` / `replay_done` / `user_message` / `turn_retried` schema；`message_end.seq` / `agent_end.seq` 可选字段；`message.clientId`（**可选**，旧客户端发送不带 clientId 必须放行）；close code 4400/4402；`SessionEvent` 信封 schema 镜像导出
+- [x] core：`SessionStore.readEventsAfter(sessionId, sinceSeq, limit)` SQL 下推 + 单测
+- [x] core：`SessionManager` 门面 `readSessionEventsAfter` / `getSessionLastSeq`（内存日志优先、store 回落）+ 契约测试
+- [x] server hub：经 `SessionEventLog.subscribe` 订阅落库事件（`event-log.ts:50-58` 现成机制）——`user/message` → `user_message` echo（clientId + source/triggerName）；`turn/retried` → `turn_retried` 广播；`message_end`/`agent_end` seq 富化
+- [x] server hub：attach 握手流程（session_ready → since 重放 → replay_done → 快照 → run_status），门面同步切片 + 同 tick 订阅；分批纯同步循环不 yield 事件循环
+- [x] server ws-chat：close code 映射（4400/4402）；出站 TypeBox 校验移到测试、保留 `SPHERSE_VALIDATE_WS` 开关
+- [x] 契约测试：重放顺序、echo.seq 配对、message_end.seq 配对、close code、多 subscriber 互不干扰
+- [x] 兼容验证：旧 app 连新 server 不报错（新增事件被丢弃、新增字段放行）**且旧 app 发送不带 clientId 的 message 成功**（`agent-event-parse` 返回 undefined 丢弃新事件 + 单测钉住；clientId 可选已由 wire schema 测试钉住）
+
+## PR2 前端 L1 WsConnection（可与 PR1 并行）
+
+- [ ] `lib/ws/WsConnection`：状态机（connecting/open/waiting-backoff/failed/fatal/closed）、心跳、退避、probe、fatalCodes、maxRetries 配置化
+- [ ] 状态机单测：退避序列、耗尽转 failed、fatal 停止、pong 超时、probe
+- [ ] bus-store 迁移到 WsConnection（对外 API、resumedAt 语义不变），行为对齐测试
+- [ ] E2E：bus 相关场景回归（fs-watch 失效、trigger 通知）
+
+## PR3 前端 L2 session store + 游标重放（依赖 PR1、PR2，且须在 PR5 合入后合并）
+
+- [ ] 新 `chat-session-store`：状态结构（connection/history/messages/streaming/分页/cursor/scroll）
+- [ ] attach/detach 引用计数 + TTL（清消息保游标）；`ChatSessionRuntime`/registry 溶解删除，**删的是重连 reconcile**
+- [ ] 游标重放接入：connect 带 since、首事件非 `session_ready` 判定旧 server → legacy **冷对账**路径（HTTP 首页拉取 + 合并）保留在新 store，结构测试钉住存在性
+- [ ] actions：send（乐观 + clientId + echo 结算）/ abort / retry / withdraw / resolveControl / loadMore；UI SDK send-message 复用同 action
+- [ ] `streamingSessionIds` selector 化；`project-data-store` 删 streaming 字段
+- [ ] rAF 批处理补 setTimeout 兜底
+- [ ] 加入 `project-lifecycle` clearProject 级联（过 structure test）
+- [ ] streaming-store 消费方迁移点位清单：`web-resume-probe.ts`（resumeProbeAll）、`ApprovalNoticeBridge.tsx`、`ui-sdk/handlers/send-message.ts`、`useChatScroll.ts`（scrollPosition）、`chat/index.tsx`（hasMore/loadingMore/loadMore）、`TriggerEventBridge.tsx`、`project-lifecycle.ts`——统一改新 store 引用，不留旧导出名过渡
+- [ ] store 测试 + E2E 断线重连重放（含断线期间 run 结束、双端同 session）
+
+## PR4 前端 L3/L4 reducer + 渲染
+
+- [ ] `applyWireEvent`（message id stitch + turn 感知，废除尾部定位）+ `applyPersistedEvent`（seq 幂等、按 seq 截断/移除）
+- [ ] 冷启动 entries 合并缩小化；删 `mergeHistoryMessages` transient 过滤/内容匹配
+- [ ] 视图模型下沉：groupTurns / superseded 进 model 层；MessageList key 稳定化
+- [ ] ConnectionBanner 消费新状态机（waiting-backoff 独立文案）
+- [ ] HtmlCard 取数解耦（loader 注入）；组件去除 `getState()` 反向调用
+- [ ] 顺手修：Composer mimeType、`ChatRuntimeProvider` 更名
+- [ ] reducer 性质测试（随机事件流不变量）+ store 结构测试更新
+
+## PR5 trigger 收口 + 分页性能（core + server，依赖 PR1）
+
+- [ ] core：`assembleProject` 增加 `wrapSessionPort?: (port: SessionPort) => SessionPort` 钩子（sessionRuntime 创建后、capabilities init 前应用）；`SessionPort.sendMessage` 调用上下文补 agentId
+- [ ] server：hub 公开 `startRunWithMeta(channel, meta, executor)`；trigger 的 sendMessage 经 wrapSessionPort 走 hub（meta 带 source/triggerName）
+- [ ] SessionPort 门面契约测试（server/desktop 各一条不 mock 被测方法，仓库红线）
+- [ ] trigger 冲突语义对齐测试（ConflictError ↔ ensureNotBusy 行为等价）
+- [ ] fold-on-write 投影缓存挂 project-manager 层（按 session 键控、事件数版本号失效、LRU 上限，覆盖未激活 session）+ `getRecentSessionHistory` 走缓存切片；性质测试（缓存 == 全量重 fold）
+- [ ] 删 `TriggerEventBridge` 的 refreshHistory 调用（trigger run 此后 live 可达；query 失效保留）
+- [ ] E2E：trigger run 在已打开 session 页面可见（run_status + 流式）
+
+## PR6 收尾
+
+- [ ] doc-sync：`docs/official/architecture/chat.md`（协议 v2、四层、游标）、`frontend.md`（bus 层、project-data-store 字段变化）、`packages/app/README.md`（状态归属表）、backlog
+- [ ] 评估 legacy 对账路径删除条件（web 版本门槛）；可删则删 + 结构测试更新
+- [ ] 全量 `npm run verify:e2e`
+
+## 里程碑顺序
+
+PR1 → (PR2 ∥ PR5) → PR3 → PR4 → PR6。PR3 为关键路径且必须晚于 PR5（删 refreshHistory 依赖 trigger 收口在先）；合入前 PR1 契约测试必须全绿。

--- a/docs/dev/features/2026-09-05-chat-refactor/plan.md
+++ b/docs/dev/features/2026-09-05-chat-refactor/plan.md
@@ -34,19 +34,20 @@
 
 ## PR4 前端 L3/L4 reducer + 渲染
 
-- [ ] `applyWireEvent`（message id stitch + turn 感知，废除尾部定位）+ `applyPersistedEvent`（seq 幂等、按 seq 截断/移除）
+- [ ] `applyWireEvent`（message id stitch + turn 感知，废除尾部定位）+ `applyPersistedEvent`（seq 幂等、按 seq 截断/移除，**消费 control/requested、control/resolved**）
 - [ ] 冷启动 entries 合并缩小化；删 `mergeHistoryMessages` transient 过滤/内容匹配
-- [ ] reducer 支持「无完整前史的快照」与 update 懒建气泡；服务端同步落地快照收缩为 O(in-flight)（丢已完成消息 + 字节预算，见 design §1.8）
+- [ ] reducer 支持「无完整前史的快照」与 update 懒建气泡；服务端同步落地快照收缩为 O(in-flight) + 字节预算（design §1.8）；control 事件按 requestId 幂等去重（快照/重放双通道）
 - [ ] 视图模型下沉：groupTurns / superseded 进 model 层；MessageList key 稳定化
 - [ ] ConnectionBanner 消费新状态机（waiting-backoff 独立文案）
 - [ ] HtmlCard 取数解耦（loader 注入）；组件去除 `getState()` 反向调用
 - [ ] 顺手修：Composer mimeType、`ChatRuntimeProvider` 更名
 - [ ] reducer 性质测试（随机事件流不变量）+ store 结构测试更新
 
-## PR5 trigger 收口 + 分页性能（core + server，依赖 PR1）
+## PR5 trigger 收口 + control 落库 + 分页性能（core + server，依赖 PR1）
 
 - [ ] core：`assembleProject` 增加 `wrapSessionPort?: (port: SessionPort) => SessionPort` 钩子（sessionRuntime 创建后、capabilities init 前应用）；`SessionPort.sendMessage` 调用上下文补 agentId
 - [ ] server：hub 公开 `startRunWithMeta(channel, meta, executor)`；trigger 的 sendMessage 经 wrapSessionPort 走 hub（meta 带 source/triggerName）
+- [ ] core：SessionEventMap 新增 `control/requested` / `control/resolved`；AgentRunner 的 control sink 包装层 append → emit + seq 回填 wire 事件；`rejectAll`(abort) 补发 `resolved {aborted}`；fold pending 投影（requested 未配对 resolved 且无 turn/end 隔断）+ contracts 信封变体
 - [ ] SessionPort 门面契约测试（server/desktop 各一条不 mock 被测方法，仓库红线）
 - [ ] trigger 冲突语义对齐测试（ConflictError ↔ ensureNotBusy 行为等价）
 - [ ] fold-on-write 投影缓存挂 project-manager 层（按 session 键控、事件数版本号失效、LRU 上限，覆盖未激活 session）+ `getRecentSessionHistory` 走缓存切片；性质测试（缓存 == 全量重 fold）

--- a/docs/official/architecture/chat.md
+++ b/docs/official/architecture/chat.md
@@ -26,25 +26,27 @@ Composer.send
 
 ## Wire 协议（`contracts/websocket.ts`）
 
-- **client → server**：`message`（content + attachments 路径引用）、`abort`、`ping`、`retry`、`withdraw`、`resolve_control_request`（kind approval：approved / reason；kind question：answer）
+- **client → server**：`message`（content + 可选 `clientId`（乐观消息结算标识）+ attachments 路径引用）、`abort`、`ping`、`retry`、`withdraw`、`resolve_control_request`（kind approval：approved / reason；kind question：answer）
 - **server → client**：
-  - pi 生命周期族：`agent_start` / `agent_end` / `turn_start` / `turn_end` / `message_start` / `message_update` / `message_end` / `tool_execution_start` / `tool_execution_update` / `tool_execution_end`
-  - session 级：`run_status`（active）、`control_request` / `control_resolved`、`turn_withdrawn`（seq）、`error`（message + code）、`pong`
+  - pi 生命周期族：`agent_start` / `agent_end`（可带 `seq`） / `turn_start` / `turn_end` / `message_start` / `message_update` / `message_end`（可带 `messageId` + `seq`） / `tool_execution_start` / `tool_execution_update` / `tool_execution_end`
+  - session 级：`run_status`（active）、`control_request` / `control_resolved`、`turn_withdrawn`（seq）、`turn_retried`（seq + abandonedSeqs）、`user_message`（seq + clientId? + source? + triggerName?，user 消息回显/ack）、`error`（message + code）、`pong`
+  - 重放族：`session_ready`（lastSeq + replay，attach 后恒为首个事件）、`replay_events`（原始 SessionEvent 信封分批，每批 ≤200）、`replay_done`
+- **身份与游标**（[ADR-0011](../../dev/decisions/0011-chat-wire-cursor-replay.md)）：持久事件按 `seq` 幂等；流式 wire 消息按 hub 生成的 `messageId` stitch（pi message payload 运行时无 id 字段），`message_end.seq` 经落库实例引用配对（persist-before-callback）；connect query `?since=`（≥ -1）触发游标重放，游标为客户端 per-connection 状态
 - **error code**（`classify-run-error.ts`）：`MODEL_NOT_CONFIGURED`、`AUTH_ERROR`、`PERMANENT`、`TRANSIENT`。规则：
   - 401/403 → AUTH；429/5xx/网络错误 → TRANSIENT
   - 其余 4xx 及 `ConflictError` / `ValidationError` → PERMANENT
   - **未知错误兜底 TRANSIENT**
-- **close code**：`4401 SESSION_UNRECOVERABLE`——renderer 视为 fatal 不再重连；瞬时错误以 1000 关闭触发重连
+- **close code**：`4400 PROTOCOL_ERROR`、`4401 SESSION_UNRECOVERABLE`、`4402 MIGRATION_REQUIRED`——renderer 视为 fatal 不再重连；瞬时错误以 1000 关闭触发重连
+- 出站校验默认关闭（生产直发），`SPHERSE_VALIDATE_WS=1` 开启调试；schema 由 `chat-wire-schema.test.ts` 全事件族钉住
 
-## Server：ChatSessionHub（`chat-session-hub.ts`）
+## Server：hub / channel / projector（`chat-session-hub.ts` + `chat-channel.ts` + `chat-wire-projector.ts`）
 
-- channel key = `projectId:sessionId`；负责共享 restore、run 状态序列化、事件广播；hub 实例由 `server/index.ts` 创建，WS 与 sessions 路由共享
-- **run 序列化**：`startRun` 在 channel running 时抛 `ConflictError`（HTTP 映射 409，WS 路径表现为 error 事件 code=PERMANENT）
-- **快照压缩**：run 期间 `message_update` 同一消息窗口只留最后一条、`tool_execution_update` 同 toolCallId 只留最后一条——重放开销 O(压缩后)
-- **重连重放顺序**：attach ready 后先重放压缩快照，再发 `run_status` 当前值，然后才订阅
-- **空闲释放**：`cleanupIfIdle`——initialized 且无 run 且无 attachment 时销毁 session、删 channel
+- **`ChatSessionHub`（注册表）**：`Map<projectId:sessionId, ChatChannel>` + getOrCreate + 身份守卫删除回调；hub 实例由 `server/index.ts` 创建，WS 与 sessions 路由共享
+- **`ChatChannel`（单 session 生命周期）**：restore→ready、事件日志订阅、attach（连接级生命周期为闭包）、run 序列化（`startRun` 在 running 时抛 `ConflictError`，HTTP 映射 409，WS 路径表现为 error 事件 code=PERMANENT）、快照压缩（run 期间 `message_update` 同一消息窗口只留最后一条、`tool_execution_update` 同 toolCallId 只留最后一条）、握手重放、fanout、空闲销毁（`cleanupIfIdle`）
+- **`ChatWireProjector`（persist→wire 翻译纯状态机）**：经 `SessionEventLog.subscribe` 消费落库事件——`user/message` → `user_message` echo（clientId + trigger meta）、`turn/retried` → `turn_retried` 广播、落库实例引用→seq 配对、run 级 `messageId` 序列；对 pi wire 事件做富化。pending echo 与 run 状态在 run 边界重置
+- **attach 握手顺序**：ready 后同步块内 session_ready（lastSeq）→ since 游标重放（`readSessionEventsAfter` 原始事件分批，每批 200）→ replay_done → 当前 run 压缩快照 → run_status 当前值 → 加入订阅（无 await，切片与订阅同 tick 原子）
 - **HTTP 静默发送**：`POST .../sessions/:id/messages`，目标会话未 attach WS 时 UI SDK 走此路径（`open:false` 只控制不跳转导航）：
-  - `startDetachedRun` 只递增 attachment 计数保持 channel 存活、不注册订阅者——调用方只拿 `{ok:true}`，run 失败经 error 事件到达 WS 订阅者
+  - `startDetachedRun` 只递增 attachment 计数保持 channel 存活、不注册订阅者——调用方只拿 `{ok:true}`，run 失败经 error 事件到达 WS 订阅者（echo 无 clientId，仅推进其他端）
   - 与 WS 共享 run 序列化（running 时 409）
 
 ## Core：一次 sendMessage（`agent-runner.ts`）
@@ -83,6 +85,8 @@ Composer.send
 - **撤回**：非 streaming 时最新未失败 user 消息可 withdraw；hub 不经 startRun（运行中返回 ConflictError）；成功广播 `turn_withdrawn`，reducer 从该 user 消息处截断；失败给错误气泡打 `_withdrawError`（隐藏 retry）
 
 ## 重连与历史对账
+
+> 现状为过渡态：server 已发协议 v2（session_ready / 游标重放 / echo），renderer 尚未消费（`agent-event-parse.ts` 对 v2 事件返回 undefined 静默丢弃），仍走下述 HTTP 对账；chat 重构 PR3 起切换为游标重放（设计见 `docs/dev/features/2026-09-05-chat-refactor/design.md`）。
 
 - **心跳**：每 30s ping，连续 60s 无 pong 才关闭；suspend 导致 timer 大幅跳跃时重置探测窗口防误杀；web 壳 hidden ≥30s / bfcache 恢复时主动 probe（5s 短超时）强测死链
 - **重连退避**：`[1, 2, 5, 10, 30]s`，上限 10 次（超限 `reconnectFailed` + 手动重连）；fatal 4401 不重连

--- a/docs/official/architecture/core.md
+++ b/docs/official/architecture/core.md
@@ -50,7 +50,7 @@ ProjectRuntime           对外协调层，聚合以上全部
 
 ## 会话运行时
 
-- **SessionManager** 是纯 session 池：session map 生命周期、legacy 迁移、hot-reload 标记、`setDefaultModel` / `setSampling` 经 `RunConfigHolder` 单点派发。构造只收成品 `RuntimeDeps`，不自带默认装配
+- **SessionManager** 是纯 session 池：session map 生命周期、legacy 迁移、hot-reload 标记、`setDefaultModel` / `setSampling` 经 `RunConfigHolder` 单点派发。构造只收成品 `RuntimeDeps`，不自带默认装配；对外提供事件读取门面（`readSessionEventsAfter` / `getSessionLastSeq` / `subscribeSessionEvents`，内存日志优先、store 回落），server 侧 chat 重放经此消费、不触达 runner 内部
 - **AgentRunner** 直接作为会话对象并执行 turn；事件经 `EventPipeline`（log → capability middleware → sanitizer → 持久化翻译）对外直播
 - **SessionEventLog 是消息唯一真相**：user / assistant / tool result / turn 边界追加到 per-agent SQLite events 表，`deriveMessages(events)` fold 结果单向同步给 pi 的内存数组，内存可随时丢弃重建（为什么见 [ADR-0001](../../dev/decisions/0001-event-log-fold.md)）
   - 不变量：`seq` 在单个 session log 内从 0 连续，`open` 校验损坏即抛；`appendBatch` 落库失败回滚内存追加

--- a/docs/official/glossary.md
+++ b/docs/official/glossary.md
@@ -14,7 +14,10 @@
 | yolo | agent frontmatter 的自动放行开关：true 时危险工具跳过审批门，文件访问策略不受影响 | [architecture/security.md](architecture/security.md) |
 | Session（会话） | agent 的对话单元，存于该 agent 的 `sessions.db`；status 为 active / archived | [data-conventions.md](data-conventions.md) |
 | restore | 会话恢复：事件日志校验 + 未闭合 turn 修复 + legacy 迁移 + fold 重建 | [architecture/core.md](architecture/core.md) |
-| ChatSessionHub | server 侧会话编排：channel 管理、run 序列化（并发 409）、断线快照重放、空闲销毁 | [architecture/chat.md](architecture/chat.md) |
+| ChatSessionHub | server 侧 channel 注册表：`Map<projectId:sessionId, ChatChannel>` + 身份守卫删除 | [architecture/chat.md](architecture/chat.md) |
+| ChatChannel | 单 session 生命周期对象：restore、run 序列化、快照压缩、握手重放、fanout、空闲销毁；多 WS 连接共享 | [architecture/chat.md](architecture/chat.md) |
+| ChatWireProjector | persist→wire 翻译纯状态机：echo、seq 引用配对、run 级 messageId | [architecture/chat.md](architecture/chat.md) |
+| 游标重放 | connect 带 `?since=` 时服务端重放 `seq > since` 的原始持久事件，取代 HTTP 对账的增量恢复机制 | [architecture/chat.md](architecture/chat.md) |
 
 ## 事件与投影
 

--- a/docs/official/project-structure.md
+++ b/docs/official/project-structure.md
@@ -154,7 +154,7 @@ spherse/
 │   │       ├── skills.ts             # SkillDefinition（含可选 version）、SkillList/Create/Install Request 响应与请求 schema
 │   │       ├── marketplace.ts        # MarketplaceSkillEntry、MarketplaceManifestResponse、SkillMarketplaceInstallRequest（{name, version}）
 │   │       ├── debug.ts              # TurnContextSnapshot
-│   │       ├── websocket.ts          # ChatClientMessage/ChatServerEvent/TriggerServerEvent + parser
+│   │       ├── websocket.ts          # ChatClientMessage/ChatServerEvent/ChatReplayEvent（协议 v2：session_ready/replay_events/user_message/turn_retried、close code 族）+ parser
 │   │       └── __tests__/            # 契约测试（正向通过 / 负向抛 Invalid payload + Fastify coercion 兼容）
 │   ├── server/                       # @spherse/server — Fastify API 层
 │   │   └── src/
@@ -180,8 +180,11 @@ spherse/
 │   │       │   ├── attachments.ts    # 通用附件上传/删除 API（POST/DELETE /api/projects/:projectId/attachments，图片落盘 .spherse/attachments/）
 │       │       │   ├── trigger.ts         # 触发器 CRUD 与手动触发（/triggers、/trigger-logs、/run）
 │       │       │   └── debug.ts         # Debug turn context 导出（dev only）
-│       │       ├── ws-chat.ts            # WebSocket 对话流（/ws/projects/:projectId/chat/...，双向 session-scoped）
-│       │       ├── ws-bus.ts             # 全局多路复用 bus WebSocket（/ws/bus，trigger/fs-watch/debug 按 projectId×channel 订阅）
+│   │       ├── chat-session-hub.ts      # ChatSessionHub：channel 注册表（Map<projectId:sessionId, ChatChannel> + 身份守卫删除）
+│   │       ├── chat-channel.ts          # ChatChannel：单 session 生命周期（restore/run 序列化/快照压缩/握手重放/fanout/空闲销毁）
+│   │       ├── chat-wire-projector.ts   # ChatWireProjector：persist→wire 翻译纯状态机（echo/seq 配对/run 级 messageId）
+│   │       ├── ws-chat.ts            # WebSocket 对话流（/ws/projects/:projectId/chat/...，双向 session-scoped，?since= 游标重放）
+│   │       ├── ws-bus.ts             # 全局多路复用 bus WebSocket（/ws/bus，trigger/fs-watch/debug 按 projectId×channel 订阅）
 │       │       └── lib/
 │       │           └── fs-watcher.ts     # 按项目引用计数的共享 fs.watch（多订阅者共享 1 个 OS watcher）；过滤决策基于 core categorizePath 的 watched-category 集合 + node_modules/.git 段级降噪
 │   ├── app/                          # @spherse/app — 共享 React renderer（前端源码，被 desktop/web 消费）

--- a/packages/app/src/features/chat/model/agent-event-parse.test.ts
+++ b/packages/app/src/features/chat/model/agent-event-parse.test.ts
@@ -120,6 +120,11 @@ describe("parseAgentMessage", () => {
 });
 
 describe("parseAgentEvent", () => {
+  function defined<T>(value: T | undefined): T {
+    if (value === undefined) throw new Error("expected a parsed event");
+    return value;
+  }
+
   it("passes through agent_start unchanged", () => {
     expect(parseAgentEvent({ type: "agent_start" })).toEqual({ type: "agent_start" });
   });
@@ -139,6 +144,18 @@ describe("parseAgentEvent", () => {
       type: "turn_withdrawn",
       seq: 3,
     });
+  });
+  it("drops protocol v2 events until the new runtime consumes them", () => {
+    expect(parseAgentEvent({ type: "session_ready", lastSeq: 3, replay: true })).toBeUndefined();
+    expect(parseAgentEvent({ type: "replay_done" })).toBeUndefined();
+    expect(
+      parseAgentEvent({
+        type: "user_message",
+        seq: 4,
+        message: { role: "user", content: "hi", timestamp: 1 },
+      }),
+    ).toBeUndefined();
+    expect(parseAgentEvent({ type: "turn_retried", seq: 5, abandonedSeqs: [3] })).toBeUndefined();
   });
   it("passes through tool_execution_* unchanged", () => {
     expect(
@@ -237,34 +254,34 @@ describe("parseAgentEvent", () => {
     });
   });
   it("narrows assistant message in message_start", () => {
-    const result = parseAgentEvent({
+    const result = defined(parseAgentEvent({
       type: "message_start",
       message: { role: "assistant", content: [] },
-    } as unknown as ChatServerEvent);
+    } as unknown as ChatServerEvent));
     expect(result.type).toBe("message_start");
     expect(result).toHaveProperty("message");
   });
   it("narrows user message in message_end", () => {
-    const result = parseAgentEvent({
+    const result = defined(parseAgentEvent({
       type: "message_end",
       message: { role: "user", content: "hi", timestamp: 1 },
-    });
+    }));
     expect(result.type).toBe("message_end");
     expect(result).toHaveProperty("message");
   });
   it("replaces invalid message payload with fallback", () => {
-    const result = parseAgentEvent({ type: "message_start", message: null } as unknown as ChatServerEvent);
+    const result = defined(parseAgentEvent({ type: "message_start", message: null } as unknown as ChatServerEvent));
     expect(result.type).toBe("message_start");
     expect(result).toHaveProperty("message.role", "user");
   });
   it("agent_end coerces messages array via parseAgentMessage", () => {
-    const result = parseAgentEvent({
+    const result = defined(parseAgentEvent({
       type: "agent_end",
       messages: [
         { role: "user", content: "hi", timestamp: 1 },
         { role: "totally-bogus" },
       ],
-    } as unknown as ChatServerEvent);
+    } as unknown as ChatServerEvent));
     expect(result.type).toBe("agent_end");
     if (result.type === "agent_end") {
       expect(result.messages).toHaveLength(2);
@@ -273,23 +290,23 @@ describe("parseAgentEvent", () => {
     }
   });
   it("agent_end tolerates missing messages array", () => {
-    const result = parseAgentEvent({
+    const result = defined(parseAgentEvent({
       type: "agent_end",
       messages: "not-an-array",
-    } as unknown as ChatServerEvent);
+    } as unknown as ChatServerEvent));
     if (result.type === "agent_end") {
       expect(result.messages).toEqual([]);
     }
   });
   it("turn_end filters toolResults to valid ToolResultMessage", () => {
-    const result = parseAgentEvent({
+    const result = defined(parseAgentEvent({
       type: "turn_end",
       message: { role: "assistant", content: [] },
       toolResults: [
         { role: "toolResult", toolCallId: "tc1", toolName: "x" },
         { role: "user", content: "junk" },
       ],
-    } as unknown as ChatServerEvent);
+    } as unknown as ChatServerEvent));
     if (result.type === "turn_end") {
       expect(result.toolResults).toHaveLength(1);
       expect(result.toolResults[0].toolCallId).toBe("tc1");

--- a/packages/app/src/features/chat/model/agent-event-parse.ts
+++ b/packages/app/src/features/chat/model/agent-event-parse.ts
@@ -95,7 +95,7 @@ export function isRejectedToolDetails(x: unknown): boolean {
   return isObject(x) && x.rejected === true;
 }
 
-export function parseAgentEvent(event: ChatServerEvent): AgentEvent {
+export function parseAgentEvent(event: ChatServerEvent): AgentEvent | undefined {
   switch (event.type) {
     case "agent_start":
     case "run_status":
@@ -170,6 +170,8 @@ export function parseAgentEvent(event: ChatServerEvent): AgentEvent {
       return { type: "message_update", message: parseAgentMessage(event.message) };
     case "message_end":
       return { type: "message_end", message: parseAgentMessage(event.message) };
+    default:
+      return undefined;
   }
 }
 

--- a/packages/app/src/features/chat/runtime/chat-session-runtime.ts
+++ b/packages/app/src/features/chat/runtime/chat-session-runtime.ts
@@ -167,6 +167,7 @@ export class ChatSessionRuntime<T extends ChatSessionRuntimeState> {
           return;
         }
         const parsed = parseAgentEvent(parseChatServerEvent(raw));
+        if (!parsed) return;
         if (reconcilingHistory) {
           connectionEvents.push(parsed);
         } else {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -111,10 +111,11 @@ export type {
 export {
   parseChatClientMessage,
   parseChatServerEvent,
+  parseChatReplayEvent,
   ErrorEventCode,
   CHAT_CLOSE_CODES,
 } from "./websocket.js";
-export type { ChatClientMessage, ChatServerEvent } from "./websocket.js";
+export type { ChatClientMessage, ChatServerEvent, ChatReplayEvent } from "./websocket.js";
 
 export {
   parseBusServerMessage,

--- a/packages/contracts/src/websocket.ts
+++ b/packages/contracts/src/websocket.ts
@@ -2,6 +2,7 @@ import { Type, type Static } from "@sinclair/typebox";
 import type {
   AgentEvent,
   AgentMessage,
+  AssistantMessage,
   SessionControlEvent,
   ToolResultMessage,
 } from "@spherse/core";
@@ -15,7 +16,9 @@ export enum ErrorEventCode {
 }
 
 export const CHAT_CLOSE_CODES = {
+  PROTOCOL_ERROR: 4400,
   SESSION_UNRECOVERABLE: 4401,
+  MIGRATION_REQUIRED: 4402,
 } as const;
 
 /**
@@ -36,10 +39,80 @@ type EventOf<
 > = Extract<TEvent, { type: TType }>;
 
 const agentMessage = Type.Unsafe<AgentMessage>(Type.Unknown());
+const assistantMessage = Type.Unsafe<AssistantMessage>(Type.Unknown());
+const toolResultMessage = Type.Unsafe<ToolResultMessage>(Type.Unknown());
 const toolResultMessages = Type.Unsafe<ToolResultMessage[]>(
   Type.Array(Type.Unknown()),
 );
 const toolArgs = Type.Unsafe<Record<string, unknown>>(Type.Unknown());
+
+export const chatReplayEvent = Type.Union([
+  Type.Object({
+    type: Type.Literal("turn/start"),
+    seq: Type.Integer(),
+    time: Type.Integer(),
+    data: Type.Object({}),
+  }),
+  Type.Object({
+    type: Type.Literal("turn/end"),
+    seq: Type.Integer(),
+    time: Type.Integer(),
+    data: Type.Object({
+      reason: Type.Union([
+        Type.Literal("completed"),
+        Type.Literal("aborted"),
+        Type.Literal("error"),
+      ]),
+    }),
+  }),
+  Type.Object({
+    type: Type.Literal("user/message"),
+    seq: Type.Integer(),
+    time: Type.Integer(),
+    data: Type.Object({
+      message: agentMessage,
+      source: Type.Optional(Type.Literal("triggered")),
+      triggerName: Type.Optional(Type.String()),
+    }),
+  }),
+  Type.Object({
+    type: Type.Literal("assistant/message"),
+    seq: Type.Integer(),
+    time: Type.Integer(),
+    data: Type.Object({ message: assistantMessage }),
+  }),
+  Type.Object({
+    type: Type.Literal("tool/result"),
+    seq: Type.Integer(),
+    time: Type.Integer(),
+    data: Type.Object({ message: toolResultMessage }),
+  }),
+  Type.Object({
+    type: Type.Literal("compaction/applied"),
+    seq: Type.Integer(),
+    time: Type.Integer(),
+    data: Type.Object({
+      anchorSeq: Type.Integer(),
+      digestContent: Type.String(),
+      excludedSeqs: Type.Array(Type.Integer()),
+      digestSource: Type.Optional(
+        Type.Union([Type.Literal("llm"), Type.Literal("mechanical")]),
+      ),
+    }),
+  }),
+  Type.Object({
+    type: Type.Literal("turn/retried"),
+    seq: Type.Integer(),
+    time: Type.Integer(),
+    data: Type.Object({ abandonedSeqs: Type.Array(Type.Integer()) }),
+  }),
+  Type.Object({
+    type: Type.Literal("turn/withdrawn"),
+    seq: Type.Integer(),
+    time: Type.Integer(),
+    data: Type.Object({ seq: Type.Integer() }),
+  }),
+]);
 
 const chatServerEvent = Type.Union([
   Type.Object({ type: Type.Literal("agent_start") }),
@@ -48,6 +121,7 @@ const chatServerEvent = Type.Union([
     messages: Type.Unsafe<
       EventOf<AgentEvent, "agent_end">["messages"]
     >(Type.Array(Type.Unknown())),
+    seq: Type.Optional(Type.Integer()),
   }),
   Type.Object({ type: Type.Literal("run_status"), active: Type.Boolean() }),
   Type.Object({ type: Type.Literal("turn_start") }),
@@ -62,7 +136,11 @@ const chatServerEvent = Type.Union([
     message: agentMessage,
     assistantMessageEvent: Type.Optional(Type.Unknown()),
   }),
-  Type.Object({ type: Type.Literal("message_end"), message: agentMessage }),
+  Type.Object({
+    type: Type.Literal("message_end"),
+    message: agentMessage,
+    seq: Type.Optional(Type.Integer()),
+  }),
   Type.Object({
     type: Type.Literal("tool_execution_start"),
     toolCallId: Type.String(),
@@ -122,6 +200,29 @@ const chatServerEvent = Type.Union([
     seq: Type.Integer(),
   }),
   Type.Object({
+    type: Type.Literal("user_message"),
+    seq: Type.Integer(),
+    message: agentMessage,
+    clientId: Type.Optional(Type.String()),
+    source: Type.Optional(Type.String()),
+    triggerName: Type.Optional(Type.String()),
+  }),
+  Type.Object({
+    type: Type.Literal("turn_retried"),
+    seq: Type.Integer(),
+    abandonedSeqs: Type.Array(Type.Integer()),
+  }),
+  Type.Object({
+    type: Type.Literal("session_ready"),
+    lastSeq: Type.Integer(),
+    replay: Type.Boolean(),
+  }),
+  Type.Object({
+    type: Type.Literal("replay_events"),
+    events: Type.Array(chatReplayEvent),
+  }),
+  Type.Object({ type: Type.Literal("replay_done") }),
+  Type.Object({
     type: Type.Literal("error"),
     message: Type.String(),
     code: Type.Optional(Type.Enum(ErrorEventCode)),
@@ -134,6 +235,7 @@ export const schemas = {
     Type.Object({
       type: Type.Literal("message"),
       content: Type.String(),
+      clientId: Type.Optional(Type.String()),
       attachments: Type.Optional(
         Type.Array(
           Type.Object({
@@ -163,10 +265,12 @@ export const schemas = {
     }),
   ]),
   chatServerEvent,
+  chatReplayEvent,
 } as const;
 
 export type ChatClientMessage = Static<typeof schemas.chatClientMessage>;
 export type ChatServerEvent = Static<typeof chatServerEvent>;
+export type ChatReplayEvent = Static<typeof chatReplayEvent>;
 
 export function parseChatClientMessage(payload: unknown): ChatClientMessage {
   return parseContract(schemas.chatClientMessage, payload);
@@ -174,4 +278,8 @@ export function parseChatClientMessage(payload: unknown): ChatClientMessage {
 
 export function parseChatServerEvent(payload: unknown): ChatServerEvent {
   return parseContract(chatServerEvent, payload);
+}
+
+export function parseChatReplayEvent(payload: unknown): ChatReplayEvent {
+  return parseContract(chatReplayEvent, payload);
 }

--- a/packages/contracts/src/websocket.ts
+++ b/packages/contracts/src/websocket.ts
@@ -130,15 +130,17 @@ const chatServerEvent = Type.Union([
     message: agentMessage,
     toolResults: toolResultMessages,
   }),
-  Type.Object({ type: Type.Literal("message_start"), message: agentMessage }),
+  Type.Object({ type: Type.Literal("message_start"), message: agentMessage, messageId: Type.Optional(Type.String()) }),
   Type.Object({
     type: Type.Literal("message_update"),
     message: agentMessage,
+    messageId: Type.Optional(Type.String()),
     assistantMessageEvent: Type.Optional(Type.Unknown()),
   }),
   Type.Object({
     type: Type.Literal("message_end"),
     message: agentMessage,
+    messageId: Type.Optional(Type.String()),
     seq: Type.Optional(Type.Integer()),
   }),
   Type.Object({
@@ -204,7 +206,7 @@ const chatServerEvent = Type.Union([
     seq: Type.Integer(),
     message: agentMessage,
     clientId: Type.Optional(Type.String()),
-    source: Type.Optional(Type.String()),
+    source: Type.Optional(Type.Literal("triggered")),
     triggerName: Type.Optional(Type.String()),
   }),
   Type.Object({

--- a/packages/core/src/__tests__/session/session-manager.test.ts
+++ b/packages/core/src/__tests__/session/session-manager.test.ts
@@ -545,6 +545,107 @@ describe("SessionManager lifecycle", () => {
   });
 });
 
+describe("SessionManager event facade", () => {
+  let tmpDir: string;
+  let runtime: RuntimeInternals & Awaited<ReturnType<typeof createProject>>;
+  let agentId: string;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "wb-mgr-facade-"));
+    getChatStreamFnMock.mockClear();
+    resolveModelByIdMock.mockClear();
+    runtime = (await createProject(tmpDir, {
+      projectName: "Test",
+      logger: createSilentLogger(),
+    })) as RuntimeInternals & Awaited<ReturnType<typeof createProject>>;
+    const projectStore = runtime.projectManager.projectStore;
+    const testAgent = await projectStore.createAgent("test-agent", TEST_AGENT_PROFILE);
+    agentId = testAgent.getProfile().id;
+    runtime.timerService.stop();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const seedSession = (): { sessionId: string; agentStore: any } => {
+    const agentStore = runtime.projectManager.projectStore.agents.get(agentId) as any;
+    const sessionId = agentStore.sessions.createSession();
+    agentStore.sessions.appendEvents(
+      sessionId,
+      [
+        {
+          type: "user/message",
+          seq: 0,
+          time: 1,
+          data: { message: { role: "user", content: "q1", timestamp: 1 } },
+        },
+        {
+          type: "assistant/message",
+          seq: 1,
+          time: 2,
+          data: {
+            message: { role: "assistant", content: [{ type: "text", text: "a1" }], timestamp: 2 },
+          },
+        },
+        { type: "turn/end", seq: 2, time: 3, data: { reason: "completed" } },
+      ],
+      1,
+    );
+    return { sessionId, agentStore };
+  };
+
+  it("reads the event tail from memory while the session is active", async () => {
+    const { sessionId } = seedSession();
+    await runtime.sessionRuntime.restoreSession(agentId, sessionId);
+
+    const tail = runtime.sessionRuntime.readSessionEventsAfter(agentId, sessionId, 0, 10);
+    expect(tail.map((e) => [e.type, e.seq])).toEqual([
+      ["assistant/message", 1],
+      ["turn/end", 2],
+    ]);
+    expect(runtime.sessionRuntime.getSessionLastSeq(agentId, sessionId)).toBe(2);
+  });
+
+  it("falls back to the store after the session is destroyed", async () => {
+    const { sessionId } = seedSession();
+    await runtime.sessionRuntime.restoreSession(agentId, sessionId);
+    runtime.sessionRuntime.destroySession(sessionId);
+
+    const tail = runtime.sessionRuntime.readSessionEventsAfter(agentId, sessionId, 0, 10);
+    expect(tail.map((e) => e.seq)).toEqual([1, 2]);
+    expect(runtime.sessionRuntime.getSessionLastSeq(agentId, sessionId)).toBe(2);
+  });
+
+  it("reports -1 for a session with no events", async () => {
+    const sessionId = await runtime.sessionRuntime.createSession(agentId);
+    expect(runtime.sessionRuntime.getSessionLastSeq(agentId, sessionId)).toBe(-1);
+  });
+
+  it("delivers appended events to multiple subscribers", async () => {
+    const { sessionId } = seedSession();
+    await runtime.sessionRuntime.restoreSession(agentId, sessionId);
+
+    const first: Array<{ type: string; seq: number }> = [];
+    const second: Array<{ type: string; seq: number }> = [];
+    const unsubscribeFirst = runtime.sessionRuntime.subscribeSessionEvents(sessionId, (event) => {
+      first.push({ type: event.type, seq: event.seq });
+    });
+    runtime.sessionRuntime.subscribeSessionEvents(sessionId, (event) => {
+      second.push({ type: event.type, seq: event.seq });
+    });
+
+    await runtime.sessionRuntime.withdrawLastTurn(sessionId);
+    expect(first).toEqual([{ type: "turn/withdrawn", seq: 3 }]);
+    expect(second).toEqual([{ type: "turn/withdrawn", seq: 3 }]);
+    expect(() => unsubscribeFirst!()).not.toThrow();
+  });
+
+  it("returns null when subscribing to an inactive session", () => {
+    expect(runtime.sessionRuntime.subscribeSessionEvents("missing", () => {})).toBeNull();
+  });
+});
+
 describe("SessionManager getSessionStatus", () => {
   let tmpDir: string;
   let runtime: RuntimeInternals & Awaited<ReturnType<typeof createProject>>;

--- a/packages/core/src/__tests__/store/session-events.test.ts
+++ b/packages/core/src/__tests__/store/session-events.test.ts
@@ -122,6 +122,48 @@ describe("SessionStore events", () => {
     });
   });
 
+  describe("readEventsAfter", () => {
+    const seedThree = (): string => {
+      const id = store.createSession();
+      const log = SessionEventLog.open(store, id);
+      log.append("turn/start", {});
+      log.append("user/message", { message: legacyUserMsg("hello") });
+      log.append("turn/end", { reason: "completed" });
+      return id;
+    };
+
+    it("returns only events after sinceSeq in ascending order", () => {
+      const id = seedThree();
+      const tail = store.readEventsAfter(id, 0, 10);
+      expect(tail.map((e) => [e.type, e.seq])).toEqual([
+        ["user/message", 1],
+        ["turn/end", 2],
+      ]);
+    });
+
+    it("returns the full log when sinceSeq is -1", () => {
+      const id = seedThree();
+      expect(store.readEventsAfter(id, -1, 10)).toHaveLength(3);
+    });
+
+    it("returns an empty array when sinceSeq is at or past the tail", () => {
+      const id = seedThree();
+      expect(store.readEventsAfter(id, 2, 10)).toEqual([]);
+      expect(store.readEventsAfter(id, 99, 10)).toEqual([]);
+    });
+
+    it("applies the limit from the oldest matching seq", () => {
+      const id = seedThree();
+      const tail = store.readEventsAfter(id, -1, 2);
+      expect(tail.map((e) => e.seq)).toEqual([0, 1]);
+    });
+
+    it("returns an empty array for a session without events", () => {
+      const id = store.createSession();
+      expect(store.readEventsAfter(id, -1, 10)).toEqual([]);
+    });
+  });
+
   describe("needsMigration / migrated bookkeeping", () => {
     it("fresh session with no history does not need migration", () => {
       const id = store.createSession();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export {
   AccessDeniedError,
   ConflictError,
   ModelNotConfiguredError,
+  MigrationRequiredError,
 } from "./errors.js";
 export type { ProjectRuntime } from "./project-runtime.js";
 export type { ProjectManager } from "./project-manager.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export {
 export type { ProjectRuntime } from "./project-runtime.js";
 export type { ProjectManager } from "./project-manager.js";
 export type { SessionManager } from "./session/session-manager.js";
+export type { SessionEvent } from "./session/events.js";
 export type { SessionControlEvent } from "./session/types.js";
 export type { TriggerManager } from "./trigger/trigger-manager.js";
 export type { TriggerEventPayload } from "./trigger/trigger-manager.js";

--- a/packages/core/src/session/agent-runner.ts
+++ b/packages/core/src/session/agent-runner.ts
@@ -110,6 +110,10 @@ export class AgentRunner {
     return this.eventLog?.events ?? [];
   }
 
+  subscribeEvents(listener: (event: SessionEvent) => void): (() => void) | null {
+    return this.eventLog ? this.eventLog.subscribe(listener) : null;
+  }
+
   markReloadPending(): void {
     this.pendingReload = true;
   }

--- a/packages/core/src/session/session-manager.ts
+++ b/packages/core/src/session/session-manager.ts
@@ -3,7 +3,7 @@ import type { Logger } from "../logger.js";
 import { NotFoundError } from "../errors.js";
 import { AgentRunner, type RunnerEventHandler } from "./agent-runner.js";
 import { SessionEventLog } from "./event-log.js";
-import type { SendMessageMeta } from "./events.js";
+import type { SendMessageMeta, SessionEvent } from "./events.js";
 import { deriveMessages } from "./fold.js";
 import { computeSessionStatus, type SessionStatus } from "./status.js";
 import type { TurnContextSnapshot } from "./types.js";
@@ -104,6 +104,40 @@ export class SessionManager {
     const session = this.sessions.get(sessionId);
     if (!session) throw new NotFoundError(`No active session "${sessionId}"`);
     return session.getTurnContext();
+  }
+
+  subscribeSessionEvents(
+    sessionId: string,
+    listener: (event: SessionEvent) => void,
+  ): (() => void) | null {
+    return this.sessions.get(sessionId)?.subscribeEvents(listener) ?? null;
+  }
+
+  readSessionEventsAfter(
+    agentId: string,
+    sessionId: string,
+    sinceSeq: number,
+    limit: number,
+  ): SessionEvent[] {
+    const runner = this.sessions.get(sessionId);
+    if (runner) {
+      const start = Math.max(0, sinceSeq + 1);
+      return runner.currentEvents.slice(start, start + limit);
+    }
+    const agentStore = this.deps.projectStore.getAgent(agentId);
+    if (!agentStore) throw new NotFoundError(`Agent "${agentId}" not found`);
+    return agentStore.sessions.readEventsAfter(sessionId, sinceSeq, limit);
+  }
+
+  getSessionLastSeq(agentId: string, sessionId: string): number {
+    const runner = this.sessions.get(sessionId);
+    if (runner) {
+      const events = runner.currentEvents;
+      return events.length > 0 ? events[events.length - 1].seq : -1;
+    }
+    const agentStore = this.deps.projectStore.getAgent(agentId);
+    if (!agentStore) throw new NotFoundError(`Agent "${agentId}" not found`);
+    return agentStore.sessions.maxSeq(sessionId) ?? -1;
   }
 
   getSessionStatus(agentId: string, sessionId: string): SessionStatus {

--- a/packages/core/src/store/session.ts
+++ b/packages/core/src/store/session.ts
@@ -245,6 +245,19 @@ export class SessionStore {
         "SELECT * FROM events WHERE session_id = ? ORDER BY seq ASC",
       )
       .all(sessionId);
+    return SessionStore.rowsToEvents(rows);
+  }
+
+  readEventsAfter(sessionId: string, sinceSeq: number, limit: number): SessionEvent[] {
+    const rows = this.db
+      .prepare<[string, number, number], EventRow>(
+        "SELECT * FROM events WHERE session_id = ? AND seq > ? ORDER BY seq ASC LIMIT ?",
+      )
+      .all(sessionId, sinceSeq, limit);
+    return SessionStore.rowsToEvents(rows);
+  }
+
+  private static rowsToEvents(rows: EventRow[]): SessionEvent[] {
     return rows.map((row) => {
       assertSupportedEventVersion(row);
       return {

--- a/packages/server/src/__tests__/chat-hub-runtime-contract.test.ts
+++ b/packages/server/src/__tests__/chat-hub-runtime-contract.test.ts
@@ -1,0 +1,175 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createProject, type Logger, type ProjectRuntime } from "@spherse/core";
+import { ChatSessionHub } from "../chat-session-hub.js";
+
+const silentLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  trace: () => {},
+  fatal: () => {},
+  child: () => silentLogger,
+};
+
+const TEST_AGENT_PROFILE = `---
+name: Test Agent
+tools:
+  - read_file
+---
+
+Test agent for contracts.`;
+
+const stubCatalog = {
+  getChatStreamFn: vi.fn(() => vi.fn()),
+  resolveModelById: vi.fn((modelId: string) => {
+    const slashIdx = modelId.indexOf("/");
+    return slashIdx >= 0
+      ? { id: modelId.slice(slashIdx + 1), provider: modelId.slice(0, slashIdx) }
+      : { id: modelId, provider: modelId };
+  }),
+} as never;
+
+describe("chat hub ↔ real SessionManager contract", () => {
+  let tmpDir: string;
+  let runtime: ProjectRuntime & {
+    projectManager: { projectStore: any };
+    sessionRuntime: any;
+  };
+  let agentId: string;
+  let sessionId: string;
+  let store: any;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "spherse-hub-contract-"));
+    runtime = (await createProject(tmpDir, {
+      projectName: "Contract",
+      logger: silentLogger,
+      modelCatalog: stubCatalog,
+      defaultModel: "openai/gpt-4o",
+    })) as never;
+    const projectStore = runtime.projectManager.projectStore;
+    const agent = await projectStore.createAgent("test-agent", TEST_AGENT_PROFILE);
+    agentId = agent.getProfile().id;
+    sessionId = await runtime.sessionRuntime.createSession(agentId);
+    store = projectStore.agents.get(agentId).sessions;
+  });
+
+  afterAll(async () => {
+    runtime.timerService.stop();
+    await runtime.shutdown();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("echo, wire enrichment, and replay stay consistent with the persisted log", async () => {
+    const hub = new ChatSessionHub(silentLogger as never);
+    const events: any[] = [];
+    const attachment = hub.attach(
+      "p1",
+      runtime.sessionRuntime,
+      agentId,
+      sessionId,
+      (event) => events.push(event),
+    );
+    await attachment.ready;
+    expect(events[0]).toEqual({ type: "session_ready", lastSeq: -1, replay: true });
+    events.length = 0;
+
+    const runner = runtime.sessionRuntime.sessions.get(sessionId);
+    const liveAgent = runner.agentRef;
+    let dispatch: ((event: unknown) => unknown) | undefined;
+    liveAgent.subscribe = vi.fn((handler: (event: unknown) => unknown) => {
+      dispatch = handler;
+      return () => {};
+    });
+    liveAgent.prompt = vi.fn().mockResolvedValue(undefined);
+
+    const run = attachment.sendMessage("hi", [], "c1");
+    await vi.waitFor(() =>
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "user_message", seq: 0, clientId: "c1" }),
+      ),
+    );
+    const echo = events.find((event) => event.type === "user_message");
+    expect(echo.message).toMatchObject({ role: "user" });
+    expect(store.readEvents(sessionId).map((event: any) => [event.type, event.seq])).toEqual([
+      ["user/message", 0],
+      ["turn/start", 1],
+    ]);
+    await dispatch?.({ type: "agent_end", messages: [] });
+    await run;
+    events.length = 0;
+
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+      api: "anthropic",
+      provider: "anthropic",
+      model: "claude",
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+    };
+    const secondRun = attachment.sendMessage("again", [], "c2");
+    await vi.waitFor(() =>
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "user_message", seq: 3, clientId: "c2" }),
+      ),
+    );
+
+    await dispatch?.({ type: "message_start", message: { ...assistantMessage } });
+    await dispatch?.({ type: "message_end", message: assistantMessage });
+    await dispatch?.({ type: "agent_end", messages: [assistantMessage] });
+    await secondRun;
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "message_end",
+        messageId: expect.any(String),
+        seq: 5,
+      }),
+    );
+    expect(events).toContainEqual(expect.objectContaining({ type: "agent_end", seq: 6 }));
+    expect(store.readEvents(sessionId).map((event: any) => [event.type, event.seq])).toEqual([
+      ["user/message", 0],
+      ["turn/start", 1],
+      ["turn/end", 2],
+      ["user/message", 3],
+      ["turn/start", 4],
+      ["assistant/message", 5],
+      ["turn/end", 6],
+    ]);
+    const liveRunner = runtime.sessionRuntime.sessions.get(sessionId);
+    expect(liveRunner.currentEvents[5].data.message).toBe(assistantMessage);
+    events.length = 0;
+
+    const replayEvents: any[] = [];
+    const replayAttachment = hub.attach(
+      "p1",
+      runtime.sessionRuntime,
+      agentId,
+      sessionId,
+      (event) => replayEvents.push(event),
+      { since: 4 },
+    );
+    await replayAttachment.ready;
+
+    expect(replayEvents[0]).toEqual({ type: "session_ready", lastSeq: 6, replay: true });
+    const expected = store.readEvents(sessionId).filter((event: any) => event.seq > 4);
+    const replayBatches = replayEvents.filter((event) => event.type === "replay_events");
+    expect(replayBatches.flatMap((batch: any) => batch.events)).toEqual(expected);
+    expect(replayEvents.at(-1)).toEqual({ type: "run_status", active: false });
+
+    replayAttachment.close();
+    attachment.close();
+  });
+});

--- a/packages/server/src/__tests__/chat-session-hub.test.ts
+++ b/packages/server/src/__tests__/chat-session-hub.test.ts
@@ -4,6 +4,7 @@ import { ChatSessionHub } from "../chat-session-hub.js";
 function createRuntime() {
   let emit: ((event: any) => void) | undefined;
   let finish: (() => void) | undefined;
+  let logListener: ((event: any) => void) | undefined;
   const runtime = {
     restoreSession: vi.fn().mockResolvedValue(undefined),
     sendMessage: vi.fn(
@@ -26,10 +27,21 @@ function createRuntime() {
     abortSession: vi.fn(),
     resolveControlRequest: vi.fn(),
     destroySession: vi.fn(),
+    subscribeSessionEvents: vi.fn(
+      (_sessionId: string, listener: (event: any) => void) => {
+        logListener = listener;
+        return () => {
+          logListener = undefined;
+        };
+      },
+    ),
+    readSessionEventsAfter: vi.fn(() => []),
+    getSessionLastSeq: vi.fn(() => -1),
   };
   return {
     runtime,
     emit: (event: any) => emit?.(event),
+    appendLog: (event: any) => logListener?.(event),
     finish: () => finish?.(),
   };
 }
@@ -86,10 +98,12 @@ describe("ChatSessionHub", () => {
 
     expect(mock.runtime.restoreSession).toHaveBeenCalledTimes(1);
     expect(replayed.map((event) => event.type)).toEqual([
+      "session_ready",
       "agent_start",
       "message_update",
       "run_status",
     ]);
+    expect(replayed[0]).toEqual({ type: "session_ready", lastSeq: -1, replay: true });
     expect(replayed.at(-1)).toEqual({ type: "run_status", active: true });
 
     mock.emit({ type: "agent_end", messages: [] });
@@ -285,5 +299,287 @@ describe("ChatSessionHub", () => {
     await expect(
       hub.startDetachedRun("p1", mock.runtime as never, "a1", "s1", "hi"),
     ).rejects.toThrow("no such session");
+  });
+
+  it("sends session_ready, since replay, replay_done, then run_status", async () => {
+    const mock = createRuntime();
+    mock.runtime.getSessionLastSeq.mockReturnValue(9);
+    mock.runtime.readSessionEventsAfter.mockReturnValue([
+      { type: "user/message", seq: 8, time: 1, data: { message: { role: "user", content: "hi" } } },
+      { type: "turn/start", seq: 9, time: 1, data: {} },
+    ]);
+    const hub = new ChatSessionHub(logger);
+    const events: any[] = [];
+    const attachment = hub.attach(
+      "p1",
+      mock.runtime as never,
+      "a1",
+      "s1",
+      (event) => events.push(event),
+      { since: 7 },
+    );
+    await attachment.ready;
+
+    expect(mock.runtime.readSessionEventsAfter).toHaveBeenCalledWith(
+      "a1",
+      "s1",
+      7,
+      expect.any(Number),
+    );
+    expect(events.map((event) => event.type)).toEqual([
+      "session_ready",
+      "replay_events",
+      "replay_done",
+      "run_status",
+    ]);
+    expect(events[0]).toEqual({ type: "session_ready", lastSeq: 9, replay: true });
+    expect(events[1].events.map((event: any) => event.seq)).toEqual([8, 9]);
+    expect(events.at(-1)).toEqual({ type: "run_status", active: false });
+    attachment.close();
+  });
+
+  it("skips the replay entirely when no since cursor is provided", async () => {
+    const mock = createRuntime();
+    const hub = new ChatSessionHub(logger);
+    const events: any[] = [];
+    const attachment = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+      events.push(event),
+    );
+    await attachment.ready;
+
+    expect(mock.runtime.readSessionEventsAfter).not.toHaveBeenCalled();
+    expect(events.map((event) => event.type)).toEqual(["session_ready", "run_status"]);
+    attachment.close();
+  });
+
+  it("batches replay events in chunks of 200", async () => {
+    const mock = createRuntime();
+    mock.runtime.readSessionEventsAfter.mockReturnValue(
+      Array.from({ length: 250 }, (_, i) => ({
+        type: "turn/start",
+        seq: i,
+        time: 1,
+        data: {},
+      })),
+    );
+    const hub = new ChatSessionHub(logger);
+    const events: any[] = [];
+    const attachment = hub.attach(
+      "p1",
+      mock.runtime as never,
+      "a1",
+      "s1",
+      (event) => events.push(event),
+      { since: -1 },
+    );
+    await attachment.ready;
+
+    const batches = events.filter((event) => event.type === "replay_events");
+    expect(batches.map((batch) => batch.events.length)).toEqual([200, 50]);
+    expect(events.at(-2)?.type).toBe("replay_done");
+    attachment.close();
+  });
+
+  it("echoes persisted user/message with clientId and trigger metadata to all subscribers", async () => {
+    const mock = createRuntime();
+    const hub = new ChatSessionHub(logger);
+    const eventsA: any[] = [];
+    const eventsB: any[] = [];
+    const first = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+      eventsA.push(event),
+    );
+    const second = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+      eventsB.push(event),
+    );
+    await first.ready;
+    await second.ready;
+    eventsA.length = 0;
+    eventsB.length = 0;
+
+    const run = first.sendMessage("hi", [], "client-1");
+    await vi.waitFor(() => expect(mock.runtime.sendMessage).toHaveBeenCalled());
+    mock.appendLog({
+      type: "user/message",
+      seq: 5,
+      time: 1,
+      data: {
+        message: { role: "user", content: "hi" },
+        source: "triggered",
+        triggerName: "t1",
+      },
+    });
+
+    const expectedEcho = {
+      type: "user_message",
+      seq: 5,
+      message: { role: "user", content: "hi" },
+      clientId: "client-1",
+      source: "triggered",
+      triggerName: "t1",
+    };
+    expect(eventsA).toContainEqual(expectedEcho);
+    expect(eventsB).toContainEqual(expectedEcho);
+
+    mock.emit({ type: "agent_end", messages: [] });
+    mock.finish();
+    await run;
+    first.close();
+    second.close();
+  });
+
+  it("echoes user_message without clientId for detached runs", async () => {
+    const mock = createRuntime();
+    const hub = new ChatSessionHub(logger);
+    const events: any[] = [];
+    const attachment = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+      events.push(event),
+    );
+    await attachment.ready;
+    events.length = 0;
+
+    await hub.startDetachedRun("p1", mock.runtime as never, "a1", "s1", "hi");
+    mock.appendLog({
+      type: "user/message",
+      seq: 3,
+      time: 1,
+      data: { message: { role: "user", content: "hi" } },
+    });
+
+    expect(events).toContainEqual({
+      type: "user_message",
+      seq: 3,
+      message: { role: "user", content: "hi" },
+    });
+
+    mock.emit({ type: "agent_end", messages: [] });
+    mock.finish();
+    await vi.waitFor(() =>
+      expect(events).toContainEqual({ type: "run_status", active: false }),
+    );
+    attachment.close();
+  });
+
+  it("does not leak clientId from a rejected send into later echoes", async () => {
+    const mock = createRuntime();
+    const hub = new ChatSessionHub(logger);
+    const events: any[] = [];
+    const first = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+      events.push(event),
+    );
+    await first.ready;
+
+    const run = first.sendMessage("hi");
+    await vi.waitFor(() => expect(mock.runtime.sendMessage).toHaveBeenCalled());
+
+    const second = hub.attach("p1", mock.runtime as never, "a1", "s1", () => {});
+    await second.ready;
+    await expect(second.sendMessage("again", [], "client-b")).rejects.toThrow(
+      /already running/,
+    );
+
+    mock.appendLog({
+      type: "user/message",
+      seq: 2,
+      time: 1,
+      data: { message: { role: "user", content: "hi" } },
+    });
+    const echo = events.find((event) => event.type === "user_message");
+    expect(echo).toEqual({
+      type: "user_message",
+      seq: 2,
+      message: { role: "user", content: "hi" },
+    });
+
+    mock.emit({ type: "agent_end", messages: [] });
+    mock.finish();
+    await run;
+    first.close();
+    second.close();
+  });
+
+  it("broadcasts turn_retried when the log records turn/retried", async () => {
+    const mock = createRuntime();
+    const hub = new ChatSessionHub(logger);
+    const events: any[] = [];
+    const attachment = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+      events.push(event),
+    );
+    await attachment.ready;
+    events.length = 0;
+
+    const run = attachment.retryLastTurn();
+    await vi.waitFor(() => expect(mock.runtime.retryLastTurn).toHaveBeenCalled());
+    mock.appendLog({
+      type: "turn/retried",
+      seq: 7,
+      time: 1,
+      data: { abandonedSeqs: [5, 6] },
+    });
+
+    expect(events).toContainEqual({
+      type: "turn_retried",
+      seq: 7,
+      abandonedSeqs: [5, 6],
+    });
+
+    mock.emit({ type: "agent_end", messages: [] });
+    mock.finish();
+    await run;
+    attachment.close();
+  });
+
+  it("enriches message_end and agent_end with persisted seqs", async () => {
+    const mock = createRuntime();
+    const hub = new ChatSessionHub(logger);
+    const events: any[] = [];
+    const attachment = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+      events.push(event),
+    );
+    await attachment.ready;
+    events.length = 0;
+
+    const run = attachment.sendMessage("hi");
+    await vi.waitFor(() => expect(mock.runtime.sendMessage).toHaveBeenCalled());
+
+    const assistantMessage = { id: "m1", role: "assistant", content: [] };
+    mock.appendLog({
+      type: "assistant/message",
+      seq: 9,
+      time: 1,
+      data: { message: assistantMessage },
+    });
+    mock.emit({ type: "message_end", message: assistantMessage });
+    mock.appendLog({ type: "turn/end", seq: 10, time: 1, data: { reason: "completed" } });
+    mock.emit({ type: "agent_end", messages: [] });
+    mock.finish();
+    await run;
+
+    expect(events).toContainEqual({
+      type: "message_end",
+      message: assistantMessage,
+      seq: 9,
+    });
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "agent_end", seq: 10 }),
+    );
+    attachment.close();
+  });
+
+  it("unsubscribes the log listener when the channel is cleaned up", async () => {
+    const mock = createRuntime();
+    const unsubscribe = vi.fn();
+    mock.runtime.subscribeSessionEvents.mockReturnValue(unsubscribe);
+    const hub = new ChatSessionHub(logger);
+    const attachment = hub.attach("p1", mock.runtime as never, "a1", "s1", () => {});
+    await attachment.ready;
+    expect(mock.runtime.subscribeSessionEvents).toHaveBeenCalledWith(
+      "s1",
+      expect.any(Function),
+    );
+
+    attachment.close();
+
+    expect(mock.runtime.destroySession).toHaveBeenCalledWith("s1");
+    expect(unsubscribe).toHaveBeenCalled();
   });
 });

--- a/packages/server/src/__tests__/chat-session-hub.test.ts
+++ b/packages/server/src/__tests__/chat-session-hub.test.ts
@@ -528,7 +528,7 @@ describe("ChatSessionHub", () => {
     attachment.close();
   });
 
-  it("enriches message_end and agent_end with persisted seqs", async () => {
+  it("enriches the wire message stream with messageId and persisted seq", async () => {
     const mock = createRuntime();
     const hub = new ChatSessionHub(logger);
     const events: any[] = [];
@@ -541,7 +541,9 @@ describe("ChatSessionHub", () => {
     const run = attachment.sendMessage("hi");
     await vi.waitFor(() => expect(mock.runtime.sendMessage).toHaveBeenCalled());
 
-    const assistantMessage = { id: "m1", role: "assistant", content: [] };
+    const assistantMessage = { role: "assistant", content: [] };
+    mock.emit({ type: "message_start", message: assistantMessage });
+    mock.emit({ type: "message_update", message: assistantMessage });
     mock.appendLog({
       type: "assistant/message",
       seq: 9,
@@ -554,15 +556,105 @@ describe("ChatSessionHub", () => {
     mock.finish();
     await run;
 
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "message_start", messageId: "m1" }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "message_update", messageId: "m1" }),
+    );
     expect(events).toContainEqual({
       type: "message_end",
       message: assistantMessage,
+      messageId: "m1",
       seq: 9,
     });
     expect(events).toContainEqual(
       expect.objectContaining({ type: "agent_end", seq: 10 }),
     );
     attachment.close();
+  });
+
+  it("keeps the in-flight run's clientId when a concurrent send hits ConflictError", async () => {
+    const mock = createRuntime();
+    const hub = new ChatSessionHub(logger);
+    const events: any[] = [];
+    const first = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+      events.push(event),
+    );
+    await first.ready;
+
+    const run = first.sendMessage("hi", [], "client-a");
+    await vi.waitFor(() => expect(mock.runtime.sendMessage).toHaveBeenCalled());
+
+    const second = hub.attach("p1", mock.runtime as never, "a1", "s1", () => {});
+    await second.ready;
+    await expect(second.sendMessage("again", [], "client-b")).rejects.toThrow(
+      /already running/,
+    );
+
+    mock.appendLog({
+      type: "user/message",
+      seq: 2,
+      time: 1,
+      data: { message: { role: "user", content: "hi" } },
+    });
+    expect(events).toContainEqual({
+      type: "user_message",
+      seq: 2,
+      message: { role: "user", content: "hi" },
+      clientId: "client-a",
+    });
+
+    mock.emit({ type: "agent_end", messages: [] });
+    mock.finish();
+    await run;
+    first.close();
+    second.close();
+  });
+
+  it("sends the full handshake sequence when attaching mid-run with a since cursor", async () => {
+    const mock = createRuntime();
+    mock.runtime.getSessionLastSeq.mockReturnValue(11);
+    mock.runtime.readSessionEventsAfter.mockReturnValue([
+      { type: "user/message", seq: 10, time: 1, data: { message: { role: "user", content: "hi" } } },
+      { type: "turn/start", seq: 11, time: 1, data: {} },
+    ]);
+    const hub = new ChatSessionHub(logger);
+    const liveEvents: any[] = [];
+    const first = hub.attach("p1", mock.runtime as never, "a1", "s1", (event) =>
+      liveEvents.push(event),
+    );
+    await first.ready;
+    liveEvents.length = 0;
+
+    const run = first.sendMessage("hi");
+    await vi.waitFor(() => expect(mock.runtime.sendMessage).toHaveBeenCalled());
+    mock.emit({ type: "agent_start" });
+    mock.emit({ type: "message_update", message: { role: "assistant", content: [] } });
+
+    const replayEvents: any[] = [];
+    const second = hub.attach(
+      "p1",
+      mock.runtime as never,
+      "a1",
+      "s1",
+      (event) => replayEvents.push(event),
+      { since: 9 },
+    );
+    await second.ready;
+
+    const types = replayEvents.map((event) => event.type);
+    expect(types[0]).toBe("session_ready");
+    expect(types[1]).toBe("replay_events");
+    expect(types[2]).toBe("replay_done");
+    expect(types.slice(3)).toEqual(["agent_start", "message_update", "run_status"]);
+    expect(replayEvents.at(-1)).toEqual({ type: "run_status", active: true });
+
+    mock.emit({ type: "agent_end", messages: [] });
+    mock.finish();
+    await run;
+    first.close();
+    second.close();
   });
 
   it("unsubscribes the log listener when the channel is cleaned up", async () => {

--- a/packages/server/src/__tests__/chat-wire-projector.test.ts
+++ b/packages/server/src/__tests__/chat-wire-projector.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import { ChatWireProjector } from "../chat-wire-projector.js";
+import type { SessionEvent } from "@spherse/core";
+
+function logEvent<T extends SessionEvent["type"]>(
+  type: T,
+  seq: number,
+  data: Extract<SessionEvent, { type: T }>["data"],
+): SessionEvent {
+  return { type, seq, time: 1, data } as SessionEvent;
+}
+
+describe("ChatWireProjector", () => {
+  it("sequences messageIds across a run", () => {
+    const projector = new ChatWireProjector();
+    projector.resetRun();
+
+    expect(projector.enrich({ type: "message_start", message: {} })).toMatchObject({
+      type: "message_start",
+      messageId: "m1",
+    });
+    expect(projector.enrich({ type: "message_update", message: {} })).toMatchObject({
+      messageId: "m1",
+    });
+    expect(projector.enrich({ type: "message_end", message: {} })).toMatchObject({
+      type: "message_end",
+      messageId: "m1",
+    });
+    expect(projector.enrich({ type: "message_update", message: {} })).not.toHaveProperty(
+      "messageId",
+    );
+    expect(projector.enrich({ type: "message_start", message: {} })).toMatchObject({
+      messageId: "m2",
+    });
+  });
+
+  it("restarts messageId sequencing after resetRun", () => {
+    const projector = new ChatWireProjector();
+    projector.resetRun();
+    projector.enrich({ type: "message_start", message: {} });
+    projector.enrich({ type: "message_end", message: {} });
+
+    projector.resetRun();
+
+    expect(projector.enrich({ type: "message_start", message: {} })).toMatchObject({
+      messageId: "m1",
+    });
+  });
+
+  it("pairs message_end with the seq recorded from the log by reference", () => {
+    const projector = new ChatWireProjector();
+    projector.resetRun();
+    const assistant = { role: "assistant", content: [] };
+    const other = { role: "toolResult", content: [] };
+
+    expect(
+      projector.consumeLogEvent(logEvent("assistant/message", 7, { message: assistant as never })),
+    ).toBeUndefined();
+    expect(projector.consumeLogEvent(logEvent("tool/result", 8, { message: other as never }))).toBeUndefined();
+
+    expect(projector.enrich({ type: "message_end", message: assistant })).toMatchObject({
+      seq: 7,
+    });
+    expect(projector.enrich({ type: "message_end", message: other })).toMatchObject({
+      seq: 8,
+    });
+    expect(projector.enrich({ type: "message_end", message: { role: "user" } })).not.toHaveProperty(
+      "seq",
+    );
+  });
+
+  it("drops reference pairings from the previous run after resetRun", () => {
+    const projector = new ChatWireProjector();
+    projector.resetRun();
+    const assistant = { role: "assistant", content: [] };
+    projector.consumeLogEvent(logEvent("assistant/message", 3, { message: assistant as never }));
+
+    projector.resetRun();
+
+    expect(projector.enrich({ type: "message_end", message: assistant })).not.toHaveProperty(
+      "seq",
+    );
+  });
+
+  it("echoes user/message with the pending clientId once, then clears it", () => {
+    const projector = new ChatWireProjector();
+    const message = { role: "user", content: "hi" };
+
+    projector.markPendingEcho("c1");
+    expect(
+      projector.consumeLogEvent(logEvent("user/message", 0, { message: message as never })),
+    ).toEqual({
+      type: "user_message",
+      seq: 0,
+      message,
+      clientId: "c1",
+    });
+    expect(
+      projector.consumeLogEvent(logEvent("user/message", 2, { message: message as never })),
+    ).toEqual({
+      type: "user_message",
+      seq: 2,
+      message,
+    });
+  });
+
+  it("passes trigger metadata through the echo", () => {
+    const projector = new ChatWireProjector();
+    const message = { role: "user", content: "go" };
+
+    expect(
+      projector.consumeLogEvent(
+        logEvent("user/message", 5, {
+          message: message as never,
+          source: "triggered",
+          triggerName: "t1",
+        }),
+      ),
+    ).toEqual({
+      type: "user_message",
+      seq: 5,
+      message,
+      source: "triggered",
+      triggerName: "t1",
+    });
+  });
+
+  it("discards a pending echo only for its own clientId", () => {
+    const projector = new ChatWireProjector();
+    projector.markPendingEcho("a");
+
+    projector.discardPendingEcho("b");
+    expect(
+      projector.consumeLogEvent(logEvent("user/message", 0, { message: {} as never })),
+    ).toMatchObject({ clientId: "a" });
+
+    projector.markPendingEcho("a");
+    projector.discardPendingEcho("a");
+    expect(
+      projector.consumeLogEvent(logEvent("user/message", 1, { message: {} as never })),
+    ).not.toHaveProperty("clientId");
+  });
+
+  it("clearPendingEcho removes any pending clientId", () => {
+    const projector = new ChatWireProjector();
+    projector.markPendingEcho("a");
+    projector.clearPendingEcho();
+    expect(
+      projector.consumeLogEvent(logEvent("user/message", 0, { message: {} as never })),
+    ).not.toHaveProperty("clientId");
+  });
+
+  it("translates turn/retried and ignores non-message log events", () => {
+    const projector = new ChatWireProjector();
+
+    expect(
+      projector.consumeLogEvent(logEvent("turn/retried", 9, { abandonedSeqs: [5, 6] })),
+    ).toEqual({
+      type: "turn_retried",
+      seq: 9,
+      abandonedSeqs: [5, 6],
+    });
+    expect(projector.consumeLogEvent(logEvent("turn/start", 0, {}))).toBeUndefined();
+    expect(
+      projector.consumeLogEvent(
+        logEvent("compaction/applied", 4, {
+          anchorSeq: 1,
+          digestContent: "d",
+          excludedSeqs: [],
+        }),
+      ),
+    ).toBeUndefined();
+    expect(projector.consumeLogEvent(logEvent("turn/withdrawn", 6, { seq: 2 }))).toBeUndefined();
+  });
+
+  it("enriches agent_end with the last turn/end seq", () => {
+    const projector = new ChatWireProjector();
+    expect(projector.enrich({ type: "agent_end", messages: [] })).not.toHaveProperty("seq");
+
+    projector.consumeLogEvent(logEvent("turn/end", 12, { reason: "completed" }));
+    expect(projector.enrich({ type: "agent_end", messages: [] })).toMatchObject({ seq: 12 });
+  });
+
+  it("passes unrelated wire events through unchanged", () => {
+    const projector = new ChatWireProjector();
+    const event = { type: "tool_execution_start", toolCallId: "tc1" };
+    expect(projector.enrich(event)).toBe(event);
+  });
+});

--- a/packages/server/src/__tests__/chat-wire-schema.test.ts
+++ b/packages/server/src/__tests__/chat-wire-schema.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHAT_CLOSE_CODES,
+  parseChatClientMessage,
+  parseChatReplayEvent,
+  parseChatServerEvent,
+} from "@spherse/contracts";
+
+const userMessage = { role: "user", content: "hi", timestamp: 1 };
+const assistantMessage = {
+  role: "assistant",
+  content: [{ type: "text", text: "hello" }],
+  timestamp: 2,
+};
+
+const replaySamples = [
+  { type: "turn/start", seq: 0, time: 1, data: {} },
+  { type: "turn/end", seq: 1, time: 1, data: { reason: "completed" } },
+  { type: "turn/end", seq: 1, time: 1, data: { reason: "aborted" } },
+  { type: "turn/end", seq: 1, time: 1, data: { reason: "error" } },
+  { type: "user/message", seq: 2, time: 1, data: { message: userMessage } },
+  {
+    type: "user/message",
+    seq: 2,
+    time: 1,
+    data: { message: userMessage, source: "triggered", triggerName: "t1" },
+  },
+  { type: "assistant/message", seq: 3, time: 1, data: { message: assistantMessage } },
+  {
+    type: "tool/result",
+    seq: 4,
+    time: 1,
+    data: { message: { role: "toolResult", toolCallId: "tc1", content: [], timestamp: 3 } },
+  },
+  {
+    type: "compaction/applied",
+    seq: 5,
+    time: 1,
+    data: { anchorSeq: 1, digestContent: "digest", excludedSeqs: [2, 3] },
+  },
+  {
+    type: "compaction/applied",
+    seq: 5,
+    time: 1,
+    data: {
+      anchorSeq: 1,
+      digestContent: "digest",
+      excludedSeqs: [],
+      digestSource: "llm",
+    },
+  },
+  { type: "turn/retried", seq: 6, time: 1, data: { abandonedSeqs: [3, 4] } },
+  { type: "turn/withdrawn", seq: 7, time: 1, data: { seq: 2 } },
+];
+
+const serverEventSamples = [
+  { type: "agent_start" },
+  { type: "agent_end", messages: [assistantMessage] },
+  { type: "agent_end", messages: [], seq: 7 },
+  { type: "run_status", active: true },
+  { type: "run_status", active: false },
+  { type: "turn_start" },
+  { type: "turn_end", message: assistantMessage, toolResults: [] },
+  { type: "message_start", message: assistantMessage },
+  { type: "message_update", message: assistantMessage },
+  { type: "message_update", message: assistantMessage, assistantMessageEvent: { delta: "x" } },
+  { type: "message_end", message: assistantMessage },
+  { type: "message_end", message: assistantMessage, seq: 9 },
+  { type: "tool_execution_start", toolCallId: "tc1", toolName: "read_file", args: { path: "a" } },
+  {
+    type: "tool_execution_update",
+    toolCallId: "tc1",
+    toolName: "read_file",
+    args: { path: "a" },
+    partialResult: { text: "..." },
+  },
+  {
+    type: "tool_execution_end",
+    toolCallId: "tc1",
+    toolName: "read_file",
+    result: { text: "done" },
+    isError: false,
+  },
+  {
+    type: "control_request",
+    requestId: "r1",
+    kind: "approval",
+    toolCallId: "tc1",
+    toolName: "write_file",
+    args: { path: "a" },
+  },
+  {
+    type: "control_request",
+    requestId: "r2",
+    kind: "question",
+    toolCallId: "tc2",
+    toolName: "ask_user",
+    args: { question: "q" },
+  },
+  { type: "control_resolved", requestId: "r1", kind: "approval", approved: true },
+  {
+    type: "control_resolved",
+    requestId: "r2",
+    kind: "question",
+    answer: "a",
+    timedOut: false,
+  },
+  { type: "turn_withdrawn", seq: 4 },
+  { type: "user_message", seq: 5, message: userMessage },
+  { type: "user_message", seq: 5, message: userMessage, clientId: "c1" },
+  {
+    type: "user_message",
+    seq: 5,
+    message: userMessage,
+    clientId: "c1",
+    source: "triggered",
+    triggerName: "t1",
+  },
+  { type: "turn_retried", seq: 6, abandonedSeqs: [1, 2] },
+  { type: "session_ready", lastSeq: 9, replay: true },
+  { type: "replay_events", events: replaySamples },
+  { type: "replay_done" },
+  { type: "error", message: "boom" },
+  { type: "error", message: "boom", code: "TRANSIENT" },
+  { type: "pong" },
+];
+
+describe("chat wire schema", () => {
+  it("accepts every replay envelope variant", () => {
+    for (const sample of replaySamples) {
+      expect(() => parseChatReplayEvent(sample)).not.toThrow();
+    }
+  });
+
+  it("accepts every server event variant the hub can emit", () => {
+    for (const sample of serverEventSamples) {
+      expect(() => parseChatServerEvent(sample)).not.toThrow();
+    }
+  });
+
+  it("rejects malformed replay envelopes", () => {
+    expect(() => parseChatReplayEvent({ type: "turn/retried", seq: 1, time: 1 })).toThrow();
+    expect(() =>
+      parseChatReplayEvent({ type: "turn/end", seq: 1, time: 1, data: { reason: "nope" } }),
+    ).toThrow();
+    expect(() => parseChatReplayEvent({ type: "unknown", seq: 1, time: 1, data: {} })).toThrow();
+  });
+
+  it("rejects malformed server events", () => {
+    expect(() => parseChatServerEvent({ type: "user_message", message: userMessage })).toThrow();
+    expect(() =>
+      parseChatServerEvent({ type: "session_ready", lastSeq: "x", replay: true }),
+    ).toThrow();
+    expect(() => parseChatServerEvent({ type: "definitely_not_an_event" })).toThrow();
+  });
+
+  it("accepts client messages with and without clientId", () => {
+    expect(parseChatClientMessage({ type: "message", content: "hi" })).toEqual({
+      type: "message",
+      content: "hi",
+    });
+    expect(
+      parseChatClientMessage({ type: "message", content: "hi", clientId: "c1" }),
+    ).toEqual({ type: "message", content: "hi", clientId: "c1" });
+  });
+
+  it("keeps close codes stable on the wire contract", () => {
+    expect(CHAT_CLOSE_CODES).toEqual({
+      PROTOCOL_ERROR: 4400,
+      SESSION_UNRECOVERABLE: 4401,
+      MIGRATION_REQUIRED: 4402,
+    });
+  });
+});

--- a/packages/server/src/__tests__/chat-wire-schema.test.ts
+++ b/packages/server/src/__tests__/chat-wire-schema.test.ts
@@ -62,10 +62,13 @@ const serverEventSamples = [
   { type: "turn_start" },
   { type: "turn_end", message: assistantMessage, toolResults: [] },
   { type: "message_start", message: assistantMessage },
+  { type: "message_start", message: assistantMessage, messageId: "m1" },
   { type: "message_update", message: assistantMessage },
+  { type: "message_update", message: assistantMessage, messageId: "m1" },
   { type: "message_update", message: assistantMessage, assistantMessageEvent: { delta: "x" } },
   { type: "message_end", message: assistantMessage },
   { type: "message_end", message: assistantMessage, seq: 9 },
+  { type: "message_end", message: assistantMessage, messageId: "m1", seq: 9 },
   { type: "tool_execution_start", toolCallId: "tc1", toolName: "read_file", args: { path: "a" } },
   {
     type: "tool_execution_update",

--- a/packages/server/src/__tests__/sessions-send-message.test.ts
+++ b/packages/server/src/__tests__/sessions-send-message.test.ts
@@ -28,6 +28,9 @@ function createRuntime() {
     abortSession: vi.fn(),
     resolveControlRequest: vi.fn(),
     destroySession: vi.fn(),
+    subscribeSessionEvents: vi.fn(() => () => {}),
+    readSessionEventsAfter: vi.fn(() => []),
+    getSessionLastSeq: vi.fn(() => -1),
   };
   return {
     runtime,

--- a/packages/server/src/__tests__/ws-chat.test.ts
+++ b/packages/server/src/__tests__/ws-chat.test.ts
@@ -163,6 +163,31 @@ describe("ws-chat /ws/projects/:p/chat/:a/:s handler", () => {
     ]);
   });
 
+  it("treats since=-1 as a full-replay cursor", async () => {
+    routeHandler = null;
+    const mock = createMockRegistry();
+    mock.sessionRuntime.readSessionEventsAfter.mockReturnValue([
+      { type: "turn/start", seq: 0, time: 1, data: {} },
+    ]);
+    handleChatWebSocket(mockFastify as never, mock.registry as never, new ChatSessionHub(hubLogger));
+    const cursorSocket = createMockSocket();
+    routeHandler!(
+      cursorSocket,
+      req({ projectId: "p1", agentId: "a1", sessionId: "s1" }, { since: "-1" }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mock.sessionRuntime.readSessionEventsAfter).toHaveBeenCalledWith(
+      "a1",
+      "s1",
+      -1,
+      expect.any(Number),
+    );
+    expect(
+      sentObjects(cursorSocket).map((event) => (event as { type: string }).type),
+    ).toEqual(["session_ready", "replay_events", "replay_done", "run_status"]);
+  });
+
   it("routes message sends with a clientId without changing the runtime call", async () => {
     socket.simulateMessage(
       Buffer.from(JSON.stringify({ type: "message", content: "hi", clientId: "c1" })),
@@ -193,6 +218,14 @@ describe("ws-chat /ws/projects/:p/chat/:a/:s handler", () => {
       type: "error",
       message: "Invalid WebSocket message",
     });
+    expect(socket.close).toHaveBeenCalledWith(
+      CHAT_CLOSE_CODES.PROTOCOL_ERROR,
+      "Invalid WebSocket message",
+    );
+  });
+
+  it("closes with PROTOCOL_ERROR on a schema-violating client message", () => {
+    socket.simulateMessage(Buffer.from(JSON.stringify({ type: "message" })));
     expect(socket.close).toHaveBeenCalledWith(
       CHAT_CLOSE_CODES.PROTOCOL_ERROR,
       "Invalid WebSocket message",

--- a/packages/server/src/__tests__/ws-chat.test.ts
+++ b/packages/server/src/__tests__/ws-chat.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { NotFoundError, ModelNotConfiguredError, ValidationError } from "@spherse/core";
+import {
+  NotFoundError,
+  ModelNotConfiguredError,
+  MigrationRequiredError,
+  ValidationError,
+} from "@spherse/core";
 
 import { handleChatWebSocket } from "../ws-chat.js";
 import { ChatSessionHub } from "../chat-session-hub.js";
@@ -57,6 +62,9 @@ function createMockRegistry() {
     abortSession: vi.fn(),
     resolveControlRequest: vi.fn(),
     destroySession: vi.fn(),
+    subscribeSessionEvents: vi.fn(() => () => {}),
+    readSessionEventsAfter: vi.fn(() => []),
+    getSessionLastSeq: vi.fn(() => -1),
   };
   const ctx = { sessionRuntime };
   return {
@@ -73,8 +81,8 @@ const hubLogger = {
   error: vi.fn(),
 };
 
-function req(params: Record<string, string>): unknown {
-  return { params };
+function req(params: Record<string, string>, query?: Record<string, string>): unknown {
+  return query ? { params, query } : { params };
 }
 
 describe("ws-chat /ws/projects/:p/chat/:a/:s handler", () => {
@@ -93,6 +101,102 @@ describe("ws-chat /ws/projects/:p/chat/:a/:s handler", () => {
   it("replies with pong on ping", () => {
     socket.simulateMessage(Buffer.from(JSON.stringify({ type: "ping" })));
     expect(sentObjects(socket)).toContainEqual({ type: "pong" });
+  });
+
+  it("sends the session_ready handshake as the first event on connect", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const sent = sentObjects(socket);
+    expect(sent[0]).toEqual({ type: "session_ready", lastSeq: -1, replay: true });
+    expect(sent.at(-1)).toEqual({ type: "run_status", active: false });
+  });
+
+  it("replays persisted events after the since cursor from the query string", async () => {
+    routeHandler = null;
+    const mock = createMockRegistry();
+    mock.sessionRuntime.getSessionLastSeq.mockReturnValue(9);
+    mock.sessionRuntime.readSessionEventsAfter.mockReturnValue([
+      { type: "user/message", seq: 8, time: 1, data: { message: { role: "user", content: "hi" } } },
+      { type: "turn/start", seq: 9, time: 1, data: {} },
+    ]);
+    handleChatWebSocket(mockFastify as never, mock.registry as never, new ChatSessionHub(hubLogger));
+    const replaySocket = createMockSocket();
+    routeHandler!(
+      replaySocket,
+      req({ projectId: "p1", agentId: "a1", sessionId: "s1" }, { since: "7" }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mock.sessionRuntime.readSessionEventsAfter).toHaveBeenCalledWith(
+      "a1",
+      "s1",
+      7,
+      expect.any(Number),
+    );
+    const sent = sentObjects(replaySocket);
+    expect(sent.map((event) => (event as { type: string }).type)).toEqual([
+      "session_ready",
+      "replay_events",
+      "replay_done",
+      "run_status",
+    ]);
+    expect(sent[0]).toEqual({ type: "session_ready", lastSeq: 9, replay: true });
+    expect(
+      (sent[1] as { events: Array<{ seq: number }> }).events.map((event) => event.seq),
+    ).toEqual([8, 9]);
+  });
+
+  it("ignores a non-numeric since cursor", async () => {
+    routeHandler = null;
+    const mock = createMockRegistry();
+    handleChatWebSocket(mockFastify as never, mock.registry as never, new ChatSessionHub(hubLogger));
+    const cursorSocket = createMockSocket();
+    routeHandler!(
+      cursorSocket,
+      req({ projectId: "p1", agentId: "a1", sessionId: "s1" }, { since: "abc" }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mock.sessionRuntime.readSessionEventsAfter).not.toHaveBeenCalled();
+    expect(sentObjects(cursorSocket).map((event) => (event as { type: string }).type)).toEqual([
+      "session_ready",
+      "run_status",
+    ]);
+  });
+
+  it("routes message sends with a clientId without changing the runtime call", async () => {
+    socket.simulateMessage(
+      Buffer.from(JSON.stringify({ type: "message", content: "hi", clientId: "c1" })),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sessionRuntime.sendMessage).toHaveBeenCalledWith(
+      "s1",
+      "hi",
+      [],
+      expect.any(Function),
+    );
+  });
+
+  it("routes legacy client messages without a clientId", async () => {
+    socket.simulateMessage(Buffer.from(JSON.stringify({ type: "message", content: "hi" })));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sessionRuntime.sendMessage).toHaveBeenCalledWith(
+      "s1",
+      "hi",
+      [],
+      expect.any(Function),
+    );
+  });
+
+  it("closes with PROTOCOL_ERROR on an invalid client message", () => {
+    socket.simulateMessage(Buffer.from("not-json"));
+    expect(sentObjects(socket)).toContainEqual({
+      type: "error",
+      message: "Invalid WebSocket message",
+    });
+    expect(socket.close).toHaveBeenCalledWith(
+      CHAT_CLOSE_CODES.PROTOCOL_ERROR,
+      "Invalid WebSocket message",
+    );
   });
 
   it("routes withdraw to withdrawLastTurn and broadcasts turn_withdrawn", async () => {
@@ -224,6 +328,22 @@ describe("ws-chat /ws/projects/:p/chat/:a/:s handler", () => {
     routeHandler!(errSocket, req({ projectId: "p1", agentId: "a1", sessionId: "s1" }));
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(errSocket.close).toHaveBeenCalledWith(1000, "boom");
+  });
+
+  it("closes with MIGRATION_REQUIRED when restore rejects MigrationRequiredError", async () => {
+    routeHandler = null;
+    const mock = createMockRegistry();
+    mock.sessionRuntime.restoreSession = vi.fn().mockRejectedValue(
+      new MigrationRequiredError("legacy session must be migrated"),
+    );
+    handleChatWebSocket(mockFastify as never, mock.registry as never, new ChatSessionHub(hubLogger));
+    const errSocket = createMockSocket();
+    routeHandler!(errSocket, req({ projectId: "p1", agentId: "a1", sessionId: "s1" }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(errSocket.close).toHaveBeenCalledWith(
+      CHAT_CLOSE_CODES.MIGRATION_REQUIRED,
+      "legacy session must be migrated",
+    );
   });
 
   it("sends error with MODEL_NOT_CONFIGURED code and keeps connection open", async () => {

--- a/packages/server/src/__tests__/ws-chat.test.ts
+++ b/packages/server/src/__tests__/ws-chat.test.ts
@@ -379,6 +379,22 @@ describe("ws-chat /ws/projects/:p/chat/:a/:s handler", () => {
     );
   });
 
+  it("closes with SESSION_UNRECOVERABLE when the handshake facade read fails", async () => {
+    routeHandler = null;
+    const mock = createMockRegistry();
+    mock.sessionRuntime.getSessionLastSeq.mockImplementation(() => {
+      throw new NotFoundError(`Agent "a1" not found`);
+    });
+    handleChatWebSocket(mockFastify as never, mock.registry as never, new ChatSessionHub(hubLogger));
+    const errSocket = createMockSocket();
+    routeHandler!(errSocket, req({ projectId: "p1", agentId: "a1", sessionId: "s1" }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(errSocket.close).toHaveBeenCalledWith(
+      CHAT_CLOSE_CODES.SESSION_UNRECOVERABLE,
+      'Agent "a1" not found',
+    );
+  });
+
   it("sends error with MODEL_NOT_CONFIGURED code and keeps connection open", async () => {
     sessionRuntime.sendMessage.mockRejectedValue(new ModelNotConfiguredError());
     socket.simulateMessage(Buffer.from(JSON.stringify({ type: "message", content: "hi" })));

--- a/packages/server/src/chat-channel.ts
+++ b/packages/server/src/chat-channel.ts
@@ -1,0 +1,301 @@
+import {
+  ConflictError,
+  type Attachment,
+  type SessionManager,
+} from "@spherse/core";
+import type { FastifyBaseLogger } from "fastify";
+import { classifyRunError } from "./classify-run-error.js";
+import { ChatWireProjector } from "./chat-wire-projector.js";
+
+type CoreEventHandler = Parameters<SessionManager["sendMessage"]>[3];
+type CoreEvent = Parameters<CoreEventHandler>[0];
+type Subscriber = (event: unknown) => void;
+
+const REPLAY_BATCH_SIZE = 200;
+const REPLAY_READ_LIMIT = Number.MAX_SAFE_INTEGER;
+
+export type ControlRequestDecision =
+  | { approved: boolean; reason?: string }
+  | { answer?: string; timedOut: boolean };
+
+export interface ChatSessionAttachment {
+  ready: Promise<boolean>;
+  sendMessage(content: string, attachments?: Attachment[], clientId?: string): Promise<void>;
+  retryLastTurn(): Promise<void>;
+  withdrawLastTurn(): Promise<void>;
+  abort(): void;
+  resolveControlRequest(
+    requestId: string,
+    decision: ControlRequestDecision,
+  ): void;
+  close(): void;
+}
+
+export class ChatChannel {
+  readonly ready: Promise<void>;
+  private initialized = false;
+  private attachments = 0;
+  private readonly subscribers = new Set<Subscriber>();
+  private running = false;
+  private runEvents: CoreEvent[] = [];
+  private readonly projector = new ChatWireProjector();
+  private logUnsubscribe?: () => void;
+
+  private constructor(
+    private readonly runtime: SessionManager,
+    private readonly logger: FastifyBaseLogger,
+    readonly agentId: string,
+    readonly sessionId: string,
+    private readonly dispose: () => void,
+  ) {
+    this.ready = runtime.restoreSession(agentId, sessionId)
+      .then(() => {
+        this.initialized = true;
+        this.logUnsubscribe = this.subscribeLog() ?? undefined;
+      })
+      .catch((err) => {
+        this.release();
+        throw err;
+      })
+      .finally(() => {
+        this.cleanupIfIdle();
+      });
+  }
+
+  static open(
+    runtime: SessionManager,
+    logger: FastifyBaseLogger,
+    agentId: string,
+    sessionId: string,
+    dispose: () => void,
+  ): ChatChannel {
+    return new ChatChannel(runtime, logger, agentId, sessionId, dispose);
+  }
+
+  attach(subscriber: Subscriber, since?: number): ChatSessionAttachment {
+    this.attachments += 1;
+    let active = true;
+    let subscribed = false;
+
+    const ready = this.ready.then(() => {
+      if (!active) return false;
+      this.handshake(subscriber, since);
+      this.subscribers.add(subscriber);
+      subscribed = true;
+      return true;
+    });
+
+    return {
+      ready,
+      sendMessage: async (content, attachments, clientId) => {
+        if (!(await ready) || !active) return;
+        try {
+          await this.startRun((onEvent) => {
+            if (clientId !== undefined) this.projector.markPendingEcho(clientId);
+            return this.runtime.sendMessage(
+              this.sessionId,
+              content,
+              attachments ?? [],
+              onEvent,
+            );
+          });
+        } catch (err) {
+          if (clientId !== undefined) {
+            this.projector.discardPendingEcho(clientId);
+          }
+          throw err;
+        }
+      },
+      retryLastTurn: async () => {
+        if (!(await ready) || !active) return;
+        await this.startRun((onEvent) =>
+          this.runtime.retryLastTurn(this.sessionId, onEvent),
+        );
+      },
+      withdrawLastTurn: async () => {
+        if (!(await ready) || !active) return;
+        if (this.running) {
+          throw new ConflictError(`Session "${this.sessionId}" is already running`);
+        }
+        const seq = await this.runtime.withdrawLastTurn(this.sessionId);
+        this.publish({ type: "turn_withdrawn", seq });
+      },
+      abort: () => {
+        if (active) this.runtime.abortSession(this.sessionId);
+      },
+      resolveControlRequest: (requestId, decision) => {
+        if (active) {
+          this.runtime.resolveControlRequest(this.sessionId, requestId, decision);
+        }
+      },
+      close: () => {
+        if (!active) return;
+        active = false;
+        this.attachments = Math.max(0, this.attachments - 1);
+        if (subscribed) this.subscribers.delete(subscriber);
+        this.cleanupIfIdle();
+      },
+    };
+  }
+
+  async startDetachedRun(content: string): Promise<void> {
+    this.attachments += 1;
+    try {
+      await this.ready;
+      if (this.running) {
+        throw new ConflictError(`Session "${this.sessionId}" is already running`);
+      }
+    } catch (err) {
+      this.attachments -= 1;
+      this.cleanupIfIdle();
+      throw err;
+    }
+    this.startRun((onEvent) =>
+      this.runtime.sendMessage(this.sessionId, content, [], onEvent),
+    )
+      .catch((err) => {
+        this.logger.error({ err, sessionId: this.sessionId }, "detached chat run failed");
+        this.publish({
+          type: "error",
+          message: err instanceof Error ? err.message : "chat error",
+          code: classifyRunError(err),
+        });
+      })
+      .finally(() => {
+        this.attachments -= 1;
+        this.cleanupIfIdle();
+      });
+  }
+
+  private release(): void {
+    this.logUnsubscribe?.();
+    this.logUnsubscribe = undefined;
+    this.dispose();
+  }
+
+  private subscribeLog(): (() => void) | null {
+    return this.runtime.subscribeSessionEvents(this.sessionId, (event) => {
+      const wireEvent = this.projector.consumeLogEvent(event);
+      if (wireEvent !== undefined) {
+        this.publish(wireEvent);
+      }
+    });
+  }
+
+  private handshake(subscriber: Subscriber, since: number | undefined): void {
+    const lastSeq = this.runtime.getSessionLastSeq(this.agentId, this.sessionId);
+    this.notify(subscriber, {
+      type: "session_ready",
+      lastSeq,
+      replay: true,
+    });
+    if (since !== undefined) {
+      const events = this.runtime.readSessionEventsAfter(
+        this.agentId,
+        this.sessionId,
+        since,
+        REPLAY_READ_LIMIT,
+      );
+      for (let i = 0; i < events.length; i += REPLAY_BATCH_SIZE) {
+        this.notify(subscriber, {
+          type: "replay_events",
+          events: events.slice(i, i + REPLAY_BATCH_SIZE),
+        });
+      }
+      this.notify(subscriber, { type: "replay_done" });
+    }
+    for (const event of this.runEvents) {
+      this.notify(subscriber, event);
+    }
+    this.notify(subscriber, {
+      type: "run_status",
+      active: this.running,
+    });
+  }
+
+  private async startRun(
+    executor: (onEvent: CoreEventHandler) => Promise<void>,
+  ): Promise<void> {
+    if (this.running) {
+      throw new ConflictError(`Session "${this.sessionId}" is already running`);
+    }
+    this.running = true;
+    this.runEvents = [];
+    this.projector.resetRun();
+    this.publish({ type: "run_status", active: true });
+    try {
+      await executor((event) => {
+        const enriched = this.projector.enrich(event);
+        this.recordRunEvent(enriched);
+        this.publish(enriched);
+      });
+    } finally {
+      this.running = false;
+      this.runEvents = [];
+      this.projector.clearPendingEcho();
+      this.publish({ type: "run_status", active: false });
+      this.cleanupIfIdle();
+    }
+  }
+
+  private recordRunEvent(event: CoreEvent): void {
+    if (event.type === "message_update") {
+      for (let i = this.runEvents.length - 1; i >= 0; i--) {
+        if (
+          this.runEvents[i].type === "message_start" ||
+          this.runEvents[i].type === "message_end"
+        ) {
+          break;
+        }
+        if (this.runEvents[i].type === "message_update") {
+          this.runEvents[i] = event;
+          return;
+        }
+      }
+    }
+    if (event.type === "tool_execution_update") {
+      for (let i = this.runEvents.length - 1; i >= 0; i--) {
+        const previous = this.runEvents[i];
+        if (
+          previous.type === "tool_execution_update" &&
+          previous.toolCallId === event.toolCallId
+        ) {
+          this.runEvents[i] = event;
+          return;
+        }
+        if (
+          previous.type === "tool_execution_start" &&
+          previous.toolCallId === event.toolCallId
+        ) {
+          break;
+        }
+      }
+    }
+    this.runEvents.push(event);
+  }
+
+  private publish(event: unknown): void {
+    for (const subscriber of this.subscribers) {
+      this.notify(subscriber, event);
+    }
+  }
+
+  private notify(subscriber: Subscriber, event: unknown): void {
+    try {
+      subscriber(event);
+    } catch (err) {
+      this.logger.debug(
+        { err, sessionId: this.sessionId },
+        "chat session subscriber failed",
+      );
+    }
+  }
+
+  private cleanupIfIdle(): void {
+    if (!this.initialized || this.running || this.attachments > 0) {
+      return;
+    }
+    this.runtime.destroySession(this.sessionId);
+    this.release();
+  }
+}

--- a/packages/server/src/chat-session-hub.ts
+++ b/packages/server/src/chat-session-hub.ts
@@ -5,6 +5,7 @@ import {
 } from "@spherse/core";
 import type { FastifyBaseLogger } from "fastify";
 import { classifyRunError } from "./classify-run-error.js";
+import { ChatWireProjector } from "./chat-wire-projector.js";
 
 type CoreEventHandler = Parameters<SessionManager["sendMessage"]>[3];
 type CoreEvent = Parameters<CoreEventHandler>[0];
@@ -28,12 +29,8 @@ interface ChatChannel {
   subscribers: Set<Subscriber>;
   running: boolean;
   runEvents: CoreEvent[];
+  projector: ChatWireProjector;
   logUnsubscribe?: () => void;
-  pendingClientId?: string;
-  messageSeqByRef: WeakMap<object, number>;
-  currentMessageId?: string;
-  messageCounter: number;
-  lastTurnEndSeq?: number;
 }
 
 export interface ChatSessionAttachment {
@@ -86,7 +83,7 @@ export class ChatSessionHub {
         if (!(await ready) || !active) return;
         try {
           await this.startRun(channel, (onEvent) => {
-            if (clientId !== undefined) channel.pendingClientId = clientId;
+            if (clientId !== undefined) channel.projector.markPendingEcho(clientId);
             return channel.runtime.sendMessage(
               channel.sessionId,
               content,
@@ -95,8 +92,8 @@ export class ChatSessionHub {
             );
           });
         } catch (err) {
-          if (clientId !== undefined && channel.pendingClientId === clientId) {
-            channel.pendingClientId = undefined;
+          if (clientId !== undefined) {
+            channel.projector.discardPendingEcho(clientId);
           }
           throw err;
         }
@@ -194,8 +191,7 @@ export class ChatSessionHub {
       subscribers: new Set(),
       running: false,
       runEvents: [],
-      messageSeqByRef: new WeakMap(),
-      messageCounter: 0,
+      projector: new ChatWireProjector(),
     };
     channel.ready = runtime.restoreSession(agentId, sessionId)
       .then(() => {
@@ -215,38 +211,9 @@ export class ChatSessionHub {
 
   private subscribeLog(channel: ChatChannel): (() => void) | null {
     return channel.runtime.subscribeSessionEvents(channel.sessionId, (event) => {
-      switch (event.type) {
-        case "user/message": {
-          const clientId = channel.pendingClientId;
-          channel.pendingClientId = undefined;
-          this.publish(channel, {
-            type: "user_message",
-            seq: event.seq,
-            message: event.data.message,
-            ...(clientId !== undefined ? { clientId } : {}),
-            ...(event.data.source !== undefined ? { source: event.data.source } : {}),
-            ...(event.data.triggerName !== undefined
-              ? { triggerName: event.data.triggerName }
-              : {}),
-          });
-          break;
-        }
-        case "turn/retried":
-          this.publish(channel, {
-            type: "turn_retried",
-            seq: event.seq,
-            abandonedSeqs: event.data.abandonedSeqs,
-          });
-          break;
-        case "assistant/message":
-        case "tool/result":
-          channel.messageSeqByRef.set(event.data.message as object, event.seq);
-          break;
-        case "turn/end":
-          channel.lastTurnEndSeq = event.seq;
-          break;
-        default:
-          break;
+      const wireEvent = channel.projector.consumeLogEvent(event);
+      if (wireEvent !== undefined) {
+        this.publish(channel, wireEvent);
       }
     });
   }
@@ -286,36 +253,6 @@ export class ChatSessionHub {
     });
   }
 
-  private enrichWireEvent(channel: ChatChannel, event: CoreEvent): CoreEvent {
-    if (event.type === "message_start") {
-      channel.messageCounter += 1;
-      channel.currentMessageId = `m${channel.messageCounter}`;
-      return { ...event, messageId: channel.currentMessageId } as CoreEvent;
-    }
-    if (event.type === "message_update") {
-      return channel.currentMessageId === undefined
-        ? event
-        : ({ ...event, messageId: channel.currentMessageId } as CoreEvent);
-    }
-    if (event.type === "message_end") {
-      const seq = channel.messageSeqByRef.get(event.message as object);
-      const messageId = channel.currentMessageId;
-      channel.currentMessageId = undefined;
-      const enriched = {
-        ...event,
-        ...(messageId !== undefined ? { messageId } : {}),
-        ...(seq !== undefined ? { seq } : {}),
-      };
-      return enriched as CoreEvent;
-    }
-    if (event.type === "agent_end") {
-      return channel.lastTurnEndSeq === undefined
-        ? event
-        : ({ ...event, seq: channel.lastTurnEndSeq } as CoreEvent);
-    }
-    return event;
-  }
-
   private deleteChannel(channel: ChatChannel): void {
     channel.logUnsubscribe?.();
     channel.logUnsubscribe = undefined;
@@ -331,21 +268,18 @@ export class ChatSessionHub {
     }
     channel.running = true;
     channel.runEvents = [];
-    channel.messageSeqByRef = new WeakMap();
-    channel.currentMessageId = undefined;
-    channel.messageCounter = 0;
-    channel.lastTurnEndSeq = undefined;
+    channel.projector.resetRun();
     this.publish(channel, { type: "run_status", active: true });
     try {
       await executor((event) => {
-        const enriched = this.enrichWireEvent(channel, event);
+        const enriched = channel.projector.enrich(event);
         this.recordRunEvent(channel, enriched);
         this.publish(channel, enriched);
       });
     } finally {
       channel.running = false;
       channel.runEvents = [];
-      channel.pendingClientId = undefined;
+      channel.projector.clearPendingEcho();
       this.publish(channel, { type: "run_status", active: false });
       this.cleanupIfIdle(channel);
     }

--- a/packages/server/src/chat-session-hub.ts
+++ b/packages/server/src/chat-session-hub.ts
@@ -1,50 +1,8 @@
-import {
-  ConflictError,
-  type Attachment,
-  type SessionManager,
-} from "@spherse/core";
+import type { SessionManager } from "@spherse/core";
 import type { FastifyBaseLogger } from "fastify";
-import { classifyRunError } from "./classify-run-error.js";
-import { ChatWireProjector } from "./chat-wire-projector.js";
+import { ChatChannel, type ChatSessionAttachment } from "./chat-channel.js";
 
-type CoreEventHandler = Parameters<SessionManager["sendMessage"]>[3];
-type CoreEvent = Parameters<CoreEventHandler>[0];
 type Subscriber = (event: unknown) => void;
-
-const REPLAY_BATCH_SIZE = 200;
-const REPLAY_READ_LIMIT = Number.MAX_SAFE_INTEGER;
-
-export type ControlRequestDecision =
-  | { approved: boolean; reason?: string }
-  | { answer?: string; timedOut: boolean };
-
-interface ChatChannel {
-  key: string;
-  runtime: SessionManager;
-  agentId: string;
-  sessionId: string;
-  ready: Promise<void>;
-  initialized: boolean;
-  attachments: number;
-  subscribers: Set<Subscriber>;
-  running: boolean;
-  runEvents: CoreEvent[];
-  projector: ChatWireProjector;
-  logUnsubscribe?: () => void;
-}
-
-export interface ChatSessionAttachment {
-  ready: Promise<boolean>;
-  sendMessage(content: string, attachments?: Attachment[], clientId?: string): Promise<void>;
-  retryLastTurn(): Promise<void>;
-  withdrawLastTurn(): Promise<void>;
-  abort(): void;
-  resolveControlRequest(
-    requestId: string,
-    decision: ControlRequestDecision,
-  ): void;
-  close(): void;
-}
 
 export class ChatSessionHub {
   private readonly channels = new Map<string, ChatChannel>();
@@ -59,79 +17,10 @@ export class ChatSessionHub {
     subscriber: Subscriber,
     options?: { since?: number },
   ): ChatSessionAttachment {
-    const channel = this.getOrCreateChannel(
-      projectId,
-      runtime,
-      agentId,
-      sessionId,
+    return this.getOrCreate(projectId, runtime, agentId, sessionId).attach(
+      subscriber,
+      options?.since,
     );
-    channel.attachments += 1;
-    let active = true;
-    let subscribed = false;
-
-    const ready = channel.ready.then(() => {
-      if (!active) return false;
-      this.handshake(channel, subscriber, options?.since);
-      channel.subscribers.add(subscriber);
-      subscribed = true;
-      return true;
-    });
-
-    return {
-      ready,
-      sendMessage: async (content, attachments, clientId) => {
-        if (!(await ready) || !active) return;
-        try {
-          await this.startRun(channel, (onEvent) => {
-            if (clientId !== undefined) channel.projector.markPendingEcho(clientId);
-            return channel.runtime.sendMessage(
-              channel.sessionId,
-              content,
-              attachments ?? [],
-              onEvent,
-            );
-          });
-        } catch (err) {
-          if (clientId !== undefined) {
-            channel.projector.discardPendingEcho(clientId);
-          }
-          throw err;
-        }
-      },
-      retryLastTurn: async () => {
-        if (!(await ready) || !active) return;
-        await this.startRun(channel, (onEvent) =>
-          channel.runtime.retryLastTurn(channel.sessionId, onEvent),
-        );
-      },
-      withdrawLastTurn: async () => {
-        if (!(await ready) || !active) return;
-        if (channel.running) {
-          throw new ConflictError(`Session "${channel.sessionId}" is already running`);
-        }
-        const seq = await channel.runtime.withdrawLastTurn(channel.sessionId);
-        this.publish(channel, { type: "turn_withdrawn", seq });
-      },
-      abort: () => {
-        if (active) channel.runtime.abortSession(channel.sessionId);
-      },
-      resolveControlRequest: (requestId, decision) => {
-        if (active) {
-          channel.runtime.resolveControlRequest(
-            channel.sessionId,
-            requestId,
-            decision,
-          );
-        }
-      },
-      close: () => {
-        if (!active) return;
-        active = false;
-        channel.attachments = Math.max(0, channel.attachments - 1);
-        if (subscribed) channel.subscribers.delete(subscriber);
-        this.cleanupIfIdle(channel);
-      },
-    };
   }
 
   async startDetachedRun(
@@ -141,36 +30,10 @@ export class ChatSessionHub {
     sessionId: string,
     content: string,
   ): Promise<void> {
-    const channel = this.getOrCreateChannel(projectId, runtime, agentId, sessionId);
-    channel.attachments += 1;
-    try {
-      await channel.ready;
-      if (channel.running) {
-        throw new ConflictError(`Session "${sessionId}" is already running`);
-      }
-    } catch (err) {
-      channel.attachments -= 1;
-      this.cleanupIfIdle(channel);
-      throw err;
-    }
-    this.startRun(channel, (onEvent) =>
-      channel.runtime.sendMessage(sessionId, content, [], onEvent),
-    )
-      .catch((err) => {
-        this.logger.error({ err, sessionId }, "detached chat run failed");
-        this.publish(channel, {
-          type: "error",
-          message: err instanceof Error ? err.message : "chat error",
-          code: classifyRunError(err),
-        });
-      })
-      .finally(() => {
-        channel.attachments -= 1;
-        this.cleanupIfIdle(channel);
-      });
+    return this.getOrCreate(projectId, runtime, agentId, sessionId).startDetachedRun(content);
   }
 
-  private getOrCreateChannel(
+  private getOrCreate(
     projectId: string,
     runtime: SessionManager,
     agentId: string,
@@ -180,178 +43,12 @@ export class ChatSessionHub {
     const existing = this.channels.get(key);
     if (existing) return existing;
 
-    const channel: ChatChannel = {
-      key,
-      runtime,
-      agentId,
-      sessionId,
-      ready: Promise.resolve(),
-      initialized: false,
-      attachments: 0,
-      subscribers: new Set(),
-      running: false,
-      runEvents: [],
-      projector: new ChatWireProjector(),
-    };
-    channel.ready = runtime.restoreSession(agentId, sessionId)
-      .then(() => {
-        channel.initialized = true;
-        channel.logUnsubscribe = this.subscribeLog(channel) ?? undefined;
-      })
-      .catch((err) => {
-        if (this.channels.get(key) === channel) this.deleteChannel(channel);
-        throw err;
-      })
-      .finally(() => {
-        this.cleanupIfIdle(channel);
-      });
+    const channel = ChatChannel.open(runtime, this.logger, agentId, sessionId, () => {
+      if (this.channels.get(key) === channel) {
+        this.channels.delete(key);
+      }
+    });
     this.channels.set(key, channel);
     return channel;
-  }
-
-  private subscribeLog(channel: ChatChannel): (() => void) | null {
-    return channel.runtime.subscribeSessionEvents(channel.sessionId, (event) => {
-      const wireEvent = channel.projector.consumeLogEvent(event);
-      if (wireEvent !== undefined) {
-        this.publish(channel, wireEvent);
-      }
-    });
-  }
-
-  private handshake(
-    channel: ChatChannel,
-    subscriber: Subscriber,
-    since: number | undefined,
-  ): void {
-    const lastSeq = channel.runtime.getSessionLastSeq(channel.agentId, channel.sessionId);
-    this.notify(channel, subscriber, {
-      type: "session_ready",
-      lastSeq,
-      replay: true,
-    });
-    if (since !== undefined) {
-      const events = channel.runtime.readSessionEventsAfter(
-        channel.agentId,
-        channel.sessionId,
-        since,
-        REPLAY_READ_LIMIT,
-      );
-      for (let i = 0; i < events.length; i += REPLAY_BATCH_SIZE) {
-        this.notify(channel, subscriber, {
-          type: "replay_events",
-          events: events.slice(i, i + REPLAY_BATCH_SIZE),
-        });
-      }
-      this.notify(channel, subscriber, { type: "replay_done" });
-    }
-    for (const event of channel.runEvents) {
-      this.notify(channel, subscriber, event);
-    }
-    this.notify(channel, subscriber, {
-      type: "run_status",
-      active: channel.running,
-    });
-  }
-
-  private deleteChannel(channel: ChatChannel): void {
-    channel.logUnsubscribe?.();
-    channel.logUnsubscribe = undefined;
-    this.channels.delete(channel.key);
-  }
-
-  private async startRun(
-    channel: ChatChannel,
-    executor: (onEvent: CoreEventHandler) => Promise<void>,
-  ): Promise<void> {
-    if (channel.running) {
-      throw new ConflictError(`Session "${channel.sessionId}" is already running`);
-    }
-    channel.running = true;
-    channel.runEvents = [];
-    channel.projector.resetRun();
-    this.publish(channel, { type: "run_status", active: true });
-    try {
-      await executor((event) => {
-        const enriched = channel.projector.enrich(event);
-        this.recordRunEvent(channel, enriched);
-        this.publish(channel, enriched);
-      });
-    } finally {
-      channel.running = false;
-      channel.runEvents = [];
-      channel.projector.clearPendingEcho();
-      this.publish(channel, { type: "run_status", active: false });
-      this.cleanupIfIdle(channel);
-    }
-  }
-
-  private recordRunEvent(channel: ChatChannel, event: CoreEvent): void {
-    if (event.type === "message_update") {
-      for (let i = channel.runEvents.length - 1; i >= 0; i--) {
-        if (
-          channel.runEvents[i].type === "message_start" ||
-          channel.runEvents[i].type === "message_end"
-        ) {
-          break;
-        }
-        if (channel.runEvents[i].type === "message_update") {
-          channel.runEvents[i] = event;
-          return;
-        }
-      }
-    }
-    if (event.type === "tool_execution_update") {
-      for (let i = channel.runEvents.length - 1; i >= 0; i--) {
-        const previous = channel.runEvents[i];
-        if (
-          previous.type === "tool_execution_update" &&
-          previous.toolCallId === event.toolCallId
-        ) {
-          channel.runEvents[i] = event;
-          return;
-        }
-        if (
-          previous.type === "tool_execution_start" &&
-          previous.toolCallId === event.toolCallId
-        ) {
-          break;
-        }
-      }
-    }
-    channel.runEvents.push(event);
-  }
-
-  private publish(channel: ChatChannel, event: unknown): void {
-    for (const subscriber of channel.subscribers) {
-      this.notify(channel, subscriber, event);
-    }
-  }
-
-  private notify(
-    channel: ChatChannel,
-    subscriber: Subscriber,
-    event: unknown,
-  ): void {
-    try {
-      subscriber(event);
-    } catch (err) {
-      this.logger.debug(
-        { err, sessionId: channel.sessionId },
-        "chat session subscriber failed",
-      );
-    }
-  }
-
-  private cleanupIfIdle(channel: ChatChannel): void {
-    if (
-      !channel.initialized ||
-      channel.running ||
-      channel.attachments > 0 ||
-      this.channels.get(channel.key) !== channel
-    ) {
-      return;
-    }
-    channel.runtime.destroySession(channel.sessionId);
-    this.deleteChannel(channel);
   }
 }

--- a/packages/server/src/chat-session-hub.ts
+++ b/packages/server/src/chat-session-hub.ts
@@ -1,10 +1,17 @@
-import { ConflictError, type Attachment, type SessionManager } from "@spherse/core";
+import {
+  ConflictError,
+  type Attachment,
+  type SessionManager,
+} from "@spherse/core";
 import type { FastifyBaseLogger } from "fastify";
 import { classifyRunError } from "./classify-run-error.js";
 
 type CoreEventHandler = Parameters<SessionManager["sendMessage"]>[3];
 type CoreEvent = Parameters<CoreEventHandler>[0];
 type Subscriber = (event: unknown) => void;
+
+const REPLAY_BATCH_SIZE = 200;
+const REPLAY_READ_LIMIT = Number.MAX_SAFE_INTEGER;
 
 export type ControlRequestDecision =
   | { approved: boolean; reason?: string }
@@ -21,11 +28,15 @@ interface ChatChannel {
   subscribers: Set<Subscriber>;
   running: boolean;
   runEvents: CoreEvent[];
+  logUnsubscribe?: () => void;
+  pendingClientId?: string;
+  messageSeqByEventId: Map<string, number>;
+  lastTurnEndSeq?: number;
 }
 
 export interface ChatSessionAttachment {
   ready: Promise<boolean>;
-  sendMessage(content: string, attachments?: Attachment[]): Promise<void>;
+  sendMessage(content: string, attachments?: Attachment[], clientId?: string): Promise<void>;
   retryLastTurn(): Promise<void>;
   withdrawLastTurn(): Promise<void>;
   abort(): void;
@@ -47,6 +58,7 @@ export class ChatSessionHub {
     agentId: string,
     sessionId: string,
     subscriber: Subscriber,
+    options?: { since?: number },
   ): ChatSessionAttachment {
     const channel = this.getOrCreateChannel(
       projectId,
@@ -60,13 +72,7 @@ export class ChatSessionHub {
 
     const ready = channel.ready.then(() => {
       if (!active) return false;
-      for (const event of channel.runEvents) {
-        this.notify(channel, subscriber, event);
-      }
-      this.notify(channel, subscriber, {
-        type: "run_status",
-        active: channel.running,
-      });
+      this.handshake(channel, subscriber, options?.since);
       channel.subscribers.add(subscriber);
       subscribed = true;
       return true;
@@ -74,16 +80,22 @@ export class ChatSessionHub {
 
     return {
       ready,
-      sendMessage: async (content, attachments) => {
+      sendMessage: async (content, attachments, clientId) => {
         if (!(await ready) || !active) return;
-        await this.startRun(channel, (onEvent) =>
-          channel.runtime.sendMessage(
-            channel.sessionId,
-            content,
-            attachments ?? [],
-            onEvent,
-          ),
-        );
+        if (clientId !== undefined) channel.pendingClientId = clientId;
+        try {
+          await this.startRun(channel, (onEvent) =>
+            channel.runtime.sendMessage(
+              channel.sessionId,
+              content,
+              attachments ?? [],
+              onEvent,
+            ),
+          );
+        } catch (err) {
+          channel.pendingClientId = undefined;
+          throw err;
+        }
       },
       retryLastTurn: async () => {
         if (!(await ready) || !active) return;
@@ -178,13 +190,15 @@ export class ChatSessionHub {
       subscribers: new Set(),
       running: false,
       runEvents: [],
+      messageSeqByEventId: new Map(),
     };
     channel.ready = runtime.restoreSession(agentId, sessionId)
       .then(() => {
         channel.initialized = true;
+        channel.logUnsubscribe = this.subscribeLog(channel) ?? undefined;
       })
       .catch((err) => {
-        if (this.channels.get(key) === channel) this.channels.delete(key);
+        if (this.channels.get(key) === channel) this.deleteChannel(channel);
         throw err;
       })
       .finally(() => {
@@ -192,6 +206,103 @@ export class ChatSessionHub {
       });
     this.channels.set(key, channel);
     return channel;
+  }
+
+  private subscribeLog(channel: ChatChannel): (() => void) | null {
+    return channel.runtime.subscribeSessionEvents(channel.sessionId, (event) => {
+      switch (event.type) {
+        case "user/message": {
+          const clientId = channel.pendingClientId;
+          channel.pendingClientId = undefined;
+          this.publish(channel, {
+            type: "user_message",
+            seq: event.seq,
+            message: event.data.message,
+            ...(clientId !== undefined ? { clientId } : {}),
+            ...(event.data.source !== undefined ? { source: event.data.source } : {}),
+            ...(event.data.triggerName !== undefined
+              ? { triggerName: event.data.triggerName }
+              : {}),
+          });
+          break;
+        }
+        case "turn/retried":
+          this.publish(channel, {
+            type: "turn_retried",
+            seq: event.seq,
+            abandonedSeqs: event.data.abandonedSeqs,
+          });
+          break;
+        case "assistant/message":
+        case "tool/result": {
+          const id = (event.data.message as { id?: unknown }).id;
+          if (id !== undefined) {
+            channel.messageSeqByEventId.set(String(id), event.seq);
+          }
+          break;
+        }
+        case "turn/end":
+          channel.lastTurnEndSeq = event.seq;
+          break;
+        default:
+          break;
+      }
+    });
+  }
+
+  private handshake(
+    channel: ChatChannel,
+    subscriber: Subscriber,
+    since: number | undefined,
+  ): void {
+    const lastSeq = channel.runtime.getSessionLastSeq(channel.agentId, channel.sessionId);
+    this.notify(channel, subscriber, {
+      type: "session_ready",
+      lastSeq,
+      replay: true,
+    });
+    if (since !== undefined) {
+      const events = channel.runtime.readSessionEventsAfter(
+        channel.agentId,
+        channel.sessionId,
+        since,
+        REPLAY_READ_LIMIT,
+      );
+      for (let i = 0; i < events.length; i += REPLAY_BATCH_SIZE) {
+        this.notify(channel, subscriber, {
+          type: "replay_events",
+          events: events.slice(i, i + REPLAY_BATCH_SIZE),
+        });
+      }
+      this.notify(channel, subscriber, { type: "replay_done" });
+    }
+    for (const event of channel.runEvents) {
+      this.notify(channel, subscriber, event);
+    }
+    this.notify(channel, subscriber, {
+      type: "run_status",
+      active: channel.running,
+    });
+  }
+
+  private enrichWireEvent(channel: ChatChannel, event: CoreEvent): CoreEvent {
+    if (event.type === "message_end") {
+      const id = (event.message as { id?: unknown }).id;
+      const seq = id !== undefined ? channel.messageSeqByEventId.get(String(id)) : undefined;
+      return seq === undefined ? event : ({ ...event, seq } as CoreEvent);
+    }
+    if (event.type === "agent_end") {
+      return channel.lastTurnEndSeq === undefined
+        ? event
+        : ({ ...event, seq: channel.lastTurnEndSeq } as CoreEvent);
+    }
+    return event;
+  }
+
+  private deleteChannel(channel: ChatChannel): void {
+    channel.logUnsubscribe?.();
+    channel.logUnsubscribe = undefined;
+    this.channels.delete(channel.key);
   }
 
   private async startRun(
@@ -203,15 +314,19 @@ export class ChatSessionHub {
     }
     channel.running = true;
     channel.runEvents = [];
+    channel.messageSeqByEventId.clear();
+    channel.lastTurnEndSeq = undefined;
     this.publish(channel, { type: "run_status", active: true });
     try {
       await executor((event) => {
-        this.recordRunEvent(channel, event);
-        this.publish(channel, event);
+        const enriched = this.enrichWireEvent(channel, event);
+        this.recordRunEvent(channel, enriched);
+        this.publish(channel, enriched);
       });
     } finally {
       channel.running = false;
       channel.runEvents = [];
+      channel.pendingClientId = undefined;
       this.publish(channel, { type: "run_status", active: false });
       this.cleanupIfIdle(channel);
     }
@@ -284,6 +399,6 @@ export class ChatSessionHub {
       return;
     }
     channel.runtime.destroySession(channel.sessionId);
-    this.channels.delete(channel.key);
+    this.deleteChannel(channel);
   }
 }

--- a/packages/server/src/chat-session-hub.ts
+++ b/packages/server/src/chat-session-hub.ts
@@ -30,7 +30,9 @@ interface ChatChannel {
   runEvents: CoreEvent[];
   logUnsubscribe?: () => void;
   pendingClientId?: string;
-  messageSeqByEventId: Map<string, number>;
+  messageSeqByRef: WeakMap<object, number>;
+  currentMessageId?: string;
+  messageCounter: number;
   lastTurnEndSeq?: number;
 }
 
@@ -82,18 +84,20 @@ export class ChatSessionHub {
       ready,
       sendMessage: async (content, attachments, clientId) => {
         if (!(await ready) || !active) return;
-        if (clientId !== undefined) channel.pendingClientId = clientId;
         try {
-          await this.startRun(channel, (onEvent) =>
-            channel.runtime.sendMessage(
+          await this.startRun(channel, (onEvent) => {
+            if (clientId !== undefined) channel.pendingClientId = clientId;
+            return channel.runtime.sendMessage(
               channel.sessionId,
               content,
               attachments ?? [],
               onEvent,
-            ),
-          );
+            );
+          });
         } catch (err) {
-          channel.pendingClientId = undefined;
+          if (clientId !== undefined && channel.pendingClientId === clientId) {
+            channel.pendingClientId = undefined;
+          }
           throw err;
         }
       },
@@ -190,7 +194,8 @@ export class ChatSessionHub {
       subscribers: new Set(),
       running: false,
       runEvents: [],
-      messageSeqByEventId: new Map(),
+      messageSeqByRef: new WeakMap(),
+      messageCounter: 0,
     };
     channel.ready = runtime.restoreSession(agentId, sessionId)
       .then(() => {
@@ -234,13 +239,9 @@ export class ChatSessionHub {
           });
           break;
         case "assistant/message":
-        case "tool/result": {
-          const id = (event.data.message as { id?: unknown }).id;
-          if (id !== undefined) {
-            channel.messageSeqByEventId.set(String(id), event.seq);
-          }
+        case "tool/result":
+          channel.messageSeqByRef.set(event.data.message as object, event.seq);
           break;
-        }
         case "turn/end":
           channel.lastTurnEndSeq = event.seq;
           break;
@@ -286,10 +287,26 @@ export class ChatSessionHub {
   }
 
   private enrichWireEvent(channel: ChatChannel, event: CoreEvent): CoreEvent {
+    if (event.type === "message_start") {
+      channel.messageCounter += 1;
+      channel.currentMessageId = `m${channel.messageCounter}`;
+      return { ...event, messageId: channel.currentMessageId } as CoreEvent;
+    }
+    if (event.type === "message_update") {
+      return channel.currentMessageId === undefined
+        ? event
+        : ({ ...event, messageId: channel.currentMessageId } as CoreEvent);
+    }
     if (event.type === "message_end") {
-      const id = (event.message as { id?: unknown }).id;
-      const seq = id !== undefined ? channel.messageSeqByEventId.get(String(id)) : undefined;
-      return seq === undefined ? event : ({ ...event, seq } as CoreEvent);
+      const seq = channel.messageSeqByRef.get(event.message as object);
+      const messageId = channel.currentMessageId;
+      channel.currentMessageId = undefined;
+      const enriched = {
+        ...event,
+        ...(messageId !== undefined ? { messageId } : {}),
+        ...(seq !== undefined ? { seq } : {}),
+      };
+      return enriched as CoreEvent;
     }
     if (event.type === "agent_end") {
       return channel.lastTurnEndSeq === undefined
@@ -314,7 +331,9 @@ export class ChatSessionHub {
     }
     channel.running = true;
     channel.runEvents = [];
-    channel.messageSeqByEventId.clear();
+    channel.messageSeqByRef = new WeakMap();
+    channel.currentMessageId = undefined;
+    channel.messageCounter = 0;
     channel.lastTurnEndSeq = undefined;
     this.publish(channel, { type: "run_status", active: true });
     try {

--- a/packages/server/src/chat-wire-projector.ts
+++ b/packages/server/src/chat-wire-projector.ts
@@ -1,0 +1,97 @@
+import type { SessionEvent } from "@spherse/core";
+
+export type ProjectedWireEvent = { type: string } & Record<string, unknown>;
+
+export class ChatWireProjector {
+  private pendingClientId?: string;
+  private messageSeqByRef = new WeakMap<object, number>();
+  private currentMessageId?: string;
+  private messageCounter = 0;
+  private lastTurnEndSeq?: number;
+
+  resetRun(): void {
+    this.messageSeqByRef = new WeakMap();
+    this.currentMessageId = undefined;
+    this.messageCounter = 0;
+    this.lastTurnEndSeq = undefined;
+  }
+
+  markPendingEcho(clientId: string): void {
+    this.pendingClientId = clientId;
+  }
+
+  discardPendingEcho(clientId: string): void {
+    if (this.pendingClientId === clientId) {
+      this.pendingClientId = undefined;
+    }
+  }
+
+  clearPendingEcho(): void {
+    this.pendingClientId = undefined;
+  }
+
+  consumeLogEvent(event: SessionEvent): ProjectedWireEvent | undefined {
+    switch (event.type) {
+      case "user/message": {
+        const clientId = this.pendingClientId;
+        this.pendingClientId = undefined;
+        return {
+          type: "user_message",
+          seq: event.seq,
+          message: event.data.message,
+          ...(clientId !== undefined ? { clientId } : {}),
+          ...(event.data.source !== undefined ? { source: event.data.source } : {}),
+          ...(event.data.triggerName !== undefined
+            ? { triggerName: event.data.triggerName }
+            : {}),
+        };
+      }
+      case "turn/retried":
+        return {
+          type: "turn_retried",
+          seq: event.seq,
+          abandonedSeqs: event.data.abandonedSeqs,
+        };
+      case "assistant/message":
+      case "tool/result":
+        this.messageSeqByRef.set(event.data.message as object, event.seq);
+        return undefined;
+      case "turn/end":
+        this.lastTurnEndSeq = event.seq;
+        return undefined;
+      default:
+        return undefined;
+    }
+  }
+
+  enrich<T>(event: T): T {
+    const type = (event as { type?: unknown }).type;
+    if (type === "message_start") {
+      this.messageCounter += 1;
+      this.currentMessageId = `m${this.messageCounter}`;
+      return { ...(event as object), messageId: this.currentMessageId } as T;
+    }
+    if (type === "message_update") {
+      return this.currentMessageId === undefined
+        ? event
+        : ({ ...(event as object), messageId: this.currentMessageId } as T);
+    }
+    if (type === "message_end") {
+      const message = (event as { message?: unknown }).message;
+      const seq = this.messageSeqByRef.get(message as object);
+      const messageId = this.currentMessageId;
+      this.currentMessageId = undefined;
+      return {
+        ...(event as object),
+        ...(messageId !== undefined ? { messageId } : {}),
+        ...(seq !== undefined ? { seq } : {}),
+      } as T;
+    }
+    if (type === "agent_end") {
+      return this.lastTurnEndSeq === undefined
+        ? event
+        : ({ ...(event as object), seq: this.lastTurnEndSeq } as T);
+    }
+    return event;
+  }
+}

--- a/packages/server/src/ws-chat.ts
+++ b/packages/server/src/ws-chat.ts
@@ -30,7 +30,8 @@ export function handleChatWebSocket(
       }
       const { agentId, sessionId } = req.params;
       const sinceQuery = Number(req.query?.since);
-      const since = Number.isInteger(sinceQuery) && sinceQuery >= 0 ? sinceQuery : undefined;
+      const since =
+        Number.isInteger(sinceQuery) && sinceQuery >= -1 ? sinceQuery : undefined;
       let closed = false;
       const send = (event: unknown): void => {
         if (closed) return;

--- a/packages/server/src/ws-chat.ts
+++ b/packages/server/src/ws-chat.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from "fastify";
-import { NotFoundError } from "@spherse/core";
+import { MigrationRequiredError, NotFoundError } from "@spherse/core";
 import {
   CHAT_CLOSE_CODES,
   parseChatClientMessage,
@@ -9,12 +9,17 @@ import { classifyRunError } from "./classify-run-error.js";
 import type { ProjectRegistry } from "./registry.js";
 import type { ChatSessionHub } from "./chat-session-hub.js";
 
+const validateOutbound = process.env.SPHERSE_VALIDATE_WS === "1";
+
 export function handleChatWebSocket(
   fastify: FastifyInstance,
   registry: ProjectRegistry,
   hub: ChatSessionHub,
 ) {
-  fastify.get<{ Params: { projectId: string; agentId: string; sessionId: string } }>(
+  fastify.get<{
+    Params: { projectId: string; agentId: string; sessionId: string };
+    Querystring: { since?: string };
+  }>(
     "/ws/projects/:projectId/chat/:agentId/:sessionId",
     { websocket: true },
     (socket, req) => {
@@ -24,11 +29,15 @@ export function handleChatWebSocket(
         return;
       }
       const { agentId, sessionId } = req.params;
+      const sinceQuery = Number(req.query?.since);
+      const since = Number.isInteger(sinceQuery) && sinceQuery >= 0 ? sinceQuery : undefined;
       let closed = false;
       const send = (event: unknown): void => {
         if (closed) return;
         try {
-          socket.send(JSON.stringify(parseChatServerEvent(event)));
+          socket.send(
+            JSON.stringify(validateOutbound ? parseChatServerEvent(event) : event),
+          );
         } catch (err) {
           fastify.log.debug({ err, sessionId }, "chat ws send skipped");
         }
@@ -41,13 +50,16 @@ export function handleChatWebSocket(
         agentId,
         sessionId,
         send,
+        since !== undefined ? { since } : undefined,
       );
       const ready = attachment.ready
         .catch((err) => {
           const message = err instanceof Error ? err.message : "request failed";
           const code = err instanceof NotFoundError
             ? CHAT_CLOSE_CODES.SESSION_UNRECOVERABLE
-            : 1000;
+            : err instanceof MigrationRequiredError
+              ? CHAT_CLOSE_CODES.MIGRATION_REQUIRED
+              : 1000;
           send({ type: "error", message });
           socket.close(code, message);
           return false;
@@ -60,6 +72,7 @@ export function handleChatWebSocket(
         } catch (err) {
           fastify.log.warn({ err, sessionId }, "invalid chat ws message");
           send({ type: "error", message: "Invalid WebSocket message" });
+          socket.close(CHAT_CLOSE_CODES.PROTOCOL_ERROR, "Invalid WebSocket message");
           return;
         }
 
@@ -70,7 +83,7 @@ export function handleChatWebSocket(
 
         if (msg.type === "message") {
           try {
-            await attachment.sendMessage(msg.content, msg.attachments ?? []);
+            await attachment.sendMessage(msg.content, msg.attachments ?? [], msg.clientId);
           } catch (err) {
             if (closed) return;
             fastify.log.error({ err, sessionId }, "chat ws message error");

--- a/packages/server/src/ws-chat.ts
+++ b/packages/server/src/ws-chat.ts
@@ -11,6 +11,12 @@ import type { ChatSessionHub } from "./chat-session-hub.js";
 
 const validateOutbound = process.env.SPHERSE_VALIDATE_WS === "1";
 
+function toCloseCode(err: unknown): number {
+  if (err instanceof NotFoundError) return CHAT_CLOSE_CODES.SESSION_UNRECOVERABLE;
+  if (err instanceof MigrationRequiredError) return CHAT_CLOSE_CODES.MIGRATION_REQUIRED;
+  return 1000;
+}
+
 export function handleChatWebSocket(
   fastify: FastifyInstance,
   registry: ProjectRegistry,
@@ -56,11 +62,7 @@ export function handleChatWebSocket(
       const ready = attachment.ready
         .catch((err) => {
           const message = err instanceof Error ? err.message : "request failed";
-          const code = err instanceof NotFoundError
-            ? CHAT_CLOSE_CODES.SESSION_UNRECOVERABLE
-            : err instanceof MigrationRequiredError
-              ? CHAT_CLOSE_CODES.MIGRATION_REQUIRED
-              : 1000;
+          const code = toCloseCode(err);
           send({ type: "error", message });
           socket.close(code, message);
           return false;


### PR DESCRIPTION
## 概要

chat 重构（[design doc](../blob/feat/chat-refactor-pr1/docs/dev/features/2026-09-05-chat-refactor/design.md)）的 **PR1/6：协议先行**。把持久层已有的连续 seq 提升到 wire 协议，建立增量重连恢复的协议地基；renderer 行为不变（v2 事件静默丢弃，PR3 起消费）。

## 变更

- **contracts v2**：`user_message`（echo/ack，含 `clientId`）/ `turn_retried` / `session_ready` / `replay_events` / `replay_done`；`message_end`/`agent_end` 附 seq、流式消息附 hub 生成的 `messageId`；`message.clientId` 可选（旧客户端兼容）；close code 族 4400/4401/4402；`ChatReplayEvent` 信封镜像导出
- **core**：`SessionStore.readEventsAfter` SQL 下推；`SessionManager` 事件门面（读尾 / lastSeq / 订阅，内存优先 store 回落）
- **server**：attach 握手五段序列（session_ready → since 重放[200/批] → replay_done → 快照 → run_status，同 tick 原子）；`ChatChannel`（单 session 生命周期）+ `ChatWireProjector`（persist→wire 翻译纯状态机）+ `ChatSessionHub`（注册表）；出站 TypeBox 校验移测试（`SPHERSE_VALIDATE_WS=1` 开关）
- **app**：`parseAgentEvent` 对 v2 事件返回 undefined 静默丢弃（过渡态）
- **ADR-0011** + chat.md/glossary/project-structure/backlog doc-sync

## Review report（sub agent review：0C / 1I / 3M / 5m）

| 级别 | 问题 | 处置 |
|---|---|---|
| I-1 | `pendingClientId` 竞态：冲突 send 抹掉在飞 run 的 echo clientId（reviewer 实证复现） | ✅ 已修：赋值移入 executor 闭包 + 条件清理 + 回归测试 |
| M-1 | `since` 取值域不一致（wire 拒 -1，hub/门面用 -1 表全量） | ✅ 已修：统一 ≥ -1，design doc 记录 + 测试 |
| M-2 | hub→SessionManager 接缝契约测试全 mock | ✅ 已修：`chat-hub-runtime-contract.test.ts`（真 createProject runtime 贯穿 echo/seq 配对/门面读尾一致性） |
| M-3 | 握手五段完整序列无单测 | ✅ 已修：mid-run + since 重叠用例 |
| m-1 | `user_message.source` schema 宽度不一致 | ✅ 已修：统一 Literal("triggered") |
| m-2 | 入站 schema 违例 / since 边界测试缺口 | ✅ 已补 |
| m-3 | seq 富化依赖 pi message 未声明的运行时 `id` 字段 | ⚠️ 升级为设计修正：实证 pi-ai 运行时构造的 message **无 id**，改为 hub 生成 wire `messageId` + 落库实例引用配对（persist-before-callback），真 runtime 契约测试钉住引用一致性；design §1.2/§1.5 同步 |
| m-4 | `session_ready.replay` 恒 true，字段冗余 | ❌ 未修：保留为「server 支持重放」能力声明（语义已记录）；协议未冻结，PR3 前可再议 |
| m-5 | app fatal 集合仍为 {4401}，4402 触发重连噪音（~48s） | ❌ 未修：属 PR2 `WsConnection` 状态机范围；窗口期行为与现状（1000 亦重连）一致，无回归 |
| 疑点 | evictAgent 后 channel 订阅悬空 | 评估为实际不可达（agent 删除连带 session 清理），不改 |
| 疑点 | 快照/重放去重前提 | PR4 客户端职责，design §1.5 已覆盖 |

review 后追加的结构化 refactor（行为不变、246→247 测试全绿）：`ChatWireProjector` / `ChatChannel` 拆分、close code 映射单点化；并固化决策 #7（control 事件落库，PR5 落地）。

## 验证

`npm run verify` 全绿（core 1166 / server 247 / app 983 / desktop 198；lint 0 errors，16 个存量 warning 与本变更无关）。

## 后续

PR2（`WsConnection` + bus 迁移）∥ PR5（trigger 收口 + control 落库）→ PR3（session store + 游标重放接入）→ PR4（reducer + 快照收缩）→ PR6（文档收尾）。backlog 新增：chat WS 出站背压。
