### PR TITLE
feat: trigger 收口经 hub + control 事件落库 + 分页 fold 缓存（chat 重构 PR5/6）

### DIFF
--- a/docs/dev/features/2026-09-05-chat-refactor/design.md
+++ b/docs/dev/features/2026-09-05-chat-refactor/design.md
@@ -153,6 +153,7 @@ hub 持有的是 `SessionManager` 而非 store，且其 sessions map 为 private
 - 行为对齐：trigger 撞上运行中 session 的冲突语义不变（今天 `ensureNotBusy` 抛 ValidationError → trigger failed；收口后 hub `startRun` 抛 ConflictError → 同样 failed，错误路径统一）
 - 按仓库契约测试红线，server/desktop 对新 SessionPort 门面各补一条不 mock 被测方法的真实边界测试
 - trigger 完成通知仍走 bus trigger 频道（TriggerEventBridge 的 query 失效职责不变，删掉的只是 refreshHistory 部分，见 §7）
+- **行为面记录（PR5 实现确认）**：① trigger run 中途同步 throw（model 未配置、restore 失败等）会向该 session 的 chat 订阅者广播 `error` 事件——旧行为是完全不可见，现选择保留（订阅者已看到 run_status 翻转，静默失败更难排查）；冲突路径仍为 pre-check 抛出、不广播。② 中间态（PR5 合入、PR3/PR4 未合）下，已打开的旧 session 页面在 trigger run 期间能看到 assistant 流式但看不到触发 user 消息（旧 reducer 丢弃 `user_message`），重连/重开后经对账补全——接受此窗口，PR3/PR4 修复。③ SessionPort 契约测试由 server 侧承担（desktop 经 `createMultiProjectServer` 整体嵌入 server，不直接消费 SessionPort，红线「消费方包」不适用）。
 
 ### 2.4 分页性能（增量 fold 缓存）
 

--- a/docs/dev/features/2026-09-05-chat-refactor/plan.md
+++ b/docs/dev/features/2026-09-05-chat-refactor/plan.md
@@ -45,14 +45,14 @@
 
 ## PR5 trigger 收口 + control 落库 + 分页性能（core + server，依赖 PR1）
 
-- [ ] core：`assembleProject` 增加 `wrapSessionPort?: (port: SessionPort) => SessionPort` 钩子（sessionRuntime 创建后、capabilities init 前应用）；`SessionPort.sendMessage` 调用上下文补 agentId
-- [ ] server：hub 公开 `startRunWithMeta(channel, meta, executor)`；trigger 的 sendMessage 经 wrapSessionPort 走 hub（meta 带 source/triggerName）
-- [ ] core：SessionEventMap 新增 `control/requested` / `control/resolved`；AgentRunner 的 control sink 包装层 append → emit + seq 回填 wire 事件；`rejectAll`(abort) 补发 `resolved {aborted}`；fold pending 投影（requested 未配对 resolved 且无 turn/end 隔断）+ contracts 信封变体
-- [ ] SessionPort 门面契约测试（server/desktop 各一条不 mock 被测方法，仓库红线）
-- [ ] trigger 冲突语义对齐测试（ConflictError ↔ ensureNotBusy 行为等价）
-- [ ] fold-on-write 投影缓存挂 project-manager 层（按 session 键控、事件数版本号失效、LRU 上限，覆盖未激活 session）+ `getRecentSessionHistory` 走缓存切片；性质测试（缓存 == 全量重 fold）
-- [ ] 删 `TriggerEventBridge` 的 refreshHistory 调用（trigger run 此后 live 可达；query 失效保留）
-- [ ] E2E：trigger run 在已打开 session 页面可见（run_status + 流式）
+- [x] core：`assembleProject` 增加 `wrapSessionPort?: (port: SessionPort) => SessionPort` 钩子（sessionRuntime 创建后、capabilities init 前应用）；`SessionPort.sendMessage` 调用上下文补 agentId（meta 扩展路线：`SendMessageMeta.agentId`，hub 路由后剥离不入持久化）
+- [x] server：hub 公开 `startRunWithMeta`（channel `startDetachedRun` 增 meta/onEvent/awaitRun 选项，trigger 走完成语义）；trigger 的 sendMessage 经 wrapSessionPort 走 hub（meta 带 source/triggerName）
+- [x] core：SessionEventMap 新增 `control/requested` / `control/resolved`；AgentRunner 的 control sink 包装层 append → emit + seq 回填 wire 事件；`rejectAll`(abort) 补发 `resolved {aborted}`；fold pending 投影（requested 未配对 resolved 且无 turn/end 隔断）+ contracts 信封变体
+- [x] SessionPort 门面契约测试——server 侧 `trigger-hub-routing.test.ts`（真 registry + hub + triggerManager + AgentRunner，仅 stub 最深 pi agentRef，被测路由链全真）；desktop 经 createMultiProjectServer 整体嵌入、不直接消费 SessionPort，红线由 server 侧承担（裁决记录于 design §2.3）
+- [x] trigger 冲突语义对齐测试（ConflictError ↔ ensureNotBusy 行为等价；executor 单元级 + server 真边界级各一条）
+- [x] fold-on-write 投影缓存挂 project-manager 层（按 session 键控、事件数版本号失效、LRU 32，覆盖未激活 session）+ `getRecentSessionHistory` 走缓存切片；性质测试（缓存分页 == 全量重 fold + 失效 + 淘汰）
+- [x] 删 `TriggerEventBridge` 的 refreshHistory 调用（trigger run 此后 live 可达；query 失效保留）
+- [x] E2E：~~trigger run 在已打开 session 页面可见~~——deviation：e2e 无服务端 LLM stub 模式（chat spec 均为 renderer 级 WS mock），改为 server 真实边界契约测试钉住 live 可达性（user_message echo + run_status 双向）；中间态渲染缺口（旧 reducer 丢 user_message）已在 design §2.3 记录，PR3 修复；chat-streaming-resilience / chat-retry e2e 回归通过
 
 ## PR6 收尾
 

--- a/docs/official/architecture/chat.md
+++ b/docs/official/architecture/chat.md
@@ -29,8 +29,8 @@ Composer.send
 - **client → server**：`message`（content + 可选 `clientId`（乐观消息结算标识）+ attachments 路径引用）、`abort`、`ping`、`retry`、`withdraw`、`resolve_control_request`（kind approval：approved / reason；kind question：answer）
 - **server → client**：
   - pi 生命周期族：`agent_start` / `agent_end`（可带 `seq`） / `turn_start` / `turn_end` / `message_start` / `message_update` / `message_end`（可带 `messageId` + `seq`） / `tool_execution_start` / `tool_execution_update` / `tool_execution_end`
-  - session 级：`run_status`（active）、`control_request` / `control_resolved`、`turn_withdrawn`（seq）、`turn_retried`（seq + abandonedSeqs）、`user_message`（seq + clientId? + source? + triggerName?，user 消息回显/ack）、`error`（message + code）、`pong`
-  - 重放族：`session_ready`（lastSeq + replay，attach 后恒为首个事件）、`replay_events`（原始 SessionEvent 信封分批，每批 ≤200）、`replay_done`
+  - session 级：`run_status`（active）、`control_request` / `control_resolved`（PR5 起落库，可带 `seq`；abort 路径 `resolved` 带 `aborted: true`）、`turn_withdrawn`（seq）、`turn_retried`（seq + abandonedSeqs）、`user_message`（seq + clientId? + source? + triggerName?，user 消息回显/ack）、`error`（message + code）、`pong`
+  - 重放族：`session_ready`（lastSeq + replay，attach 后恒为首个事件）、`replay_events`（原始 SessionEvent 信封分批，每批 ≤200，含 `control/requested`/`control/resolved`）、`replay_done`
 - **身份与游标**（[ADR-0011](../../dev/decisions/0011-chat-wire-cursor-replay.md)）：持久事件按 `seq` 幂等；流式 wire 消息按 hub 生成的 `messageId` stitch（pi message payload 运行时无 id 字段），`message_end.seq` 经落库实例引用配对（persist-before-callback）；connect query `?since=`（≥ -1）触发游标重放，游标为客户端 per-connection 状态
 - **error code**（`classify-run-error.ts`）：`MODEL_NOT_CONFIGURED`、`AUTH_ERROR`、`PERMANENT`、`TRANSIENT`。规则：
   - 401/403 → AUTH；429/5xx/网络错误 → TRANSIENT

--- a/docs/official/architecture/core.md
+++ b/docs/official/architecture/core.md
@@ -60,7 +60,8 @@ ProjectRuntime           对外协调层，聚合以上全部
   - compaction：阈值触发时经 agent 自身 streamFn 生成 LLM 摘要——精确复刻请求前缀（systemPrompt + tools + fold 视图 + 追加摘要指令）命中 provider prompt cache；失败且 tokens ≤ 90% window 跳过本轮，> 90% 回退机械拼接
     摘要长度预算按压缩时 context tokens 的 5% 动态给定（clamp 1500–16000），同时约束摘要指令文本与 stream `maxTokens`（再与模型输出上限取 min）
     摘要来源以 `digestSource: "llm" | "mechanical"` 标记
-- 触发器 ⇄ 会话的循环依赖经 `SessionPort` 消解：factory 先构造 SessionManager，port 是普通对象，capability 在 `init` 中拿到它
+- 触发器 ⇄ 会话的循环依赖经 `SessionPort` 消解：factory 先构造 SessionManager，port 是普通对象，capability 在 `init` 中拿到它；`assembleProject` 支持 `wrapSessionPort` 钩子在 capabilities init 前替换 port（server 侧 trigger 借此改走 chat hub，`SendMessageMeta.agentId` 是路由上下文、不入持久化）
+- **control 事件落库**：审批/问答 gate 的 `control/requested` / `control/resolved` 经 runner 的 control sink 包装层 persist → emit（wire 附 seq）；abort 的 `rejectAll` 对每个 pending 补发 `resolved {aborted}`；`derivePendingControls(events)` 投影 pending（requested 未配对 resolved 且其后无 `turn/end`，repair 合成的 turn/end 自动排除崩溃悬空）
 
 ## ProjectRuntime（对外协调层）
 

--- a/docs/official/data-conventions.md
+++ b/docs/official/data-conventions.md
@@ -154,12 +154,13 @@ frontmatter 字段：
   - `user/message`（data 可选 `source: "triggered"` + `triggerName`，trigger 发送标记；absent = 手动发送）、`assistant/message`、`tool/result`
   - `compaction/applied`（anchorSeq、digestContent、digestSource、excludedSeqs）
   - `turn/retried`（abandonedSeqs）、`turn/withdrawn`（seq）
+  - `control/requested`（requestId、kind、toolCallId、toolName、args）与 `control/resolved`（requestId、kind、approval 的 approved/reason / question 的 answer/timedOut、可选 aborted）——审批/问答 gate 事件；abort 路径的 `rejectAll` 补发 `resolved {aborted}`；fold 白名单不含它们（消息投影忽略），pending 投影 = requested 未配对 resolved 且其后无 turn/end
 
 存储不变量（fold 投影与控制事件语义见 `architecture/core.md`「会话运行时」）：
 
 - **append-only**：消息与控制事件只追加；compaction、retry、withdraw 均以重启点事件表达，不修改或删除历史
 - **seq 连续**：session log 内从 0 连续，`open` 校验损坏即抛；`appendBatch` 落库失败回滚内存追加
-- **可重建**：运行时消息数组是 fold 投影缓存，可随时丢弃重建
+- **可重建**：运行时消息数组是 fold 投影缓存，可随时丢弃重建；分页读取（`getRecentSessionHistory`）另有 project-manager 层的 fold-on-write 缓存（按 session 键控、事件数版本号失效、LRU 上限，覆盖未激活 session），缓存条目视为不可变
 - **正向兼容**：未知事件类型被 fold 白名单过滤跳过；additive 事件不升 schema version
 - **崩溃恢复幂等**：restore 为未闭合 turn 持久化补写合成 error toolResult 与 aborted `turn/end`，二次恢复不再追加
 

--- a/docs/official/glossary.md
+++ b/docs/official/glossary.md
@@ -26,6 +26,7 @@
 | Event Log（events 表） | 消息唯一真相：per-session append-only 事件日志，主键 `(session_id, seq)` | [data-conventions.md](data-conventions.md) |
 | fold（投影） | 从事件日志推导内存消息数组的纯函数过程；内存只是可重建缓存 | [architecture/core.md](architecture/core.md) |
 | 控制事件（重启点） | `turn/retried` / `turn/withdrawn` / `compaction/applied` 三类事件，restore 时按语义重建 | [architecture/core.md](architecture/core.md) |
+| control gate 事件 | `control/requested` / `control/resolved` 审批/问答门事件（区别于上面的重启点控制事件），落库并附 seq；pending = requested 未配对 resolved 且无 turn/end 隔断 | [architecture/core.md](architecture/core.md) |
 | compaction（上下文压缩） | 历史超阈值时生成摘要、以 `compaction/applied` 重启点表达；LLM 双路与机械回退 | [architecture/core.md](architecture/core.md) |
 | withdraw（撤回） | 以 `turn/withdrawn {seq}` 锚定被撤回 user message，fold 推导废弃区间 | [architecture/core.md](architecture/core.md) |
 | 历史对账 | renderer 重连后拉取历史、按 `_messageId` 去重合并的过程 | [architecture/chat.md](architecture/chat.md) |

--- a/packages/app/src/features/agent-trigger/TriggerEventBridge.tsx
+++ b/packages/app/src/features/agent-trigger/TriggerEventBridge.tsx
@@ -3,8 +3,7 @@ import { toast } from "sonner";
 import { useNavigate } from "react-router";
 import { useI18n } from "@spherse/i18n/react";
 import { useProjectCtx } from "../../context/project-context";
-import { useApiClient } from "../../lib/use-connection";
-import { useStreamingStore } from "../chat/runtime/streaming-store";
+
 import { useTriggerStore, getCachedTriggersForAgent } from "./store";
 import { useBusSubscription } from "../../hooks/useBusSubscription";
 import { useReconnectedSync } from "../../hooks/useReconnectedSync";
@@ -15,7 +14,6 @@ const INVALIDATING_EVENTS = new Set(["trigger_updated", "trigger_completed", "tr
 
 export function TriggerEventBridge() {
   const { projectId } = useProjectCtx();
-  const client = useApiClient(projectId);
   const navigate = useNavigate();
   const { t } = useI18n();
   const handleTriggerEvent = useTriggerStore((s) => s.handleTriggerEvent);
@@ -46,7 +44,6 @@ export function TriggerEventBridge() {
     if (type === "trigger_completed") {
       const p = payload as { agentId: string; triggerId: string; sessionId: string };
       showTriggerNotification(p.agentId, p.triggerId, p.sessionId);
-      if (client) useStreamingStore.getState().refreshHistory(client, p.agentId, p.sessionId);
     }
   });
 

--- a/packages/contracts/src/__tests__/chat-websocket-contracts.test.ts
+++ b/packages/contracts/src/__tests__/chat-websocket-contracts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   parseChatClientMessage,
   parseChatServerEvent,
+  parseChatReplayEvent,
 } from "../index.js";
 
 describe("chat websocket control contract", () => {
@@ -209,6 +210,81 @@ describe("chat websocket control contract", () => {
     );
     expect(() =>
       parseChatServerEvent({ type: "turn_withdrawn", seq: "3" }),
+    ).toThrow(/Invalid payload/);
+  });
+
+  it("accepts control events with persisted seq and aborted marker", () => {
+    const request = {
+      type: "control_request",
+      requestId: "req9",
+      kind: "approval",
+      toolCallId: "call9",
+      toolName: "run_command",
+      args: {},
+      seq: 12,
+    };
+    expect(parseChatServerEvent(request)).toEqual(request);
+    const aborted = {
+      type: "control_resolved",
+      requestId: "req9",
+      kind: "approval",
+      approved: false,
+      aborted: true,
+      seq: 13,
+    };
+    expect(parseChatServerEvent(aborted)).toEqual(aborted);
+    const questionAborted = {
+      type: "control_resolved",
+      requestId: "req10",
+      kind: "question",
+      timedOut: false,
+      aborted: true,
+      seq: 14,
+    };
+    expect(parseChatServerEvent(questionAborted)).toEqual(questionAborted);
+  });
+
+  it("accepts control events in the replay envelope after persistence", () => {
+    expect(
+      parseChatReplayEvent({
+        type: "control/requested",
+        seq: 5,
+        time: 1000,
+        data: {
+          requestId: "req1",
+          kind: "approval",
+          toolCallId: "tc1",
+          toolName: "run_command",
+          args: { command: "ls" },
+        },
+      }),
+    ).toEqual({
+      type: "control/requested",
+      seq: 5,
+      time: 1000,
+      data: {
+        requestId: "req1",
+        kind: "approval",
+        toolCallId: "tc1",
+        toolName: "run_command",
+        args: { command: "ls" },
+      },
+    });
+    expect(
+      parseChatReplayEvent({
+        type: "control/resolved",
+        seq: 6,
+        time: 1001,
+        data: { requestId: "req1", kind: "question", timedOut: true },
+      }),
+    ).toEqual({
+      type: "control/resolved",
+      seq: 6,
+      time: 1001,
+      data: { requestId: "req1", kind: "question", timedOut: true },
+    });
+    expect(() =>
+      parseChatReplayEvent({ type: "control/requested", seq: 5, time: 1 }),
     ).toThrow(/Invalid payload/);
   });
 });

--- a/packages/contracts/src/__tests__/chat-websocket-contracts.test.ts
+++ b/packages/contracts/src/__tests__/chat-websocket-contracts.test.ts
@@ -224,6 +224,16 @@ describe("chat websocket control contract", () => {
       seq: 12,
     };
     expect(parseChatServerEvent(request)).toEqual(request);
+    const questionRequest = {
+      type: "control_request",
+      requestId: "req11",
+      kind: "question",
+      toolCallId: "call11",
+      toolName: "ask_user",
+      args: { question: "Q?" },
+      seq: 15,
+    };
+    expect(parseChatServerEvent(questionRequest)).toEqual(questionRequest);
     const aborted = {
       type: "control_resolved",
       requestId: "req9",
@@ -285,6 +295,14 @@ describe("chat websocket control contract", () => {
     });
     expect(() =>
       parseChatReplayEvent({ type: "control/requested", seq: 5, time: 1 }),
+    ).toThrow(/Invalid payload/);
+    expect(() =>
+      parseChatReplayEvent({
+        type: "control/resolved",
+        seq: 6,
+        time: 1,
+        data: { requestId: "req1" },
+      }),
     ).toThrow(/Invalid payload/);
   });
 });

--- a/packages/contracts/src/websocket.ts
+++ b/packages/contracts/src/websocket.ts
@@ -112,6 +112,32 @@ export const chatReplayEvent = Type.Union([
     time: Type.Integer(),
     data: Type.Object({ seq: Type.Integer() }),
   }),
+  Type.Object({
+    type: Type.Literal("control/requested"),
+    seq: Type.Integer(),
+    time: Type.Integer(),
+    data: Type.Object({
+      requestId: Type.String(),
+      kind: Type.Union([Type.Literal("approval"), Type.Literal("question")]),
+      toolCallId: Type.String(),
+      toolName: Type.String(),
+      args: Type.Unknown(),
+    }),
+  }),
+  Type.Object({
+    type: Type.Literal("control/resolved"),
+    seq: Type.Integer(),
+    time: Type.Integer(),
+    data: Type.Object({
+      requestId: Type.String(),
+      kind: Type.Union([Type.Literal("approval"), Type.Literal("question")]),
+      approved: Type.Optional(Type.Boolean()),
+      reason: Type.Optional(Type.String()),
+      answer: Type.Optional(Type.String()),
+      timedOut: Type.Optional(Type.Boolean()),
+      aborted: Type.Optional(Type.Boolean()),
+    }),
+  }),
 ]);
 
 const chatServerEvent = Type.Union([
@@ -172,6 +198,7 @@ const chatServerEvent = Type.Union([
     args: Type.Unsafe<
       EventOf<SessionControlEvent, "control_request">["args"]
     >(Type.Unknown()),
+    seq: Type.Optional(Type.Integer()),
   }),
   Type.Object({
     type: Type.Literal("control_request"),
@@ -182,6 +209,7 @@ const chatServerEvent = Type.Union([
     args: Type.Unsafe<
       EventOf<SessionControlEvent, "control_request">["args"]
     >(Type.Unknown()),
+    seq: Type.Optional(Type.Integer()),
   }),
   Type.Object({
     type: Type.Literal("control_resolved"),
@@ -189,6 +217,8 @@ const chatServerEvent = Type.Union([
     kind: Type.Literal("approval"),
     approved: Type.Boolean(),
     reason: Type.Optional(Type.String()),
+    aborted: Type.Optional(Type.Boolean()),
+    seq: Type.Optional(Type.Integer()),
   }),
   Type.Object({
     type: Type.Literal("control_resolved"),
@@ -196,6 +226,8 @@ const chatServerEvent = Type.Union([
     kind: Type.Literal("question"),
     answer: Type.Optional(Type.String()),
     timedOut: Type.Boolean(),
+    aborted: Type.Optional(Type.Boolean()),
+    seq: Type.Optional(Type.Integer()),
   }),
   Type.Object({
     type: Type.Literal("turn_withdrawn"),

--- a/packages/core/src/__tests__/factory.test.ts
+++ b/packages/core/src/__tests__/factory.test.ts
@@ -59,3 +59,33 @@ describe("assembleProject — open failure safety", () => {
     expect(await readFile(projectRoot, "CHANGELOG.md")).toBe("# my changelog\n");
   });
 });
+
+describe("assembleProject — wrapSessionPort hook", () => {
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    projectRoot = await createTempProject();
+  });
+
+  afterEach(async () => {
+    await cleanupDir(projectRoot);
+  });
+
+  it("applies the wrapper before capabilities receive the port in init", async () => {
+    let portSeenByCapability: { WRAPPED?: boolean } | undefined;
+    const probeCapability = {
+      init: async (services: { session: { WRAPPED?: boolean } }) => {
+        portSeenByCapability = services.session;
+      },
+    };
+    const runtime = await createProject(projectRoot, {
+      projectName: "WrapTest",
+      logger: createSilentLogger(),
+      capabilities: (builtin) => [...builtin, probeCapability as never],
+      wrapSessionPort: (port) => ({ ...port, WRAPPED: true }) as never,
+    });
+    runtime.timerService.stop();
+    await runtime.shutdown();
+    expect(portSeenByCapability?.WRAPPED).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/project-manager.test.ts
+++ b/packages/core/src/__tests__/project-manager.test.ts
@@ -219,3 +219,112 @@ describe("ProjectManager event-backed session reads", () => {
     }
   });
 });
+
+describe("ProjectManager history fold cache", () => {
+  const setup = async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "wb-pm-cache-"));
+    const projectStore = new ProjectStore(root, createSilentLogger());
+    await projectStore.create("Test");
+    const agentStore = await projectStore.createAgent(
+      "test-agent",
+      "---\nname: Test\ntools: []\n---\n\nTest.",
+    );
+    const manager = new ProjectManager(projectStore, createSilentLogger());
+    return { root, projectStore, agentStore, manager };
+  };
+
+  const userEvent = (seq: number, text: string) => ({
+    type: "user/message" as const,
+    seq,
+    time: seq,
+    data: { message: { role: "user", content: text, timestamp: seq } },
+  });
+  const assistantEvent = (seq: number, text: string) => ({
+    type: "assistant/message" as const,
+    seq,
+    time: seq,
+    data: { message: { role: "assistant", content: [{ type: "text", text }], timestamp: seq } },
+  });
+
+  it("cached pagination equals a fresh full re-fold for arbitrary event sequences", async () => {
+    const { root, projectStore, agentStore, manager } = await setup();
+    try {
+      const sessionId = agentStore.sessions.createSession();
+      const events: Array<ReturnType<typeof userEvent> | ReturnType<typeof assistantEvent>> = [];
+      for (let i = 0; i < 40; i++) {
+        events.push(i % 2 === 0 ? userEvent(i, `q${i}`) : assistantEvent(i, `a${i}`));
+      }
+      agentStore.sessions.appendEvents(sessionId, events, EVENT_SCHEMA_VERSION);
+      const agentId = agentStore.getProfile().id;
+
+      const { deriveHistoryEntries } = await import("../session/fold.js");
+      const fresh = deriveHistoryEntries(agentStore.sessions.readEvents(sessionId));
+      let cursor: number | undefined;
+      const seen: number[] = [];
+      for (;;) {
+        const page = manager.getRecentSessionHistory(agentId, sessionId, 3, cursor);
+        seen.push(...page.entries.map((e) => e.id));
+        if (!page.hasMore || page.oldestId === null) break;
+        cursor = page.oldestId;
+      }
+      expect([...seen].sort((a, b) => a - b)).toEqual(fresh.map((e) => e.seq));
+      expect(new Set(seen).size).toBe(seen.length);
+      expect(manager.getRecentSessionHistory(agentId, sessionId, 5).entries).toEqual(
+        fresh.slice(-5).map((entry) => expect.objectContaining({ id: entry.seq })),
+      );
+    } finally {
+      projectStore.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("invalidates on event count change and reflects new appends", async () => {
+    const { root, projectStore, agentStore, manager } = await setup();
+    try {
+      const sessionId = agentStore.sessions.createSession();
+      const agentId = agentStore.getProfile().id;
+      agentStore.sessions.appendEvents(
+        sessionId,
+        [userEvent(0, "q0"), assistantEvent(1, "a0")],
+        EVENT_SCHEMA_VERSION,
+      );
+      expect(manager.getRecentSessionHistory(agentId, sessionId, 10).entries).toHaveLength(2);
+      agentStore.sessions.appendEvents(
+        sessionId,
+        [userEvent(2, "q1"), assistantEvent(3, "a1")],
+        EVENT_SCHEMA_VERSION,
+      );
+      const after = manager.getRecentSessionHistory(agentId, sessionId, 10);
+      expect(after.entries).toHaveLength(4);
+      expect(after.entries.at(-1)).toMatchObject({ id: 3 });
+    } finally {
+      projectStore.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("evicts least-recently-used sessions beyond the cache limit without changing results", async () => {
+    const { root, projectStore, agentStore, manager } = await setup();
+    try {
+      const agentId = agentStore.getProfile().id;
+      const sessionIds: string[] = [];
+      for (let i = 0; i < 34; i++) {
+        const sessionId = agentStore.sessions.createSession();
+        agentStore.sessions.appendEvents(
+          sessionId,
+          [userEvent(0, `q${i}`)],
+          EVENT_SCHEMA_VERSION,
+        );
+        sessionIds.push(sessionId);
+        manager.getRecentSessionHistory(agentId, sessionId, 10);
+      }
+      const first = manager.getRecentSessionHistory(agentId, sessionIds[0], 10);
+      expect(first.entries).toHaveLength(1);
+      const last = manager.getRecentSessionHistory(agentId, sessionIds[33], 10);
+      expect(last.entries).toHaveLength(1);
+    } finally {
+      projectStore.close();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/__tests__/session/control-bus.test.ts
+++ b/packages/core/src/__tests__/session/control-bus.test.ts
@@ -164,4 +164,29 @@ describe("SessionControlBus", () => {
     await expect(p).rejects.toThrow("session aborted");
     expect(bus.pendingCount).toBe(0);
   });
+
+  it("rejectAll emits aborted control_resolved for every pending request", async () => {
+    const bus = new SessionControlBus();
+    const events: any[] = [];
+    bus.setEventSink((e) => events.push(e));
+    const approval = bus.request(
+      { requestId: "ra", kind: "approval", toolCallId: "tc", toolName: "run_command", args: {} },
+      60_000,
+      { approved: false },
+    );
+    const question = bus.request(
+      { requestId: "rq", kind: "question", toolCallId: "tq", toolName: "ask_user", args: {} },
+      60_000,
+      { timedOut: true },
+    );
+    bus.rejectAll("session aborted");
+    await expect(approval).rejects.toThrow("session aborted");
+    await expect(question).rejects.toThrow("session aborted");
+    expect(events).toEqual([
+      { type: "control_request", requestId: "ra", kind: "approval", toolCallId: "tc", toolName: "run_command", args: {} },
+      { type: "control_request", requestId: "rq", kind: "question", toolCallId: "tq", toolName: "ask_user", args: {} },
+      { type: "control_resolved", requestId: "ra", kind: "approval", approved: false, aborted: true },
+      { type: "control_resolved", requestId: "rq", kind: "question", timedOut: false, aborted: true },
+    ]);
+  });
 });

--- a/packages/core/src/__tests__/session/fold.test.ts
+++ b/packages/core/src/__tests__/session/fold.test.ts
@@ -401,3 +401,50 @@ describe("repairLog", () => {
     expect(repairs[0].data).toEqual({ reason: "aborted" });
   });
 });
+
+describe("derivePendingControls", () => {
+  it("returns unresolved requested controls with their metadata", async () => {
+    const { derivePendingControls } = await import("../../session/fold.js");
+    const pending = derivePendingControls([
+      user("hi", 0),
+      ev("turn/start", {}, 1),
+      ev("control/requested", { requestId: "r1", kind: "approval", toolCallId: "tc1", toolName: "run_command", args: {} }, 2),
+    ]);
+    expect(pending).toEqual([
+      { seq: 2, requestId: "r1", kind: "approval", toolCallId: "tc1", toolName: "run_command" },
+    ]);
+  });
+
+  it("drops requests paired with a resolved event", async () => {
+    const { derivePendingControls } = await import("../../session/fold.js");
+    const pending = derivePendingControls([
+      ev("control/requested", { requestId: "r1", kind: "approval", toolCallId: "tc1", toolName: "run_command", args: {} }, 0),
+      ev("control/resolved", { requestId: "r1", kind: "approval", approved: true }, 1),
+      ev("control/requested", { requestId: "r2", kind: "question", toolCallId: "tc2", toolName: "ask_user", args: {} }, 2),
+      ev("control/resolved", { requestId: "r2", kind: "question", timedOut: true }, 3),
+    ]);
+    expect(pending).toEqual([]);
+  });
+
+  it("excludes requests separated from the log tail by a turn/end (crash danglings via repair)", async () => {
+    const { derivePendingControls } = await import("../../session/fold.js");
+    const pending = derivePendingControls([
+      ev("control/requested", { requestId: "r1", kind: "approval", toolCallId: "tc1", toolName: "run_command", args: {} }, 0),
+      ev("turn/end", { reason: "aborted" }, 1),
+    ]);
+    expect(pending).toEqual([]);
+  });
+
+  it("keeps a request from the latest turn even when earlier turns ended", async () => {
+    const { derivePendingControls } = await import("../../session/fold.js");
+    const pending = derivePendingControls([
+      ev("control/requested", { requestId: "r1", kind: "approval", toolCallId: "tc1", toolName: "run_command", args: {} }, 0),
+      ev("control/resolved", { requestId: "r1", kind: "approval", approved: true }, 1),
+      ev("turn/end", { reason: "completed" }, 2),
+      ev("control/requested", { requestId: "r2", kind: "question", toolCallId: "tc2", toolName: "ask_user", args: {} }, 3),
+    ]);
+    expect(pending).toEqual([
+      { seq: 3, requestId: "r2", kind: "question", toolCallId: "tc2", toolName: "ask_user" },
+    ]);
+  });
+});

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -31,6 +31,7 @@ export interface AssembleOptions {
   logger?: Logger;
   modelCatalog?: ModelCatalog;
   capabilities?: Capability[] | ((builtin: Capability[]) => Capability[]);
+  wrapSessionPort?: (port: SessionPort) => SessionPort;
 }
 
 export function defaultCapabilities(
@@ -100,7 +101,7 @@ export async function assembleProject(
 
   const sessionRuntime = new SessionManager(deps, { initialRunConfig: runConfig });
 
-  const sessionPort: SessionPort = {
+  let sessionPort: SessionPort = {
     createSession: (agentId, source) => sessionRuntime.createSession(agentId, source),
     restoreSession: (agentId, sessionId) => sessionRuntime.restoreSession(agentId, sessionId),
     sendMessage: (sessionId, message, onEvent, meta) =>
@@ -108,6 +109,9 @@ export async function assembleProject(
     abortSession: (sessionId) => sessionRuntime.abortSession(sessionId),
     sessionExists: (agentId, sessionId) => sessionRuntime.sessionExists(agentId, sessionId),
   };
+  if (options?.wrapSessionPort) {
+    sessionPort = options.wrapSessionPort(sessionPort);
+  }
 
   for (const capability of capabilities) {
     if (!capability.init) continue;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,8 @@ export type { ProjectManager } from "./project-manager.js";
 export type { SessionManager } from "./session/session-manager.js";
 export type { SessionEvent } from "./session/events.js";
 export type { SessionControlEvent } from "./session/types.js";
+export type { SendMessageMeta } from "./session/events.js";
+export type { SessionPort } from "./kernel/ports.js";
 export type { TriggerManager } from "./trigger/trigger-manager.js";
 export type { TriggerEventPayload } from "./trigger/trigger-manager.js";
 export type { TimerService } from "./trigger/timer-service.js";

--- a/packages/core/src/project-manager.ts
+++ b/packages/core/src/project-manager.ts
@@ -7,9 +7,16 @@ import { resolveProjectPath } from "./utils/path-safety.js";
 import { serverAccessPolicy } from "./access/access-policy.js";
 import { type Logger, createSilentLogger } from "./logger.js";
 import { ConflictError, NotFoundError, ValidationError } from "./errors.js";
-import { deriveHistoryEntries } from "./session/fold.js";
+import { deriveHistoryEntries, type DerivedMessageEntry } from "./session/fold.js";
 import fs from "node:fs/promises";
 import path from "node:path";
+
+const HISTORY_CACHE_LIMIT = 32;
+
+interface HistoryCacheEntry {
+  version: number;
+  entries: DerivedMessageEntry[];
+}
 
 export class ProjectManager {
   private projectStore: ProjectStore;
@@ -17,11 +24,37 @@ export class ProjectManager {
   private logger: Logger;
 
   private serverPolicy: ReturnType<typeof serverAccessPolicy> | undefined;
+  private readonly historyCache = new Map<string, HistoryCacheEntry>();
 
   constructor(projectStore: ProjectStore, logger: Logger, fileWriteMutex: FileWriteMutex) {
     this.projectStore = projectStore;
     this.fileWriteMutex = fileWriteMutex;
     this.logger = logger ?? createSilentLogger();
+  }
+
+  private derivedHistoryEntries(
+    agentId: string,
+    sessionId: string,
+  ): DerivedMessageEntry[] {
+    const sessions = this.projectStore.getAgent(agentId)?.sessions;
+    if (!sessions) return [];
+    const key = `${agentId}:${sessionId}`;
+    const version = sessions.readEventCount(sessionId);
+    const cached = this.historyCache.get(key);
+    if (cached && cached.version === version) {
+      this.historyCache.delete(key);
+      this.historyCache.set(key, cached);
+      return cached.entries;
+    }
+    const entries = deriveHistoryEntries(sessions.readEvents(sessionId));
+    this.historyCache.delete(key);
+    while (this.historyCache.size >= HISTORY_CACHE_LIMIT) {
+      const oldest = this.historyCache.keys().next().value;
+      if (oldest === undefined) break;
+      this.historyCache.delete(oldest);
+    }
+    this.historyCache.set(key, { version, entries });
+    return entries;
   }
 
   close(): void {
@@ -199,7 +232,7 @@ export class ProjectManager {
         oldestId: result.oldestId,
       };
     }
-    const projected = deriveHistoryEntries(sessions.readEvents(sessionId));
+    const projected = this.derivedHistoryEntries(agentId, sessionId);
     const before = beforeId ?? Number.POSITIVE_INFINITY;
     const eligible = projected.filter((entry) => entry.seq < before);
     // 页首若为孤儿 toolResult，向后扩展到其 toolCall 的 assistant 消息，保证单页配对自洽

--- a/packages/core/src/session/agent-runner.ts
+++ b/packages/core/src/session/agent-runner.ts
@@ -172,7 +172,7 @@ export class AgentRunner {
         onEvent,
       );
 
-      const previousSink = this.controlBus.swapEventSink(onEvent);
+      const previousSink = this.controlBus.swapEventSink(this.persistingControlSink(onEvent));
       restoreSink = () => this.controlBus.swapEventSink(previousSink);
       unsubscribe = this.agent.subscribe(dispatch);
 
@@ -232,7 +232,7 @@ export class AgentRunner {
         onEvent,
       );
 
-      const previousSink = this.controlBus.swapEventSink(onEvent);
+      const previousSink = this.controlBus.swapEventSink(this.persistingControlSink(onEvent));
       restoreSink = () => this.controlBus.swapEventSink(previousSink);
       unsubscribe = this.agent.subscribe(dispatch);
 
@@ -421,6 +421,41 @@ export class AgentRunner {
     if (this.eventLog.events.length !== eventsBefore) {
       this.syncBufferFromLog();
     }
+  }
+
+  private persistingControlSink(onEvent: RunnerEventHandler): RunnerEventHandler {
+    return (event) => {
+      if (
+        !this.eventLog ||
+        (event.type !== "control_request" && event.type !== "control_resolved")
+      ) {
+        onEvent(event);
+        return;
+      }
+      if (event.type === "control_request") {
+        const persisted = this.eventLog.append("control/requested", {
+          requestId: event.requestId,
+          kind: event.kind,
+          toolCallId: event.toolCallId,
+          toolName: event.toolName,
+          args: event.args,
+        });
+        onEvent({ ...event, seq: persisted.seq });
+        return;
+      }
+      const persisted = this.eventLog.append("control/resolved", {
+        requestId: event.requestId,
+        kind: event.kind,
+        ...(event.kind === "approval"
+          ? { approved: event.approved, ...(event.reason !== undefined ? { reason: event.reason } : {}) }
+          : {}),
+        ...(event.kind === "question"
+          ? { ...(event.answer !== undefined ? { answer: event.answer } : {}), timedOut: event.timedOut }
+          : {}),
+        ...(event.aborted !== undefined ? { aborted: event.aborted } : {}),
+      });
+      onEvent({ ...event, seq: persisted.seq });
+    };
   }
 
   private persistMiddleware(): EventMiddleware<AgentEvent> {

--- a/packages/core/src/session/control-bus.ts
+++ b/packages/core/src/session/control-bus.ts
@@ -9,6 +9,7 @@ export interface ControlRequest {
 }
 
 interface PendingRequest {
+  requestId: string;
   kind: ControlRequestKind;
   resolve: (decision: unknown) => void;
   reject: (err: Error) => void;
@@ -42,6 +43,7 @@ export class SessionControlBus {
         }
       }, timeoutMs);
       this.pending.set(req.requestId, {
+        requestId: req.requestId,
         kind: req.kind,
         resolve: resolve as (d: unknown) => void,
         reject,
@@ -71,6 +73,7 @@ export class SessionControlBus {
     for (const entry of this.pending.values()) {
       clearTimeout(entry.timer);
       entry.reject(new Error(reason));
+      this.emitAborted(entry.requestId, entry.kind);
     }
     this.pending.clear();
   }
@@ -98,6 +101,26 @@ export class SessionControlBus {
         kind,
         answer: d.answer,
         timedOut: d.timedOut,
+      });
+    }
+  }
+
+  private emitAborted(requestId: string, kind: ControlRequestKind): void {
+    if (kind === "approval") {
+      this.emit({
+        type: "control_resolved",
+        requestId,
+        kind,
+        approved: false,
+        aborted: true,
+      });
+    } else {
+      this.emit({
+        type: "control_resolved",
+        requestId,
+        kind,
+        timedOut: false,
+        aborted: true,
       });
     }
   }

--- a/packages/core/src/session/events.ts
+++ b/packages/core/src/session/events.ts
@@ -1,11 +1,13 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai";
+import type { ControlRequestKind } from "./types.js";
 
 export type TurnEndReason = "completed" | "aborted" | "error";
 
 export interface SendMessageMeta {
   source?: "triggered";
   triggerName?: string;
+  agentId?: string;
 }
 
 export interface SessionEventMap {
@@ -22,6 +24,22 @@ export interface SessionEventMap {
   };
   "turn/retried": { abandonedSeqs: number[] };
   "turn/withdrawn": { seq: number };
+  "control/requested": {
+    requestId: string;
+    kind: ControlRequestKind;
+    toolCallId: string;
+    toolName: string;
+    args: unknown;
+  };
+  "control/resolved": {
+    requestId: string;
+    kind: ControlRequestKind;
+    approved?: boolean;
+    reason?: string;
+    answer?: string;
+    timedOut?: boolean;
+    aborted?: boolean;
+  };
 }
 
 export type SessionEventType = keyof SessionEventMap;

--- a/packages/core/src/session/fold.ts
+++ b/packages/core/src/session/fold.ts
@@ -2,12 +2,21 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ToolResultMessage } from "@earendil-works/pi-ai";
 import { wrapDigestContent } from "../context/compaction.js";
 import { MESSAGE_EVENT_TYPES, type SessionEvent } from "./events.js";
+import type { ControlRequestKind } from "./types.js";
 
 export interface DerivedMessageEntry {
   seq: number;
   message: AgentMessage;
   source?: "triggered";
   triggerName?: string;
+}
+
+export interface PendingControlEntry {
+  seq: number;
+  requestId: string;
+  kind: ControlRequestKind;
+  toolCallId: string;
+  toolName: string;
 }
 
 interface RestartState {
@@ -102,6 +111,28 @@ export function collectAbandonedSeqs(events: readonly SessionEvent[]): Set<numbe
     }
   }
   return abandoned;
+}
+
+export function derivePendingControls(
+  events: readonly SessionEvent[],
+): PendingControlEntry[] {
+  const pending = new Map<string, PendingControlEntry>();
+  for (const event of events) {
+    if (event.type === "control/requested") {
+      pending.set(event.data.requestId, {
+        seq: event.seq,
+        requestId: event.data.requestId,
+        kind: event.data.kind,
+        toolCallId: event.data.toolCallId,
+        toolName: event.data.toolName,
+      });
+    } else if (event.type === "control/resolved") {
+      pending.delete(event.data.requestId);
+    } else if (event.type === "turn/end") {
+      pending.clear();
+    }
+  }
+  return [...pending.values()];
 }
 
 const INTERRUPTED_TOOL_TEXT = "The tool call was interrupted and did not execute.";

--- a/packages/core/src/session/types.ts
+++ b/packages/core/src/session/types.ts
@@ -20,6 +20,7 @@ export type SessionControlEvent =
       toolCallId: string;
       toolName: string;
       args: unknown;
+      seq?: number;
     }
   | {
       type: "control_resolved";
@@ -27,6 +28,8 @@ export type SessionControlEvent =
       kind: "approval";
       approved: boolean;
       reason?: string;
+      aborted?: boolean;
+      seq?: number;
     }
   | {
       type: "control_request";
@@ -35,6 +38,7 @@ export type SessionControlEvent =
       toolCallId: string;
       toolName: string;
       args: unknown;
+      seq?: number;
     }
   | {
       type: "control_resolved";
@@ -42,4 +46,6 @@ export type SessionControlEvent =
       kind: "question";
       answer?: string;
       timedOut: boolean;
+      aborted?: boolean;
+      seq?: number;
     };

--- a/packages/core/src/store/session.ts
+++ b/packages/core/src/store/session.ts
@@ -257,6 +257,15 @@ export class SessionStore {
     return SessionStore.rowsToEvents(rows);
   }
 
+  readEventCount(sessionId: string): number {
+    const row = this.db
+      .prepare<[string], { count: number }>(
+        "SELECT COUNT(*) AS count FROM events WHERE session_id = ?",
+      )
+      .get(sessionId);
+    return row?.count ?? 0;
+  }
+
   private static rowsToEvents(rows: EventRow[]): SessionEvent[] {
     return rows.map((row) => {
       assertSupportedEventVersion(row);

--- a/packages/core/src/trigger/__tests__/executor.test.ts
+++ b/packages/core/src/trigger/__tests__/executor.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { TriggerExecutor } from "../executor.js";
+import { ConflictError, ValidationError } from "../../errors.js";
 import type { SessionPort } from "../../kernel/ports.js";
 import type { TriggerStore } from "../../store/trigger.js";
 import type { TriggerEntry } from "../../types.js";
@@ -55,7 +56,7 @@ describe("TriggerExecutor", () => {
       "s-new",
       "Hello world",
       expect.any(Function),
-      { source: "triggered", triggerName: "evt" },
+      { source: "triggered", triggerName: "evt", agentId: "a1" },
     );
     expect(triggered).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "a1", triggerId: "tr-1" }),
@@ -84,6 +85,45 @@ describe("TriggerExecutor", () => {
     );
     expect(failed).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "a1", triggerId: "tr-1", error: "Error: boom" }),
+    );
+  });
+
+  it("records a failed log on ConflictError (hub-routed busy session) with the same failure semantics as a direct ValidationError", async () => {
+    const conflictDeps = makeDeps({
+      sendMessage: vi.fn(async () => {
+        throw new ConflictError(`Session "s-new" is already running`);
+      }) as unknown as SessionPort["sendMessage"],
+    });
+    const conflictFailed = vi.fn();
+    conflictDeps.executor.on("trigger_failed", conflictFailed);
+    await conflictDeps.executor.fire(makeEntry(), "a1", "Agent", "");
+
+    const validationDeps = makeDeps({
+      sendMessage: vi.fn(async () => {
+        throw new ValidationError(`Session "s-new" already has a turn in progress`);
+      }) as unknown as SessionPort["sendMessage"],
+    });
+    const validationFailed = vi.fn();
+    validationDeps.executor.on("trigger_failed", validationFailed);
+    await validationDeps.executor.fire(makeEntry(), "a1", "Agent", "");
+
+    expect(conflictDeps.store.appendLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        error: expect.stringContaining("already running"),
+      }),
+    );
+    expect(validationDeps.store.appendLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        error: expect.stringContaining("already has a turn"),
+      }),
+    );
+    expect(conflictFailed).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "a1", triggerId: "tr-1" }),
+    );
+    expect(validationFailed).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "a1", triggerId: "tr-1" }),
     );
   });
 

--- a/packages/core/src/trigger/__tests__/trigger-manager.test.ts
+++ b/packages/core/src/trigger/__tests__/trigger-manager.test.ts
@@ -188,7 +188,7 @@ describe("TriggerManager", () => {
       "Hello Alice",
       [],
       expect.any(Function),
-      { source: "triggered", triggerName: "user-login" },
+      { source: "triggered", triggerName: "user-login", agentId },
     );
 
     sendMessageSpy.mockRestore();
@@ -234,7 +234,7 @@ describe("TriggerManager", () => {
       "Payload: []",
       [],
       expect.any(Function),
-      { source: "triggered", triggerName: "test-event" },
+      { source: "triggered", triggerName: "test-event", agentId },
     );
     sendMessageSpy.mockRestore();
   });

--- a/packages/core/src/trigger/executor.ts
+++ b/packages/core/src/trigger/executor.ts
@@ -129,7 +129,7 @@ export class TriggerExecutor extends EventEmitter {
           agentEnded = true;
           turnError = readTurnError(event);
         },
-        { source: "triggered", triggerName },
+        { source: "triggered", triggerName, agentId },
       );
 
       if (turnError !== undefined) {

--- a/packages/server/src/__tests__/trigger-hub-routing.test.ts
+++ b/packages/server/src/__tests__/trigger-hub-routing.test.ts
@@ -1,0 +1,182 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Logger } from "@spherse/core";
+import { ProjectRegistry } from "../registry.js";
+import { ChatSessionHub } from "../chat/chat-session-hub.js";
+
+const silentLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  trace: () => {},
+  fatal: () => {},
+  child: () => silentLogger,
+};
+
+const TEST_AGENT_PROFILE = `---
+name: Trigger Agent
+tools:
+  - read_file
+---
+
+Trigger routing contract agent.`;
+
+const stubCatalog = {
+  getChatStreamFn: vi.fn(() => vi.fn()),
+  resolveModelById: vi.fn((modelId: string) => {
+    const slashIdx = modelId.indexOf("/");
+    return slashIdx >= 0
+      ? { id: modelId.slice(slashIdx + 1), provider: modelId.slice(0, slashIdx) }
+      : { id: modelId, provider: modelId };
+  }),
+} as never;
+
+describe("trigger sessionPort routing through the chat hub (real boundary)", () => {
+  let tmpDir: string;
+  let hub: ChatSessionHub;
+  let registry: ProjectRegistry;
+  let ctx: Awaited<ReturnType<ProjectRegistry["register"]>>;
+  let agentId: string;
+  let sessionId: string;
+  let store: any;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "spherse-trigger-routing-"));
+    hub = new ChatSessionHub(silentLogger as never);
+    registry = new ProjectRegistry(silentLogger, {
+      modelCatalog: stubCatalog,
+      defaultModel: "openai/gpt-4o",
+      chatHub: hub,
+    });
+    ctx = await registry.register(tmpDir);
+    const projectStore = (ctx.projectManager as any).projectStore;
+    const agent = await projectStore.createAgent("trigger-agent", TEST_AGENT_PROFILE);
+    agentId = agent.getProfile().id;
+    sessionId = await ctx.sessionRuntime.createSession(agentId);
+    store = projectStore.agents.get(agentId).sessions;
+  });
+
+  afterAll(async () => {
+    await registry.removeAll();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function stubAgentTurn(dispatchAgentEnd: boolean) {
+    await ctx.sessionRuntime.restoreSession(agentId, sessionId);
+    const runner = (ctx.sessionRuntime as any).sessions.get(sessionId);
+    const liveAgent = runner.agentRef;
+    let dispatch: ((event: unknown) => unknown) | undefined;
+    liveAgent.subscribe = vi.fn((handler: (event: unknown) => unknown) => {
+      dispatch = handler;
+      return () => {};
+    });
+    liveAgent.prompt = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          if (dispatchAgentEnd) {
+            void Promise.resolve().then(async () => {
+              await dispatch?.({ type: "agent_end", messages: [] });
+              resolve();
+            });
+          }
+        }),
+    );
+    return { liveAgent };
+  }
+
+  function makeEntry(overrides?: Record<string, unknown>) {
+    return {
+      id: `tr-${Math.random().toString(36).slice(2, 8)}`,
+      enabled: true,
+      type: "event",
+      eventName: "routing-evt",
+      mode: "existing_session",
+      targetSessionId: sessionId,
+      message: "Hello {{payload}}",
+      notify: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      ...overrides,
+    } as never;
+  }
+
+  it("routes a trigger send through the hub: live echo with trigger meta reaches subscribers", async () => {
+    await stubAgentTurn(true);
+    const events: any[] = [];
+    const attachment = hub.attach(
+      ctx.projectId,
+      ctx.sessionRuntime,
+      agentId,
+      sessionId,
+      (event) => events.push(event),
+    );
+    await attachment.ready;
+    events.length = 0;
+
+    const entry = makeEntry({ name: "routing-trigger" });
+    ctx.triggerManager.create(agentId, entry);
+    const logs = (ctx.triggerManager as any).getTriggerStore(agentId);
+    ctx.triggerManager.onUserEvent("routing-evt", "world");
+
+    await vi.waitFor(() => {
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "user_message",
+          source: "triggered",
+          triggerName: "routing-trigger",
+        }),
+      );
+    });
+    const statuses = events.filter((e) => e.type === "run_status").map((e) => e.active);
+    await vi.waitFor(() => {
+      const storeLog = (logs as any).getRecentLogs(50) as any[];
+      expect(storeLog.some((l) => l.triggerId === entry.id && l.status === "success")).toBe(true);
+    });
+    expect(statuses[0]).toBe(true);
+    await vi.waitFor(() => {
+      expect(
+        events.filter((e) => e.type === "run_status").map((e) => e.active),
+      ).toEqual([true, false]);
+    });
+    const persisted = store.readEvents(sessionId).find((e: any) => e.type === "user/message");
+    expect(persisted.data.source).toBe("triggered");
+    expect(persisted.data.triggerName).toBe("routing-trigger");
+    attachment.close();
+  });
+
+  it("fails the trigger when the hub rejects a concurrent run (ConflictError equivalence)", async () => {
+    await stubAgentTurn(false);
+    const events: any[] = [];
+    const attachment = hub.attach(
+      ctx.projectId,
+      ctx.sessionRuntime,
+      agentId,
+      sessionId,
+      (event) => events.push(event),
+    );
+    await attachment.ready;
+    events.length = 0;
+
+    const first = makeEntry({ eventName: "conflict-evt", name: "first" });
+    const second = makeEntry({ eventName: "conflict-evt", name: "second" });
+    ctx.triggerManager.create(agentId, first);
+    ctx.triggerManager.create(agentId, second);
+    ctx.triggerManager.onUserEvent("conflict-evt", "");
+
+    await vi.waitFor(() => {
+      expect(events.some((e) => e.type === "run_status" && e.active)).toBe(true);
+    });
+
+    const logStore = (ctx.triggerManager as any).getTriggerStore(agentId);
+    await vi.waitFor(() => {
+      const all = logStore.getRecentLogs(50) as any[];
+      expect(all.some((l) => (l.triggerId === first.id || l.triggerId === second.id) && l.status === "failed" && /already running/.test(String(l.error)))).toBe(true);
+      expect(all.some((l) => (l.triggerId === first.id || l.triggerId === second.id) && l.status === "success")).toBe(false);
+    });
+    expect(events.filter((e) => e.type === "run_status" && e.active)).toHaveLength(1);
+    attachment.close();
+  });
+});

--- a/packages/server/src/chat/chat-channel.ts
+++ b/packages/server/src/chat/chat-channel.ts
@@ -1,6 +1,7 @@
 import {
   ConflictError,
   type Attachment,
+  type SendMessageMeta,
   type SessionManager,
 } from "@spherse/core";
 import type { FastifyBaseLogger } from "fastify";
@@ -138,7 +139,14 @@ export class ChatChannel {
     };
   }
 
-  async startDetachedRun(content: string): Promise<void> {
+  async startDetachedRun(
+    content: string,
+    options?: {
+      meta?: SendMessageMeta;
+      onEvent?: (event: CoreEvent) => void;
+      awaitRun?: boolean;
+    },
+  ): Promise<void> {
     this.attachments += 1;
     try {
       await this.ready;
@@ -150,21 +158,39 @@ export class ChatChannel {
       this.cleanupIfIdle();
       throw err;
     }
-    this.startRun((onEvent) =>
-      this.runtime.sendMessage(this.sessionId, content, [], onEvent),
-    )
-      .catch((err) => {
-        this.logger.error({ err, sessionId: this.sessionId }, "detached chat run failed");
-        this.publish({
-          type: "error",
-          message: err instanceof Error ? err.message : "chat error",
-          code: classifyRunError(err),
-        });
-      })
-      .finally(() => {
-        this.attachments -= 1;
-        this.cleanupIfIdle();
+    const executor = (broadcast: CoreEventHandler) => {
+      const fanOut = (event: CoreEvent) => {
+        options?.onEvent?.(event);
+        broadcast(event);
+      };
+      if (options?.meta !== undefined) {
+        return this.runtime.sendMessage(this.sessionId, content, [], fanOut, options.meta);
+      }
+      return this.runtime.sendMessage(this.sessionId, content, [], fanOut);
+    };
+    const handleFailure = (err: unknown) => {
+      this.logger.error({ err, sessionId: this.sessionId }, "detached chat run failed");
+      this.publish({
+        type: "error",
+        message: err instanceof Error ? err.message : "chat error",
+        code: classifyRunError(err),
       });
+    };
+    const release = () => {
+      this.attachments -= 1;
+      this.cleanupIfIdle();
+    };
+    if (options?.awaitRun) {
+      return this.startRun(executor)
+        .catch((err: unknown) => {
+          handleFailure(err);
+          throw err;
+        })
+        .finally(release);
+    }
+    void this.startRun(executor)
+      .catch(handleFailure)
+      .finally(release);
   }
 
   private release(): void {

--- a/packages/server/src/chat/chat-channel.ts
+++ b/packages/server/src/chat/chat-channel.ts
@@ -9,6 +9,7 @@ import { classifyRunError } from "./classify-run-error.js";
 import { ChatWireProjector } from "./chat-wire-projector.js";
 
 type CoreEventHandler = Parameters<SessionManager["sendMessage"]>[3];
+export type DetachedRunHandler = CoreEventHandler;
 type CoreEvent = Parameters<CoreEventHandler>[0];
 type Subscriber = (event: unknown) => void;
 
@@ -143,7 +144,7 @@ export class ChatChannel {
     content: string,
     options?: {
       meta?: SendMessageMeta;
-      onEvent?: (event: CoreEvent) => void;
+      onEvent?: DetachedRunHandler;
       awaitRun?: boolean;
     },
   ): Promise<void> {

--- a/packages/server/src/chat/chat-session-hub.ts
+++ b/packages/server/src/chat/chat-session-hub.ts
@@ -1,4 +1,4 @@
-import type { SessionManager } from "@spherse/core";
+import type { SendMessageMeta, SessionManager } from "@spherse/core";
 import type { FastifyBaseLogger } from "fastify";
 import { ChatChannel, type ChatSessionAttachment } from "./chat-channel.js";
 
@@ -31,6 +31,22 @@ export class ChatSessionHub {
     content: string,
   ): Promise<void> {
     return this.getOrCreate(projectId, runtime, agentId, sessionId).startDetachedRun(content);
+  }
+
+  async startRunWithMeta(
+    projectId: string,
+    runtime: SessionManager,
+    agentId: string,
+    sessionId: string,
+    content: string,
+    meta: SendMessageMeta,
+    onEvent?: (event: unknown) => void,
+  ): Promise<void> {
+    return this.getOrCreate(projectId, runtime, agentId, sessionId).startDetachedRun(content, {
+      meta,
+      awaitRun: true,
+      ...(onEvent !== undefined ? { onEvent: onEvent as never } : {}),
+    });
   }
 
   private getOrCreate(

--- a/packages/server/src/chat/chat-session-hub.ts
+++ b/packages/server/src/chat/chat-session-hub.ts
@@ -1,6 +1,6 @@
 import type { SendMessageMeta, SessionManager } from "@spherse/core";
 import type { FastifyBaseLogger } from "fastify";
-import { ChatChannel, type ChatSessionAttachment } from "./chat-channel.js";
+import { ChatChannel, type ChatSessionAttachment, type DetachedRunHandler } from "./chat-channel.js";
 
 type Subscriber = (event: unknown) => void;
 
@@ -40,12 +40,12 @@ export class ChatSessionHub {
     sessionId: string,
     content: string,
     meta: SendMessageMeta,
-    onEvent?: (event: unknown) => void,
+    onEvent?: DetachedRunHandler,
   ): Promise<void> {
     return this.getOrCreate(projectId, runtime, agentId, sessionId).startDetachedRun(content, {
       meta,
       awaitRun: true,
-      ...(onEvent !== undefined ? { onEvent: onEvent as never } : {}),
+      ...(onEvent !== undefined ? { onEvent } : {}),
     });
   }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -106,14 +106,14 @@ export async function createMultiProjectServer(
     reply.code(404).send({ error: "Route not found" });
   });
 
+  const chatHub = new ChatSessionHub(logger);
   const registry = new ProjectRegistry(logger, {
     defaultModel: options?.defaultModel,
     sampling: options?.sampling,
     thinkingLevel: options?.thinkingLevel,
     modelCatalog: options?.modelCatalog,
+    chatHub,
   });
-
-  const chatHub = new ChatSessionHub(logger);
 
   registerAuthHook(fastify, options?.auth ?? {});
   registerAllRoutes(fastify, registry, {

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -157,12 +157,12 @@ export class ProjectRegistry {
             sessionId,
             message,
             triggerMeta,
-            onEvent as never,
+            onEvent,
           );
         }
-        this.logger.debug(
-          { projectRoot: resolvedRoot },
-          "session port sendMessage fell back to direct path (no trigger context or not yet assembled)",
+        this.logger.warn(
+          { projectRoot: resolvedRoot, source: meta?.source, hasAgentId: agentId !== undefined },
+          "trigger sendMessage fell back to the direct path (no trigger context or project not yet assembled); the run will not be broadcast to chat subscribers",
         );
         return port.sendMessage(sessionId, message, onEvent, meta);
       },

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
 import { nanoid } from "nanoid";
 import { createProject, ModelCatalog } from "@spherse/core";
-import type { ProjectRuntime, ProjectManager, SessionManager, TriggerManager, Logger, SamplingParams, ThinkingLevel } from "@spherse/core";
+import type { ProjectRuntime, ProjectManager, SessionManager, TriggerManager, Logger, SamplingParams, ThinkingLevel, SessionPort, SendMessageMeta } from "@spherse/core";
+import type { ChatSessionHub } from "./chat/index.js";
 
 export interface ProjectContext {
   runtime: ProjectRuntime;
@@ -25,6 +26,8 @@ export interface RegisterOptions {
   lastOpened?: string;
 }
 
+type SessionPortFactory = (port: SessionPort) => SessionPort;
+
 export class ProjectRegistry {
   private projects = new Map<string, ProjectContextCompat>();
   private pending = new Map<string, Promise<ProjectContextCompat>>();
@@ -35,6 +38,7 @@ export class ProjectRegistry {
   private thinkingLevel?: ThinkingLevel;
 
   private readonly modelCatalog: ModelCatalog;
+  private readonly chatHub: ChatSessionHub | undefined;
 
   getSupportedProviders() {
     return this.modelCatalog.getSupportedProviders();
@@ -42,13 +46,14 @@ export class ProjectRegistry {
 
   constructor(
     logger: Logger,
-    options?: { defaultModel?: string; sampling?: SamplingParams; thinkingLevel?: ThinkingLevel; modelCatalog?: ModelCatalog },
+    options?: { defaultModel?: string; sampling?: SamplingParams; thinkingLevel?: ThinkingLevel; modelCatalog?: ModelCatalog; chatHub?: ChatSessionHub },
   ) {
     this.logger = logger;
     this.defaultModel = options?.defaultModel;
     this.sampling = options?.sampling;
     this.thinkingLevel = options?.thinkingLevel;
     this.modelCatalog = options?.modelCatalog ?? new ModelCatalog();
+    this.chatHub = options?.chatHub;
   }
 
   async register(projectRoot: string, options?: RegisterOptions): Promise<ProjectContextCompat> {
@@ -77,12 +82,18 @@ export class ProjectRegistry {
 
   private async doRegister(resolvedRoot: string, options?: RegisterOptions): Promise<ProjectContextCompat> {
     const projectLogger = this.logger.child({ projectRoot: resolvedRoot });
+    const assembled: { projectId?: string; sessionRuntime?: SessionManager } = {};
     const runtime = await createProject(resolvedRoot, {
       defaultModel: this.defaultModel,
       sampling: this.sampling,
       thinkingLevel: this.thinkingLevel,
       logger: projectLogger,
       ...(this.modelCatalog ? { modelCatalog: this.modelCatalog } : {}),
+      ...(this.chatHub
+        ? {
+            wrapSessionPort: this.wrapPortForHub(resolvedRoot, assembled),
+          }
+        : {}),
     });
 
     let projectId = runtime.projectId;
@@ -95,6 +106,8 @@ export class ProjectRegistry {
       );
       projectId = newId;
     }
+    assembled.projectId = projectId;
+    assembled.sessionRuntime = runtime.sessionRuntime;
 
     const ctx: ProjectContextCompat = Object.freeze({
       runtime,
@@ -114,6 +127,46 @@ export class ProjectRegistry {
       this.lastOpenedMap.set(projectId, options.lastOpened);
     }
     return ctx;
+  }
+
+  private wrapPortForHub(
+    resolvedRoot: string,
+    assembled: { projectId?: string; sessionRuntime?: SessionManager },
+  ): SessionPortFactory {
+    const hub = this.chatHub!;
+    return (port) => ({
+      ...port,
+      sendMessage: (sessionId, message, onEvent, meta) => {
+        const agentId = meta?.agentId;
+        const projectId = assembled.projectId;
+        const sessionRuntime = assembled.sessionRuntime;
+        if (
+          meta?.source === "triggered" &&
+          agentId !== undefined &&
+          projectId !== undefined &&
+          sessionRuntime !== undefined
+        ) {
+          const triggerMeta: SendMessageMeta = {
+            source: "triggered",
+            ...(meta.triggerName !== undefined ? { triggerName: meta.triggerName } : {}),
+          };
+          return hub.startRunWithMeta(
+            projectId,
+            sessionRuntime,
+            agentId,
+            sessionId,
+            message,
+            triggerMeta,
+            onEvent as never,
+          );
+        }
+        this.logger.debug(
+          { projectRoot: resolvedRoot },
+          "session port sendMessage fell back to direct path (no trigger context or not yet assembled)",
+        );
+        return port.sendMessage(sessionId, message, onEvent, meta);
+      },
+    });
   }
 
   get(projectId: string): ProjectContextCompat | undefined {


### PR DESCRIPTION
## 概要

chat 重构 **PR5/6：trigger 收口 + control 落库 + 分页性能**（[design doc](../blob/feat/chat-refactor-pr5/docs/dev/features/2026-09-05-chat-refactor/design.md) §2.3/§2.4/§1.8/决策 #7）。core + server 侧，无 renderer 行为迁移（PR3/PR4 负责）。

## 变更

### trigger 收口（trigger run live 可达）
- core：`assembleProject` 新增 `wrapSessionPort` 钩子（capabilities init 前应用）；`SendMessageMeta.agentId`（路由上下文，不入持久化）
- server：registry 注入 hub、以惰性 projectId/runtime 盒包装 port；hub 新增 `startRunWithMeta`（完成语义——trigger executor 的 agent_end 观察与 success 日志闭合）；trigger 的 sendMessage 改经 hub channel，**已打开 session 页面的订阅者实时收到 trigger run 事件**
- 冲突语义对齐：ConflictError（hub）↔ ValidationError（直连）在 executor 层等价（均 failed），双级测试钉住

### control 事件落库（决策 #7）
- `control/requested` / `control/resolved` 进 SessionEventMap，runner 的 control sink 包装层 persist → emit + seq 回填 wire；`rejectAll`(abort) 补发 `resolved {aborted}`（修多端缺口）
- `derivePendingControls` fold 投影（requested 未配对 resolved 且无 turn/end 隔断；repair 合成 turn/end 自动排除崩溃悬空）
- contracts：control wire 事件加 `seq`/`aborted`，`chatReplayEvent` 增 control/* 变体（游标重放覆盖 pending）

### 分页性能（§2.4）
- `getRecentSessionHistory` 走 project-manager 层 fold-on-write 缓存（事件数版本号失效 + LRU 32，覆盖未激活 session），性质测试：缓存分页 == 全量重 fold

### 拆除
- 删 `TriggerEventBridge` 的 refreshHistory（live 可达 + PR3 游标重放取代）

## Review report（sub agent review：0C / 2I / 1M / 7m）

| 级别 | 问题 | 处置 |
|---|---|---|
| I1 | plan 承诺 desktop 侧 SessionPort 契约测试，但 desktop 不直接消费 SessionPort（经 createMultiProjectServer 整体嵌入） | ✅ 裁决记录：红线由 server 侧 `trigger-hub-routing.test.ts`（真 registry+hub+triggerManager+AgentRunner，仅 stub 最深 pi agentRef）承担，理由写入 design §2.3 + plan |
| I2 | E2E「trigger 可见」未交付；PR5→PR3 窗口期旧页面看不到触发的 user 消息（旧 reducer 丢 `user_message`） | ⚠️ deviation 记录：e2e 无服务端 LLM stub 模式，live 可达性由真实边界契约测试钉住；中间态现象（看得到 assistant 流式、user 消息待重连对账补全）明示于 design §2.3，PR3 修复；chat-streaming-resilience / chat-retry E2E 回归通过 |
| M1 | trigger run 中途 throw 向无关订阅者广播 `error`（旧为完全不可见） | ✅ 保留为有意行为（订阅者已见 run_status 翻转，静默失败更难排查），design §2.3 补记 |
| m1 | COUNT(*) 版本号 O(n) | 不改：与设计一致，MAX(seq) 优化留给实际量级需要时 |
| m2 | `as never` 双重 cast | ✅ 已修：`DetachedRunHandler` 类型导出，cast 全消 |
| m3 | 缓存条目可变引用共享 | 现状安全（消费方经 parseContract Clone）；不可变契约写入 data-conventions |
| m4 | wrapper fallback 仅 debug 日志 | ✅ 已修：升 warn 并补上下文字段 |
| m5 | official docs 未同步 control 词汇 | ✅ 已同步：data-conventions（事件表+缓存契约）、core.md（落库+wrapSessionPort+pending 投影）、chat.md（seq/aborted/重放变体）、glossary（control gate 事件，与重启点控制事件区分） |
| m6 | contracts 测试缺口 | ✅ 已补：question request+seq、replay 缺 kind 负例 |
| m7 | `derivePendingControls` 无生产消费方 | 预期：PR4 client 词汇预铺，暂不导出（符合导出面红线） |

## 验证

core 1176 / server 249 / contracts 66 / app 983 / desktop 198 全绿；lint 0 错误；全包 typecheck 通过；E2E chat-streaming-resilience（5）+ chat-retry（2）通过。

## 后续

本 PR 合入后解除 PR3 的合入阻塞（PR3 依赖 PR5：删 refreshHistory 需 trigger 收口在先）。PR4 消费 control 事件与 pending 投影。
